### PR TITLE
Add ability to get entrypoint from remote docker image

### DIFF
--- a/test/s3/s3_remote_test.py
+++ b/test/s3/s3_remote_test.py
@@ -4,7 +4,6 @@ from pathlib import Path
 import pytest
 import shutil
 import tempfile
-from unittest import mock
 
 from conftest import assert_exception_correct, minio  # @UnusedImport
 from cdmtaskservice.s3.client import S3Client


### PR DESCRIPTION
Since JAWS/Cromwell won't automatically run the entrypoint, we'll need to pull it from the remote image and run it manually in the WDL