### PR TITLE
Add nersc manager method to run a set of file uploads

### DIFF
--- a/test/s3/s3_remote_test.py
+++ b/test/s3/s3_remote_test.py
@@ -18,7 +18,7 @@ from cdmtaskservice.s3.remote import (
     FileCorruptionError,
     TransferError,
     FileChangeError,
-    TimeoutError,
+    RemoteTimeoutError,
 )
 import config
 
@@ -166,7 +166,7 @@ async def test_download_presigned_url_fail_bad_args(minio, temp_dir):
         await _download_presigned_url_fail(
             s, url, ps, None, ValueError("outputpath is required"))
         await _download_presigned_url_fail(
-            s, url, 10, o, TimeoutError(f"Timeout downloading to file {o} with timeout 1e-05s"),
+            s, url, 10, o, RemoteTimeoutError(f"Timeout downloading to file {o} with timeout 1e-05s"),
             timeout_sec=0.00001
         )
     
@@ -323,7 +323,7 @@ async def test_upload_presigned_url_fail(minio):
             "infile must exist and be a file"))
         await _upload_presigned_url_fail(
             s, url, flds, fl,
-            TimeoutError(f"Timeout uploading from file {fl} with timeout 0.001s"),
+            RemoteTimeoutError(f"Timeout uploading from file {fl} with timeout 0.001s"),
             timeout_sec=0.001)
 
 


### PR DESCRIPTION
```python
In [7]: from authlib.integrations.httpx_client.oauth2_client import AsyncOAuth2C
   ...: lient

In [8]: from authlib.oauth2.rfc7523 import PrivateKeyJWT

In [9]: nersc_token_url = "https://oidc.nersc.gov/c2id/token"

In [10]: auth = AsyncOAuth2Client(nersc_client_id, nersc_private_key, PrivateKey
    ...: JWT(nersc_token_url), grant_type="client_credentials", token_endpoint=n
    ...: ersc_token_url)

In [11]: await auth.fetch_token();

In [12]: async def get_token():
    ...:     await auth.ensure_active_token(auth.token)
    ...:     return auth.token["access_token"]
    ...:

In [13]: from cdmtaskservice.s3.paths import S3Paths

In [14]: from cdmtaskservice.s3.client import S3Client

In [15]: from cdmtaskservice.nersc.manager import NERSCManager

In [16]: from pathlib import Path

In [17]: from sfapi_client import AsyncClient

In [20]: newpaths = S3Paths(["test-bucket/gavin/fast-genomics-source/" + f for f
    ...:  in files_procs])

In [21]: newpaths.paths
Out[21]:
('test-bucket/gavin/fast-genomics-source/AllGenome_202406051229.csv',
 'test-bucket/gavin/fast-genomics-source/ClusterProtein_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/ClusteringInfo_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Gene_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Genome_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Protein_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/Scaffold_202406051230.csv',
 'test-bucket/gavin/fast-genomics-source/SubDb_202406051231.csv',
 'test-bucket/gavin/fast-genomics-source/Taxon_202406051231.csv')

In [22]: remote_root = "/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-g
    ...: enomics-source"

In [23]: remote_files = [Path(remote_root) / f for f in files_procs]

In [24]: remote_files
Out[24]:
[PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/AllGenome_202406051229.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/ClusterProtein_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/ClusteringInfo_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/Gene_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/Genome_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/Protein_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/Scaffold_202406051230.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/SubDb_202406051231.csv'),
 PosixPath('/global/homes/g/gaprice/tmp/cts_test/fake_out_dir/fast-genomics-source/Taxon_202406051231.csv')]

In [25]: s3c_external = await S3Client.create("https://ci.berkeley.kbase.us:9000
    ...: ", minio_access_key, minio_secret_key, skip_connection_check=True)

In [26]: newurls = await s3c_external.presign_post_urls(newpaths)

In [28]: nerscman = await NERSCManager.create(
    ...:     get_token,
    ...:     Path("/global/homes/g/gaprice/tmp/cts_test/code"),
    ...:     Path("/global/homes/g/gaprice/tmp/cts_test/jaws"),
    ...: )

In [29]: tid = await nerscman.upload_s3_files("fake_job_id", remote_files, newur
    ...: ls, "https://teletubbiesunleashed.com", insecure_ssl=True, concurrency=
    ...: 5)

In [30]: # files are now in Minio
```