### PR TITLE
Add file path -> crc32 algorithm

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.11"
-            minio: "2021-04-22T15-44-28Z"  # minimum supported version
-            mc: "2021-04-22T17-40-00Z"
-          - python-version: "3.11"
-            minio: "2024-08-03T04-33-23Z"  # current version as of this update
+            minio: "2024-08-17T01-24-54Z"  # minimum supported version
             mc: "2024-08-13T05-33-17Z"
 
     steps:

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Enables running jobs on remote compute from the KBase CDM cluster.
   AWS key management service.
 * The provided credentials must enable listing buckets, as the service performs that operation
   to check the host and credentials on startup
-* If using Minio, the minimum version is `2021-04-22T15-44-28Z` and the server must be run
+* If using Minio, the minimum version is `2024-08-17T01-24-54Z` and the server must be run
   in `--compat` mode.
 
 ## Development

--- a/cdmtaskservice/s3/remote.py
+++ b/cdmtaskservice/s3/remote.py
@@ -10,6 +10,8 @@ from hashlib import md5
 from pathlib import Path
 import zlib
 
+_CHUNK_SIZE_64KB = 2 ** 16
+
 
 def calculate_etag(infile: Path, partsize: int) -> str:
     """
@@ -62,7 +64,7 @@ def crc32(infile: Path) -> bytes:
     _check_file(infile)
     with open(infile.expanduser(), "rb") as f:
         checksum = 0
-        while chunk := f.read(65536):
+        while chunk := f.read(_CHUNK_SIZE_64KB):
             checksum = zlib.crc32(chunk, checksum)
     return checksum.to_bytes(4)
 


### PR DESCRIPTION
Can use the base64 encoded crc to validate uploads like so:

```
In [56]: fields
Out[56]:
{'key': 'somefile',
 'AWSAccessKeyId': 'admin',
 'policy':
'eyJleHBpcmF0aW9uIjogIjIwMjQtMDgtMjZUMjM6MzE6MDBaIiwgImNvbmRpdGlvbnMiOiBbeyJidWNrZXQiOiAidGVzdCJ9LCB7ImtleSI6ICJzb21lZmlsZSJ9XX0=',
 'signature': 'Ys4tVhnbR1fUrMgpm+1DRxXsWnY=',
 'x-amz-checksum-crc32': b'bwUq9A=='}

In [57]: with open("Dockerfile") as f:
    ...:     files = {"file": ("somefile", f)}
    ...:     res = requests.post(url["url"], data=fields, files=files)

```