### PR TITLE
Add more S3 / Minio test infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,7 +52,7 @@ jobs:
         # set up crane
         # don't bother to verify provenance here
         curl -sL "https://github.com/google/go-containerregistry/releases/download/$CRANE_VER/go-containerregistry_Linux_x86_64.tar.gz" > go-containerregistry.tar.gz
-        tar -zxvf go-containerregistry.tar.gz
+        tar -zxf go-containerregistry.tar.gz
         export CRANE_EXE_PATH=`pwd`/crane
         
         # set up Minio
@@ -60,11 +60,16 @@ jobs:
         chmod a+x minio
         export MINIOD=`pwd`/minio
         
+        wget -q https://dl.minio.io/client/mc/release/linux-amd64/archive/minio.RELEASE.${{matrix.minio}} -O mc
+        chmod a+x mc
+        export MINIO_MC=`pwd`/mc
+        
         # set up test config
         cd $HOMEDIR
-        cp -n test.cfg.example test.cfg
+        cp test.cfg.example test.cfg
         sed -i "s#^test.crane.exe=.*#test.crane.exe=$CRANE_EXE_PATH#" test.cfg
         sed -i "s#^test.minio.exe=.*#test.minio.exe=$MINIOD#" test.cfg
+        sed -i "s#^test.minio.mc.exe=.*#test.minio.mc.exe=$MINIO_MC#" test.cfg
         cat test.cfg
 
     - name: Run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,10 @@ jobs:
         include:
           - python-version: "3.11"
             minio: "2021-04-22T15-44-28Z"  # minimum supported version
+            mc: "2021-04-22T17-40-00Z"
           - python-version: "3.11"
             minio: "2024-08-03T04-33-23Z"  # current version as of this update
+            mc: "2024-08-13T05-33-17Z"
 
     steps:
     
@@ -60,7 +62,7 @@ jobs:
         chmod a+x minio
         export MINIOD=`pwd`/minio
         
-        wget -q https://dl.minio.io/client/mc/release/linux-amd64/archive/minio.RELEASE.${{matrix.minio}} -O mc
+        wget -q https://dl.minio.io/client/mc/release/linux-amd64/archive/mc.RELEASE.${{matrix.mc}} -O mc
         chmod a+x mc
         export MINIO_MC=`pwd`/mc
         

--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@ Enables running jobs on remote compute from the KBase CDM cluster.
 * Python 3.11+
 * [crane](https://github.com/google/go-containerregistry/blob/main/cmd/crane/README.md)
 * An s3 instance for use as a file store
+  * The provided credentials must enable listing buckets, as the service performs that operation
+    to check the host and credentials on startup
   * If using Minio, the minimum version is `2021-04-22T15-44-28Z` and the server must be run
     in `--compat` mode.
 

--- a/cdmtaskservice/dockerimages.py
+++ b/cdmtaskservice/dockerimages.py
@@ -121,7 +121,6 @@ _TRANS_TABLE = str.maketrans({
     '_': None,
     ':': None,
     '@': None,  # for digests
-    
 })
 
 

--- a/test.cfg.example
+++ b/test.cfg.example
@@ -12,6 +12,9 @@ test.crane.exe=/path/to/crane
 # Absolute path to a Minio server (`minio`) executable.
 test.minio.exe=/path/to/minio
 
+# Absolute path to a Minio client (`mc`) executable.
+test.minio.mc.exe=/path/to/mc
+
 # A directory in which to store temporary test files.
 test.temp.dir=cdm_task_service_temp
 

--- a/test/config.py
+++ b/test/config.py
@@ -17,5 +17,6 @@ del _cfg
 
 CRANE_EXE_PATH = Path(TEST_CFG.get("test.crane.exe"))
 MINIO_EXE_PATH = Path(TEST_CFG.get("test.minio.exe"))
+MINIO_MC_EXE_PATH = Path(TEST_CFG.get("test.minio.mc.exe"))
 TEMP_DIR       = Path(TEST_CFG.get("test.temp.dir"))
 TEMP_DIR_KEEP  = TEST_CFG.get("test.temp.dir.keep") == "true"


### PR DESCRIPTION
* mc to add users, apparently there's no way to do this via the client
* helper methods for creating buckets and files

This is all used locally for testing the s3 client I'm working on, but including it all at once would lead to a large, hard to read PR