### PR TITLE
Add download_presigned_url method

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,8 +4,9 @@ verify_ssl = true
 name = "pypi"
 
 [packages]
-fqdn = "==1.5.1"
 aiobotocore = "==2.13.2"
+aiohttp = "==3.10.5"
+fqdn = "==1.5.1"
 
 [dev-packages]
 pytest = "==8.3.2"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d29b3e7babb90ccb46b2bc6f8f6ad0ec9d43a752cb36cf94afc1691d32b0057d"
+            "sha256": "5cdecf703b316087fffc371c44b9da334ecd53a00b7d07666daf36705d5132db"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -126,7 +126,7 @@
                 "sha256:f8112fb501b1e0567a1251a2fd0747baae60a4ab325a871e975b7bb67e59221f",
                 "sha256:fd31f176429cecbc1ba499d4aba31aaccfea488f418d60376b911269d3b883c5"
             ],
-            "markers": "python_version >= '3.8'",
+            "index": "pypi",
             "version": "==3.10.5"
         },
         "aioitertools": {

--- a/test/s3/client_test.py
+++ b/test/s3/client_test.py
@@ -89,7 +89,7 @@ async def test_get_object_meta_multipart(minio):
     await minio.clean()  # couldn't get this to work as a fixture
     await minio.create_bucket("test-bucket")
     await minio.upload_file(
-        "test-bucket/big_test_file", b"abcdefghij" * 6000000, 3, b"bigolfile")
+        "test-bucket/big_test_file", b"abcdefghij" * 600000, 3, b"bigolfile")
 
     s3c = await _client(minio)
     objm = await s3c.get_object_meta(S3Paths(["test-bucket/big_test_file"]))
@@ -97,12 +97,12 @@ async def test_get_object_meta_multipart(minio):
     _check_obj_meta(
         objm[0],
         "test-bucket/big_test_file",
-        "e0fcd4584a5157e2d465bf0217ab8268-4",
-        180000009,
-        60000000,
+        "b8185adaf462a5ac2ca9db335b290d23-4",
+        18000009,
+        6000000,
         True,
         4,
-        60000000,
+        6000000,
     )
 
 @pytest.mark.asyncio
@@ -110,7 +110,7 @@ async def test_get_object_meta_mix(minio):
     await minio.clean()  # couldn't get this to work as a fixture
     await minio.create_bucket("nice-bucket")
     await minio.upload_file(
-        "nice-bucket/big_test_file", b"abcdefghij" * 6000000, 4, b"bigolfile")
+        "nice-bucket/big_test_file", b"abcdefghij" * 600000, 4, b"bigolfile")
     await minio.upload_file("nice-bucket/test_file", b"abcdefghij")
     
     s3c = await _client(minio)
@@ -120,12 +120,12 @@ async def test_get_object_meta_mix(minio):
     _check_obj_meta(
         objm[0],
         "nice-bucket/big_test_file",
-        "2c0fa9e12a28c40de69cab92da528adf-5",
-        240000009,
-        60000000,
+        "9728af2f2c566b2b944b96203769175d-5",
+        24000009,
+        6000000,
         True,
         5,
-        60000000,
+        6000000,
     )
     _check_obj_meta(
         objm[1],

--- a/test/s3/remote_test.py
+++ b/test/s3/remote_test.py
@@ -1,12 +1,35 @@
+import aiohttp
 import os
 from pathlib import Path
+import pytest
+import shutil
+import tempfile
 
-from pytest import raises
-
-from conftest import assert_exception_correct
-from cdmtaskservice.s3.remote import calculate_etag, crc32
+from conftest import assert_exception_correct, minio  # @UnusedImport
+from cdmtaskservice.s3.client import S3Client
+from cdmtaskservice.s3.paths import S3Paths
+from cdmtaskservice.s3.remote import (
+    calculate_etag,
+    crc32,
+    download_presigned_url,
+    FileCorruptionError,
+    TransferError,
+)
+import config
 
 TESTDATA = Path(os.path.normpath((Path(__file__) / ".." / ".." / "testdata")))
+
+
+@pytest.fixture(scope="module")
+def temp_dir():
+    
+    td = Path(tempfile.mkdtemp(prefix="remote_test", dir=config.TEMP_DIR))
+    
+    yield td
+    
+    if not config.TEMP_DIR_KEEP:
+        shutil.rmtree(td)
+
 
 def test_calculate_etag():
     testset = [
@@ -31,7 +54,7 @@ def test_calculate_etag_fail():
         (TESTDATA / "random_bytes_1kB", -10000, ValueError("partsize must be > 0")),
     ]
     for infile, size, expected in testset:
-        with raises(Exception) as got:
+        with pytest.raises(Exception) as got:
             calculate_etag(infile, size)
         assert_exception_correct(got.value, expected)
 
@@ -54,6 +77,130 @@ def test_crc32_fail():
         (TESTDATA, ValueError("infile must be exist and be a file")),
     ]
     for infile, expected in testset:
-        with raises(Exception) as got:
+        with pytest.raises(Exception) as got:
             crc32(infile)
         assert_exception_correct(got.value, expected)
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url(minio, temp_dir):
+    await minio.clean()  # couldn't get this to work as a fixture
+    await minio.create_bucket("test-bucket")
+    await minio.upload_file("test-bucket/myfile", b"abcdefghij")
+    
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["test-bucket/myfile"])))[0]
+    output = temp_dir / "temp1.txt"
+    async with aiohttp.ClientSession() as sess:
+        await download_presigned_url(sess, url, "a925576942e94b2ef57a066101b48876", 10, output)
+    with open(output) as f:
+        assert f.read() == "abcdefghij"
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url_multipart(minio, temp_dir):
+    await minio.clean()  # couldn't get this to work as a fixture
+    await minio.create_bucket("nice-bucket")
+    res = await minio.upload_file(
+        "nice-bucket/big_test_file", b"abcdefghij" * 600000, 4, b"bigolfile")
+    
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["nice-bucket/big_test_file"])))[0]
+    output = temp_dir / "temp2.txt"
+    async with aiohttp.ClientSession() as sess:
+        await download_presigned_url(
+            sess, url, "9728af2f2c566b2b944b96203769175d-5", 6000000, output)
+    with open(output) as f:
+        assert f.read() == "abcdefghij" * 600000 * 4 + "bigolfile"
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url_fail_no_session(minio, temp_dir):
+    output = temp_dir / "fail.txt"
+    et = "a925576942e94b2ef57a066101b48876"
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["test-bucket/myfile"])))[0]
+    with pytest.raises(Exception) as got:
+        await download_presigned_url(None, url, et, 10, output)
+    assert_exception_correct(got.value, ValueError("session is required"))
+    assert not output.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url_fail_bad_args(minio, temp_dir):
+    await minio.clean()  # couldn't get this to work as a fixture
+    await minio.create_bucket("test-bucket")
+    await minio.upload_file("test-bucket/myfile", b"abcdefghij")
+    et = "a925576942e94b2ef57a066101b48876"
+    ps = 10
+    o = temp_dir / "fail.txt"
+    
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["test-bucket/myfile"])))[0]
+    await _download_presigned_url_fail(None, et, ps, o, ValueError("url is required"))
+    await _download_presigned_url_fail("  \t   ", et, ps, o, ValueError("url is required"))
+    await _download_presigned_url_fail(url, None, ps, o, ValueError("etag is required"))
+    await _download_presigned_url_fail(url, "   \t  ", ps, o, ValueError("etag is required"))
+    await _download_presigned_url_fail(url, "foo", ps, o, FileCorruptionError(
+        f"Etag check failed for url http://localhost:{minio.port}/test-bucket/myfile. "
+        + "Expected foo, got a925576942e94b2ef57a066101b48876"))
+    await _download_presigned_url_fail(url, et, 0, o, ValueError("partsize must be > 0"))
+    await _download_presigned_url_fail(url, et, 3, o, FileCorruptionError(
+        f"Etag check failed for url http://localhost:{minio.port}/test-bucket/myfile. "
+        + "Expected a925576942e94b2ef57a066101b48876, got 1543089f5b20740cc5713f0437fcea8c-4"))
+    await _download_presigned_url_fail(url, et, ps, None, ValueError("outputpath is required"))
+    
+    
+async def _download_presigned_url_fail(url, etag, partsize, output, expected):
+    with pytest.raises(Exception) as got:
+        async with aiohttp.ClientSession() as sess:
+            await download_presigned_url(sess, url, etag, partsize, output)
+    assert_exception_correct(got.value, expected)
+    if output:
+        assert not output.exists()
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url_fail_bad_sig(minio, temp_dir):
+    starts_with = f"GET URL: http://localhost:{minio.port}/test-bucket/myfilex 403\nError:\n"
+    contains = ("<Error><Code>SignatureDoesNotMatch</Code><Message>The request signature we "
+            + "calculated does not match the signature you provided. Check your key and "
+            + "signing method.</Message><Key>myfilex</Key><BucketName>test-bucket</BucketName>"
+            + "<Resource>/test-bucket/myfilex</Resource>"
+    )
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["test-bucket/myfile"]))
+           )[0].replace("myfile", "myfilex")
+    await _download_presigned_url_fail_s3_error(minio, temp_dir, url, starts_with, contains)
+
+
+@pytest.mark.asyncio
+async def test_download_presigned_url_fail_nofile(minio, temp_dir):
+    starts_with = f"GET URL: http://localhost:{minio.port}/test-bucket/myfilex 404\nError:\n"
+    contains = ("<Error><Code>NoSuchKey</Code><Message>The specified key does not exist."
+                + "</Message><Key>myfilex</Key><BucketName>test-bucket</BucketName>"
+                +"<Resource>/test-bucket/myfilex</Resource>"
+    )
+    s3c = await _client(minio)
+    url = (await s3c.presign_get_urls(S3Paths(["test-bucket/myfilex"])))[0]
+    await _download_presigned_url_fail_s3_error(minio, temp_dir, url, starts_with, contains)
+
+
+async def _download_presigned_url_fail_s3_error(minio, temp_dir, url, starts_with, contains):
+    await minio.clean()  # couldn't get this to work as a fixture
+    await minio.create_bucket("test-bucket")
+    await minio.upload_file("test-bucket/myfile", b"abcdefghij")
+    et = "a925576942e94b2ef57a066101b48876"
+    output = temp_dir / "fail_s3.txt"
+    with pytest.raises(Exception) as got:
+        async with aiohttp.ClientSession() as sess:
+            await download_presigned_url(sess, url, et, 10, output)
+    errmsg = str(got.value)
+    assert errmsg.startswith(starts_with)
+    assert contains in errmsg
+    assert type(got.value) == TransferError
+    assert not output.exists()
+
+
+async def _client(minio):
+    return await S3Client.create(minio.host,  minio.access_key, minio.secret_key)


### PR DESCRIPTION
Checks the etag as part of the download

Also sped up some of the client tests by transferring 10x less data