### PR TITLE
Switch S3Client.get_object_meta to a bulk method

### DIFF
--- a/cdmtaskservice/s3/exceptions.py
+++ b/cdmtaskservice/s3/exceptions.py
@@ -1,0 +1,17 @@
+""" S3 client exceptions. """
+
+
+class S3ClientError(Exception):
+    """ The base class for S3 client errors. """ 
+
+
+class S3ClientConnectError(S3ClientError):
+    """ The base class for S3 client errors. """ 
+
+
+class S3PathError(S3ClientError):
+    """ Error thrown when an S3 path is incorrectly specified. """
+
+
+class S3UnexpectedError(S3ClientError):
+    """ Error thrown when an S3 path is incorrectly specified. """

--- a/cdmtaskservice/s3/paths.py
+++ b/cdmtaskservice/s3/paths.py
@@ -1,0 +1,72 @@
+"""
+S3 Path related classes and functions.
+"""
+
+from collections.abc import Sequence
+from typing import Generator
+
+from .exceptions import S3PathError
+
+
+class S3Paths:
+    """
+    A container of format validated S3 paths. The paths may not exist in the s3 instance.
+    
+    Instance variables:
+    
+    paths - a tuple of the input paths, stripped of surrounding whitespace.
+    """
+
+    def __init__(self, paths: Sequence[str]):
+        """
+        Create the paths.
+        
+        paths - a sequence of S3 paths, all starting with the bucket.
+        
+        throws S3Path error if a path is not formatted correctly.
+        """
+        if not paths:
+            raise ValueError("At least one path must be supplied.")
+        newpaths = []
+        for i, p in enumerate(paths):
+            newpaths.append(_validate_path(i, p))
+        self.paths = tuple(newpaths)
+
+
+    def split_paths(self, include_full_path=False) -> Generator[list[str, ...], None, None]:
+        """
+        Returns a generator over the paths, split into [bucket, key] lists.
+        
+        include_full_path - append the full path to the returned list.
+        """
+        for p in self.paths:
+            parts = p.split("/", 1)
+            if include_full_path:
+                parts.append(p)
+            yield parts
+
+
+def _validate_path(i: int, path: str) -> str:
+    if not path or not path.strip():
+        raise S3PathError(f"The s3 path at index {i} cannot be null or a whitespace string")
+    parts = [s.strip() for s in path.split("/", 1) if s.strip()]
+    if len(parts) != 2:
+        raise S3PathError(
+            f"path '{path.strip()}' at index {i} must start with the s3 bucket and include a key")
+    _validate_bucket_name(i, parts[0])
+    return path.strip()
+
+
+def _validate_bucket_name(i: int, bucket_name: str):
+    # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
+    bn = bucket_name.strip()
+    if len(bn) < 3 or len(bn) > 63:
+        raise S3PathError(f"Bucket name at index {i} must be > 2 and < 64 characters: {bn}")
+    if "." in bn:
+        raise S3PathError(f"Bucket at index {i} has `.` in the name which is unsupported: {bn}")
+    if bn.startswith("-") or bn.endswith("-"):
+        raise S3PathError(f"Bucket name at index {i} cannot start or end with '-': {bn}")
+    if not bn.replace("-", "").isalnum() or not bn.isascii() or not bn.islower():
+        raise S3PathError(
+            f"Bucket name at index {i} may only contain '-' and lowercase ascii "
+            + f"alphanumerics: {bn}")

--- a/test/s3/paths_test.py
+++ b/test/s3/paths_test.py
@@ -1,0 +1,79 @@
+import random
+from pytest import raises
+
+from cdmtaskservice.s3.paths import S3Paths
+from cdmtaskservice.s3.exceptions import S3PathError
+
+from conftest import  assert_exception_correct
+
+
+def test_init_fail_no_path():
+    for p in [None, [], tuple()]:
+        with raises(Exception) as got:
+            S3Paths(p)
+        assert_exception_correct(got.value, ValueError("At least one path must be supplied."))
+
+
+def test_init_fail_bad_path():
+    
+    charerr = "Bucket name at index x may only contain '-' and lowercase ascii alphanumerics: "
+        
+    testset = {
+        None: "The s3 path at index x cannot be null or a whitespace string",
+        "   \t   ": "The s3 path at index x cannot be null or a whitespace string",
+         "  /  ": "path '/' at index x must start with the s3 bucket and include a key",
+         "foo /  ": "path 'foo /' at index x must start with the s3 bucket and include a key",
+        " / bar   ": "path '/ bar' at index x must start with the s3 bucket and include a key",
+        "il/foo": "Bucket name at index x must be > 2 and < 64 characters: il",
+        ("illegal-bu" * 6) + "cket/foo":
+            f"Bucket name at index x must be > 2 and < 64 characters: {'illegal-bu' * 6}cket",
+        "illegal.bucket/foo":
+            "Bucket at index x has `.` in the name which is unsupported: illegal.bucket",
+        "-illegal-bucket/foo":
+            "Bucket name at index x cannot start or end with '-': -illegal-bucket",
+        "illegal-bucket-/foo":
+            "Bucket name at index x cannot start or end with '-': illegal-bucket-",
+        "illegal*bucket/foo": charerr + "illegal*bucket",
+        "illegal_bucket/foo": charerr + "illegal_bucket",
+        "illegal-Bucket/foo": charerr + "illegal-Bucket",
+        "illegal-βucket/foo": charerr + "illegal-βucket",
+    }
+    for k, v in testset.items():
+        _init_fail(k, v)
+
+
+def _init_fail(path: str, expected: str):
+    paths = []
+    for i in range(random.randrange(10)):
+        paths.append(f"foo/bar{i}")
+    paths.append(path)
+    expected = expected.replace("index x", f"index {len(paths) - 1}")
+    with raises(Exception) as got:
+        S3Paths(paths)
+    assert_exception_correct(got.value, S3PathError(expected))
+
+
+def test_init():
+    s3p = S3Paths(["foo/bar"])
+    assert s3p.paths == ("foo/bar",)
+    
+    s3p = S3Paths(["foo/bar", "baz/bat  \t ", "   thingy-stuff9/𝛙hatever"])
+    assert s3p.paths == ("foo/bar", "baz/bat", "thingy-stuff9/𝛙hatever")
+
+
+def test_split_paths():
+    s3p = S3Paths(["foo/bar", "baz/bat  \t ", "   thingy-stuff9/𝛙hatever/baz"])
+    
+    assert list(s3p.split_paths()) == [
+        ["foo", "bar"], ["baz", "bat"], ["thingy-stuff9", "𝛙hatever/baz"]
+    ]
+    
+    
+def test_split_paths_w_full_path():
+    s3p = S3Paths(["foo/bar", "baz/bat  \t ", "   thingy-stuff9/𝛙hatever/baz"])
+    
+    assert list(s3p.split_paths(include_full_path=True)) == [
+        ["foo", "bar", "foo/bar"],
+        ["baz", "bat", "baz/bat"],
+        ["thingy-stuff9", "𝛙hatever/baz", "thingy-stuff9/𝛙hatever/baz"]
+    ]


### PR DESCRIPTION
We may be dealing with thousands of files for some jobs, so better to share a client and parallelize, which is the next step after switching the method to take multiple paths.

Also makes a paths container class that handles path validation, so we can create it immediately upon reception of paths from the client and pass it around without having to revalidate. Will also have at least one more method that takes a set of paths, which means the validation tests don't need to be run again for that method.