### PR TITLE
Fix path related bugs

### DIFF
--- a/cdmtaskservice/s3/paths.py
+++ b/cdmtaskservice/s3/paths.py
@@ -4,13 +4,15 @@ S3 Path related classes and functions.
 
 from collections.abc import Sequence
 from typing import Generator
+import unicodedata
 
 from .exceptions import S3PathError
 
 
 class S3Paths:
     """
-    A container of format validated S3 paths. The paths may not exist in the s3 instance.
+    A container of format validated S3 paths. The paths may not necessarily exist in the
+    s3 instance.
     
     Instance variables:
     
@@ -49,19 +51,32 @@ class S3Paths:
 
 
 def _validate_path(i: int, path: str) -> str:
+    # keys can have spaces and / but not //, except for the first characters
     if not path or not path.strip():
         raise S3PathError(f"The s3 path at index {i} cannot be null or a whitespace string")
-    parts = [s.strip() for s in path.split("/", 1) if s.strip()]
+    parts = path.lstrip().lstrip("/").split("/", 1)  # ignore leading /s in the bucket, be nice
     if len(parts) != 2:
         raise S3PathError(
-            f"path '{path.strip()}' at index {i} must start with the s3 bucket and include a key")
-    _validate_bucket_name(i, parts[0])
-    return path.strip()
+            f"Path '{path}' at index {i} must start with the s3 bucket and include a key")
+    bucket = parts[0].strip()  # be nice to users and clean up the name a bit
+    _validate_bucket_name(i, bucket)
+    key = parts[1].lstrip("/")  # Leading /s are ignored by s3, but spaces and trailing /s count
+    if "//" in key:
+        raise S3PathError(f"Path '{path}' at index {i} contains illegal "
+                          + "character string '//' in the key")
+    # See https://stackoverflow.com/questions/4324790/removing-control-characters-from-a-string-in-python
+    for ci, c in enumerate(key):
+        if unicodedata.category(c)[0] == 'C':
+            raise S3PathError(
+                f"Key {key} at index {i} contains a control character at position {ci}")
+    return f"{bucket}/{key}"
 
 
 def _validate_bucket_name(i: int, bucket_name: str):
     # https://docs.aws.amazon.com/AmazonS3/latest/userguide/bucketnamingrules.html
-    bn = bucket_name.strip()
+    bn = bucket_name
+    if not bn:
+        raise S3PathError(f"Bucket name at index {i} cannot be whitespace only")
     if len(bn) < 3 or len(bn) > 63:
         raise S3PathError(f"Bucket name at index {i} must be > 2 and < 64 characters: {bn}")
     if "." in bn:

--- a/test/s3/client_test.py
+++ b/test/s3/client_test.py
@@ -67,7 +67,8 @@ async def _create_fail(host, akey, skey, expected, config=None, print_stacktrace
 async def test_get_object_meta_single_part(minio):
     await minio.clean()  # couldn't get this to work as a fixture
     await minio.create_bucket("test-bucket")
-    await minio.upload_file("test-bucket/test_file", b"abcdefghij")
+    # test that leading /s in key are ignored
+    await minio.upload_file("test-bucket///test_file", b"abcdefghij")
 
     s3c = await _client(minio)
     objm = await s3c.get_object_meta(S3Paths(["test-bucket/test_file"]))


### PR DESCRIPTION
* spaces are just fine in keys, so can't strip() all over the place without munging valid keys
* Disallow control characters. Even if they are allowed they're more trouble than they're worth.
* Ignore leading /s in the bucket and key since S3 does the same.