### PR TITLE
Move argument checkers into shared module

### DIFF
--- a/cdmtaskservice/arg_checkers.py
+++ b/cdmtaskservice/arg_checkers.py
@@ -1,0 +1,52 @@
+'''
+Contains common code for checking method arguments
+'''
+from typing import Any
+
+
+def not_falsy(obj: Any, name: str):
+    """
+    Check an argument is not falsy.
+    
+    obj - the argument to check.
+    name - the name of the argument to use in exceptions.
+    
+    returns the object.
+    """
+    if not obj:
+        raise ValueError(f"{name} is required")
+    return obj
+
+
+def require_string(string: str, name: str):
+    """
+    Check an argument is a non-whitespace only string.
+    
+    string - the string to check. Must be either falsy or a string.
+    name - the name of the argument to use in exceptions.
+    
+    returns the stripped string.
+    """
+    if not string or not string.strip():
+        raise ValueError(f"{name} is required")
+    return string.strip()
+
+
+def check_int(num: int, name: str, minimum: int = 1):
+    """
+    Check an integer argument is not None and is greater than some value.
+    
+    num - the number to check. Must None or an integer.
+    name - the name of the argument to use in exceptions.
+    minimum - the minimum allowed value of the integer.
+    
+    returns the integer.
+    """
+    # Converted this to float as well but realized we just want ints in all the current use
+    # cases. Leave it as it for now. Not typechecking since we assume the programmer is reading
+    # the type hints
+    if num is None:
+        raise ValueError(f"{name} is required")
+    if num < minimum:
+        raise ValueError(f"{name} must be >= {minimum}")
+    return num

--- a/test/arg_checkers_test.py
+++ b/test/arg_checkers_test.py
@@ -1,0 +1,57 @@
+from pytest import raises
+
+from cdmtaskservice.arg_checkers import not_falsy, require_string, check_int
+
+
+def test_not_falsy():
+    for o in ["thing", 1, -8.2, ["a"], {"a": "b"}, object()]:
+        assert not_falsy(o, "name") == o
+
+
+def test_not_falsy_fail():
+    for o in [None, "", 0, 0.0, [], {}]:
+        with raises(ValueError, match="^r2d2 is required$"):
+            not_falsy(o, "r2d2")
+
+
+def test_require_string():
+    assert require_string("  fooo  \t  ", "name") == "fooo"
+
+
+def test_require_string_fail():
+    for o in [None, "", "    \t   "]:
+        with raises(ValueError, match="^c3po is required$"):
+            require_string(o, "c3po")
+
+
+def test_check_int():
+    for o in [1, 2, 5, 10, 100]:
+        assert check_int(o, "name") == o
+
+
+def test_check_int_with_min():
+    test_set = {
+        100: 100,
+        -98: -156161,
+        894: 893,
+        12161662: 12161662,
+    }
+    for k, v in test_set.items():
+        assert check_int(k, "name", minimum=v) == k
+
+
+def test_check_int_fail_None():
+    with raises(ValueError, match="^JEJ is required"):
+        check_int(None, "JEJ")
+
+
+def test_check_int_fail_minimum():
+    test_set = {
+        100: 101,
+        -98: 156161,
+        894: 895,
+        12161662: 12161663,
+    }
+    for k, v in test_set.items():
+        with raises(ValueError, match=f"^Luke must be >= {v}$"):
+            check_int(k, "Luke", minimum=v)


### PR DESCRIPTION
Not surprisingly they're needed elsewhere. Still leaving the duplicates in remote.py