### PR TITLE
Add remote NERSC->Minio upload manifest processing code

### DIFF
--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -33,6 +33,8 @@ _URL_API_BETA = "https://api.nersc.gov/api/beta"
 _COMMAND_PATH = "utilities/command"
 
 _MAX_CALLBACK_TIMEOUT = 3 * 24 * 3600
+_MIN_TIMEOUT_SEC = 300
+_SEC_PER_GB = 2 * 60  # may want to make this configurable
 
 _MANIFEST_ROOT_DIR = Path("cdm_task_service")
 
@@ -275,12 +277,15 @@ class NERSCManager:
                 "op": "download",
                 "concurrency": check_int(concurrency, "concurrency"),
                 "insecure-ssl": insecure_ssl,
+                "min-timeout-sec": _MIN_TIMEOUT_SEC,
+                "sec-per-GB": _SEC_PER_GB,
                 "files": [
                     {
                         "url": url,
                         "outputpath": str(self._jaws_root_path / job_id / meta.path),
                         "etag": meta.e_tag,
                         "partsize": meta.effective_part_size,
+                        "size": meta.size,
                     } for url, meta in zip(presigned_urls, objects)
                 ]
             }


### PR DESCRIPTION
Needed to extend the default timeout for larger files; also made it easier to debug which file failed since the standard timeout exception has no message.

Tested the NERSC download code the same way as in previous PRs.

upload code tests were performed at NERSC:

```python 
(cdm-task-service) (nersc-python) gaprice@perlmutter:login26:~/tmp/local_cts_test/cdm-task-service>ipython

Python 3.11.7 | packaged by conda-forge | (main, Dec 23 2023, 14:43:09)[GCC 12.3.0]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.20.0 -- An enhanced Interactive Python. Type '?' for help.

In [3]: files = !ls /global/homes/g/gaprice/tmp/cts_test/jaws/fake_job_id/cdm-la
   ...: ke/fast-genomics-source/

In [4]: files_full = ["/global/homes/g/gaprice/tmp/cts_test/jaws/fake_job_id/cdm
   ...: -lake/fast-genomics-source/" + f for f in files]

In [5]: url_input = ["test-bucket/gavin/fast-genomics-source/" + f for f in file
   ...: s]

In [6]: from cdmtaskservice.s3.remote import process_data_transfer_manifest

In [7]: from cdmtaskservice.s3.client import S3Paths
f
In [8]: from cdmtaskservice.s3.client import S3Client

In [9]: s3c = await S3Client.create("https://ci.berkeley.kbase.us:9000", access_
   ...: key, secret_key, insecure_ssl=True)

In [10]: newpaths = S3Paths(url_input)

In [11]: newpaths.paths
Out[11]:
('test-bucket/gavin/fast-genomics-source/AllGenome_202406051229.csv',
 'test-bucket/gavin/fast-genomics-source/ClusteringInfo_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/ClusterProtein_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Gene_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Genome_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Protein_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Scaffold_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/SubDb_202406051231.csv',
 'test-bucket/gavin/fast-genomics-source/Taxon_202406051231.csv')

In [12]: newurls = await s3c.presign_post_urls(newpaths)

In [13]: manifest = {
    ...:     "op": "upload",
    ...:     "files": [
    ...:         {
    ...:             "url": url.url,
    ...:             "fields": url.fields,
    ...:             "file": file,
    ...:         } for url, file in zip(newurls, files_full)],
    ...:     "concurrency": 10,
    ...:     "insecure-ssl": True,
    ...:     "min-timeout-sec": 300,
    ...:     "sec-per-GB": 120,
    ...: }

In [14]: await process_data_transfer_manifest(manifest)

In [15]: # files are now in Minio

```