### PR TITLE
Add docker-server-less image name -> digest code

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,11 +32,30 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install dependecies
+    - name: Install dependencies and set up test config
       shell: bash
       run: |
+        export CRANE_VER=0.20.2
+        export HOMEDIR=`pwd`
+        
+        # set up python dependencies
         pip install pipenv
         pipenv sync --system --dev
+
+        # move to parent dir of homedir to install binaries etc
+        cd ..
+
+        # set up crane
+        # don't bother to verify provenance here
+        curl -sL "https://github.com/google/go-containerregistry/releases/download/$CRANE_VER/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
+        tar -zxvf go-containerregistry.tar.gz
+        export CRANE_EXE_PATH=`pwd`/crane
+        
+        # set up test config
+        cd $HOMEDIR
+        cp -n test.cfg.example test.cfg
+        sed -i "s#^test.crane.exe=.*#test.crane.exe=$CRANE_EXE_PATH#" test.cfg
+        cat test.cfg
 
     - name: Run tests
       shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies and set up test config
       shell: bash
       run: |
-        export CRANE_VER=0.20.2
+        export CRANE_VER=v0.20.2
         export HOMEDIR=`pwd`
         
         # set up python dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,28 @@
 FROM python:3.11
 
-RUN mkdir -p /cdmtaskservice
-WORKDIR /cdmtaskservice
+ENV CRANE_VER=v0.20.2
+
+RUN mkdir -p /cdmtaskservice && mkdir -p /craneinstall
+
+# Install crane
+
+WORKDIR /craneinstall
+
+# crane install docs: https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+# Note that the provenance verification step is broken, which wasted an hour or two of time
+# https://github.com/google/go-containerregistry/issues/1982
+RUN curl -sL https://github.com/google/go-containerregistry/releases/download/$CRANE_VER/go-containerregistry_Linux_x86_64.tar.gz > go-containerregistry.tar.gz \ 
+    && tar -zxvf go-containerregistry.tar.gz \
+    && mv ./crane /cdmtaskservice \
+    && rm -r /craneinstall
+
+ENV CDM_TASK_SERVICE_CRANE_EXE=/cdmtaskservice/crane
 
 # install pipenv
 RUN pip install --upgrade pip && \
     pip install pipenv
+
+WORKDIR /cdmtaskservice
 
 # install deps
 COPY Pipfile* ./

--- a/Pipfile
+++ b/Pipfile
@@ -4,6 +4,7 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
+fqdn = "==1.5.1"
 
 [dev-packages]
 pytest = "==8.3.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,10 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "6db16383fe5de9079ef53b33b9ab07ec4f5074d92c5e07d3b767aa460b00d7c5"
+            "sha256": "4fd4ec5719db894110151b3aa223d5a586448ea8a94f90a9ec096c531fdffa2a"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_full_version": "3.11.3",
             "python_version": "3.11"
         },
         "sources": [
@@ -16,7 +15,16 @@
             }
         ]
     },
-    "default": {},
+    "default": {
+        "fqdn": {
+            "hashes": [
+                "sha256:105ed3677e767fb5ca086a0c1f4bb66ebc3c100be518f0e0d755d9eae164d89f",
+                "sha256:3a179af3761e4df6eb2e026ff9e1a3033d3587bf980a0b1b2e1e5d08d7358014"
+            ],
+            "index": "pypi",
+            "version": "==1.5.1"
+        }
+    },
     "develop": {
         "asttokens": {
             "hashes": [

--- a/README.md
+++ b/README.md
@@ -4,6 +4,11 @@
 
 Enables running jobs on remote compute from the KBase CDM cluster.
 
+## Service Requirements
+
+* Python 3.11+
+* [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
+
 ## Development
 
 ### Adding code
@@ -28,7 +33,7 @@ Enables running jobs on remote compute from the KBase CDM cluster.
 
 ### Running tests
 
-Python 3.11 must be installed on the system.
+Copy `test.cfg.example` to `test.cfg` and fill it in appropriately.
 
 ```
 pipenv sync --dev  # only the first time or when Pipfile.lock changes

--- a/cdmtaskservice/dockerimages.py
+++ b/cdmtaskservice/dockerimages.py
@@ -2,29 +2,151 @@
 Contains code for querying container information without access to a docker server
 """
 
+# Trying to find a simple way to handle this was surprisingly frustrating. I spent a half
+# day or so looking at alternatives and the crane CLI seems like the least bad option. I tried
+# a number of things, most of which I don't remember, including http requests (had to be tailored
+# to each repository somewhat) and https://github.com/davedoesdev/dxf (couldn't get anonymous
+# access to work). If there's a python library that can take crane's place that'd be great but
+# I didn't find it.
+
+import asyncio
+import logging
+import os
 from pathlib import Path
+from typing import Self
+
+from fqdn import FQDN
+
 
 class DockerImageInfo:
     """
     Provides information about a remote docker image
     """
     
-    def __init__(self, crane_absolute_path: Path):
+    @classmethod
+    async def create(cls, crane_absolute_path: Path) -> Self:
         """
-        Initialize the image info provider.
+        Create the image info provider.
         
         crane_absolute_path - the absolute path to the crane executable.
         """
-        # Require an absolute path to avoid various malicious attacks
-        # TODO check is absolute path
-        # TODO run crane sync and check version, store path
+        dii = DockerImageInfo(crane_absolute_path)
+        retcode, _, stde = await dii._run_crane("version")
+        if retcode > 0:
+            raise ValueError(
+                f"crane executable version call failed, retcode: {retcode} stderr:\n{stde}")
+        return dii
+    
+    def __init__(self, crane_absolute_path: Path):
+        if not crane_absolute_path:
+            raise CranePathError("crane_absolute_path cannot be None")
+        crane = Path(os.path.normpath(crane_absolute_path))
+        if not crane.is_absolute():
+            # Require an absolute path to avoid various malicious attacks
+            raise CranePathError("crane_absolute_path must be absolute")
+        self._crane = crane_absolute_path
 
-    def get_digest_from_name(self, image_name: str):
+    async def get_digest_from_name(self, image_name: str) -> str:
         """
         Get an image digest given the image name.
         """
-        # TODO validate container_name
-        # TODO run crane asynchronously - watch out for shell injection
-        # TODO throw an exception if something goes wrong
-        return "sha256:fake"
+        image_name = _validate_image_name(image_name)
+        retcode, stdo, stde = await self._run_crane("digest", image_name)
+        if retcode > 0:
+            # TODO LOGGING figure out how this is going to work, want to associate logs with
+            #              user names, ips, etc.
+            # TDOO TEST logging add tests for logging before exiting prototype stage
+            #           manual testing for now
+            logging.getLogger(__name__).error(
+                f"crane lookup of image {image_name} failed, retcode: {retcode}, stderr:\n{stde}")
+            # special case when crane spits out html and the regular error parsing doesn't work
+            if "404 not found" in stde.lower():
+                raise DigestFetchError(
+                    f"Failed to get digest for image {image_name}. "
+                    + "Image was not found on the host")
+            # This is pretty fragile for non-docker repository hosts.
+            # Not really sure what else to do here
+            # Allowlist for hosts?
+            errcode = stde.split("\n")[-1].split(':')[-1].strip()
+            raise DigestFetchError(
+                f"Failed to get digest for image {image_name}. Error code was: {errcode}")
+        return stdo
 
+    async def _run_crane(self, *args) -> (int, str, str):
+        # crane has very small output so just buffer in memory
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                self._crane, *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE
+            )
+        except FileNotFoundError as e:
+            raise CranePathError(
+                f"Configured crane executable path {self._crane} is invalid") from e
+        stdo, stde = await proc.communicate()
+        return proc.returncode, stdo.decode().strip(), stde.decode().strip()
+
+
+def _validate_image_name(image_name: str) -> str:
+    image_name = image_name.strip() if image_name is not None else None
+    # Image name rules: https://docs.docker.com/reference/cli/docker/image/tag/
+    # Don't do an exhaustive check here, but enough that we're reasonably confident
+    # it's a real name and there's no shell injection risk
+    # Also allows us to provide more specific error messages
+    if not image_name:
+        raise ImageNameParseError("No image name provided")
+    parts = image_name.split("/")
+    # assume a namespace is always present
+    if len(parts) == 2:  # docker
+        host, repo, image_and_tag = None, parts[0], parts[1]
+    elif len(parts) == 3:
+        host, repo, image_and_tag = parts
+    else:
+        # theoretically can have > 2 slashes, but don't bother with that case for now.
+        raise ImageNameParseError(f"Expected 1 or 2 '/' symbols in image name '{image_name}'")
+    if host and not FQDN(host).is_valid:
+        raise ImageNameParseError(f"Illegal host '{host}' in image name '{image_name}'")
+    _check_path(image_name, repo)
+    _check_path(image_name, image_and_tag)
+    return image_name
+
+
+# legal non alphanum characters in docker image name path / tag
+_TRANS_TABLE = str.maketrans({
+    '-': None,
+    '.': None,
+    '_': None,
+    ':': None,
+    '@': None,  # for digests
+    
+})
+
+
+def _check_path(image_name, part):
+    part = part.translate(_TRANS_TABLE)
+    if not part.isalnum():
+        raise ImageNameParseError(
+            "path or tag contains non-alphanumeric characters other than '_-:.@' "
+            + f"in image name '{image_name}'")
+    if not part.isascii():
+        raise ImageNameParseError(
+            f"path or tag contains non-ascii characters in image name '{image_name}'")
+    if not part.islower(): 
+        raise ImageNameParseError(
+            f"path or tag contains upper case characters in image name '{image_name}'")
+
+
+class ImageInfoError(Exception):
+    """ Base class for image info exceptions. """
+
+
+class CranePathError(ImageInfoError):
+    """ Thrown when the crane executable cannot be found. """
+
+
+class ImageNameParseError(ImageInfoError):
+    """ Thrown when an image name couldn't be parsed. """
+
+
+class DigestFetchError(ImageInfoError):
+    """ Thrown when an error occurs fetching a digest for an image. """

--- a/cdmtaskservice/dockerimages.py
+++ b/cdmtaskservice/dockerimages.py
@@ -49,6 +49,9 @@ class DockerImageInfo:
     async def get_digest_from_name(self, image_name: str) -> str:
         """
         Get an image digest given the image name.
+        
+        Assumes that a namespace is always present (so names like `image:tag` will be rejected)
+        and the path always has 2 components, the namespace and the image name.
         """
         image_name = _validate_image_name(image_name)
         retcode, stdo, stde = await self._run_crane("digest", image_name)

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -1,0 +1,7 @@
+# To run tests, copy this file to test.cfg and set the values below appropriately.
+
+[cdmtaskservicetest]
+
+# Absolute path to a crane executable
+# See https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+test.crane.exe=/path/to/crane

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -4,4 +4,7 @@
 
 # Absolute path to a crane executable
 # See https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md
+# If you install with the tarball, you can omit the -C option to extract the tarball to the current
+# directory and move the crane executable to wherever you wish.
+# If you install via a package manager you can use `which crane` to get the path.
 test.crane.exe=/path/to/crane

--- a/test/config.py
+++ b/test/config.py
@@ -1,0 +1,18 @@
+import configparser
+from os import path as ospath
+from pathlib import Path
+
+
+TEST_CFG_LOC = Path(ospath.normpath((Path(__file__) / ".." / ".." / "test.cfg").absolute()))
+TEST_CFG_SEC = "cdmtaskservicetest"
+
+_cfg = configparser.ConfigParser()
+_cfg.read(TEST_CFG_LOC)
+
+if TEST_CFG_SEC not in _cfg.sections():
+    raise ValueError(f"missing {TEST_CFG_SEC} section in test config file {TEST_CFG_LOC}")
+
+TEST_CFG = dict(_cfg[TEST_CFG_SEC])
+del _cfg
+
+CRANE_EXE_PATH = TEST_CFG.get("test.crane.exe")

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,11 @@
+'''
+Configure pytest fixtures and helper functions for this directory.
+'''
+
+import traceback
+
+
+def assert_exception_correct(got: Exception, expected: Exception):
+    err = "".join(traceback.TracebackException.from_exception(got).format())
+    assert got.args == expected.args  # add , err to see the traceback
+    assert type(got) == type(expected)

--- a/test/dockerimages_test.py
+++ b/test/dockerimages_test.py
@@ -1,9 +1,99 @@
 import pytest
-from cdmtaskservice.dockerimages import DockerImageInfo
+import os
+from pathlib import Path
+
+from cdmtaskservice.dockerimages import (
+    DockerImageInfo,
+    ImageNameParseError,
+    CranePathError,
+    DigestFetchError,
+)
+import config as testcfg
+from conftest import assert_exception_correct
 
 
 @pytest.mark.asyncio
-async def test_get_digest_from_name():
-    dig = DockerImageInfo("fake_path").get_digest_from_name("fake_image")
+async def test_create_fail_invalid_crane_path():
+    badcrane = os.path.normpath((Path(__file__) / ".." / "testfiles" / "badcrane").absolute())
+    testset = {
+        None: CranePathError("crane_absolute_path cannot be None"),
+        "fake/../../crane/path": CranePathError("crane_absolute_path must be absolute"),
+        "/fake/crane/path": CranePathError(
+            "Configured crane executable path /fake/crane/path is invalid"),
+        badcrane: ValueError("crane executable version call failed, retcode: 123 stderr:\noopsie"),
+    }
+    for k, v in testset.items():
+        with pytest.raises(Exception) as got:
+            dii = await DockerImageInfo.create(k)
+        assert_exception_correct(got.value, v)
 
-    assert dig == "sha256:fake"
+
+@pytest.mark.asyncio
+async def test_get_digest_from_name_succeed():
+    ws0_15_0_sha = "sha256:7e41821daf50abcd511654ddd9bdf66ed6374a30a1d62547631e79dcbe4ad92e"
+    ws0_10_2_sha = "sha256:285b1229730192eac5b502c44bfffff98e9840057821d1a26bed47a05bc44874"
+    # no longer pushing to dockerhub so this shouldn't change, unlike ghcr
+    ws_docker_latest = "sha256:8a3eaf76ce3506da4113510221218cab0867462986c61025f0b50d18b08de7b6"
+    testset = {
+        "ghcr.io/kbase/workspace_deluxe:0.15.0": ws0_15_0_sha,
+        "ghcr.io/kbase/workspace_deluxe@" + ws0_15_0_sha: ws0_15_0_sha,
+        "ghcr.io/kbase/workspace_deluxe:0.15.0@" + ws0_15_0_sha: ws0_15_0_sha,
+        # this tests all non alphanum chars other than @
+        "kbase/workspace_deluxe:0.10.2-hotfix": ws0_10_2_sha,
+        "kbase/workspace_deluxe": ws_docker_latest,
+        "kbase/workspace_deluxe:latest": ws_docker_latest,
+    }
+    for k, v in testset.items():
+        dii = await DockerImageInfo.create(testcfg.CRANE_EXE_PATH)
+        dig = await dii.get_digest_from_name(k)
+        assert dig == v
+
+
+@pytest.mark.asyncio
+async def test_get_digest_from_name_fail():
+    testset = {
+        None: ImageNameParseError("No image name provided"),
+        "gc_hr.io/kbase/workspace_deluxe:0.15.0": ImageNameParseError(
+            "Illegal host 'gc_hr.io' in image name 'gc_hr.io/kbase/workspace_deluxe:0.15.0'"),
+        "workspace_deluxe:0.15.0": ImageNameParseError(
+            "Expected 1 or 2 '/' symbols in image name 'workspace_deluxe:0.15.0'"),
+        "ghcr.io/kb/ase/workspace_deluxe:0.15.0": ImageNameParseError(
+            "Expected 1 or 2 '/' symbols in image name 'ghcr.io/kb/ase/workspace_deluxe:0.15.0'"),
+        "ghcr.io/kbase/ɰorkspace_deluxe:0.15.0": ImageNameParseError(
+            "path or tag contains non-ascii characters in image name "
+            + "'ghcr.io/kbase/ɰorkspace_deluxe:0.15.0'"),
+        "ghcr.io/kbase/Workspace_deluxe:0.15.0": ImageNameParseError(
+            "path or tag contains upper case characters in image name "
+            + "'ghcr.io/kbase/Workspace_deluxe:0.15.0'"),
+        "superfakehostforrealihope.io/kbase/workspace_deluxe:0.15.0": DigestFetchError(
+            "Failed to get digest for image superfakehostforrealihope.io/kbase/workspace_deluxe:"
+            + "0.15.0. Error code was: no such host"),
+        # note misspelling of ghcr
+        "gchr.io/kbase/workspace_deluxe:0.15.0": DigestFetchError(
+            "Failed to get digest for image gchr.io/kbase/workspace_deluxe:0.15.0. "
+            + "Error code was: handshake failure"),
+        "hcr.io/kbase/workspace_deluxe:0.15.0": DigestFetchError(
+            "Failed to get digest for image hcr.io/kbase/workspace_deluxe:0.15.0. "
+            + "Image was not found on the host"),
+        "ghcr.io/kbase/workspace_not_deluxe:0.15.0": DigestFetchError(
+            "Failed to get digest for image ghcr.io/kbase/workspace_not_deluxe:0.15.0. "
+            + "Error code was: requested access to the resource is denied"),
+    }
+    for k, v in testset.items():
+        with pytest.raises(Exception) as got:
+            dii = await DockerImageInfo.create(testcfg.CRANE_EXE_PATH)
+            await dii.get_digest_from_name(k)
+        assert_exception_correct(got.value, v)
+
+
+@pytest.mark.asyncio
+async def test_get_digest_from_name_fail_bad_chars():
+    # test some of the scary chars for shell injection
+    for c in "[]$()`&|<>;,\n{}'\"":
+        name = f"kbase/workspace{c}deluxe"
+        with pytest.raises(Exception) as got:
+            dii = await DockerImageInfo.create(testcfg.CRANE_EXE_PATH)
+            await dii.get_digest_from_name(name)
+        assert_exception_correct(got.value, ImageNameParseError(
+            "path or tag contains non-alphanumeric characters other than '_-:.@' "
+            + f"in image name '{name}'"))

--- a/test/testfiles/badcrane
+++ b/test/testfiles/badcrane
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo oopsie > /dev/stderr
+exit 123


### PR DESCRIPTION
Uses the crane CLI tool, but abstracts it away from the API so we can switch it to something else (e.g. a python lib) later if possible without changing anything other than initialization code