### PR TITLE
Add basic error handling and response models to the service.

### DIFF
--- a/cdmtaskservice/app.py
+++ b/cdmtaskservice/app.py
@@ -5,13 +5,21 @@ API for the CDM task service.
 import os
 import sys
 
-from fastapi import FastAPI
+from fastapi import FastAPI, Request, status
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
 from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import JSONResponse
+from http.client import responses
+from starlette.exceptions import HTTPException as StarletteHTTPException
 
+from cdmtaskservice import errors
+from cdmtaskservice import models_errors
 from cdmtaskservice.config import CDMTaskServiceConfig
 from cdmtaskservice.git_commit import GIT_COMMIT
 from cdmtaskservice.routes import SERVICE_NAME, ROUTER_GENERAL
 from cdmtaskservice.version import VERSION
+from cdmtaskservice.timestamp import timestamp
 
 
 # TODO LOGGING - log all write ops w/ username
@@ -38,7 +46,15 @@ def create_app():
         description = SERVICE_DESCRIPTION,
         version = VERSION,
         root_path = cfg.service_root_path or "",
-        # TODO ERRORS handle service exceptions 
+        exception_handlers = {
+            RequestValidationError: _handle_fastapi_validation_exception,
+            StarletteHTTPException: _handle_starlette_exception,
+            Exception: _handle_general_exception
+        },
+        responses = {
+            "4XX": {"model": models_errors.ClientError},
+            "5XX": {"model": models_errors.ServerError}
+        }
     )
     app.add_middleware(GZipMiddleware)
     app.include_router(ROUTER_GENERAL)
@@ -46,3 +62,47 @@ def create_app():
     # TODO APPSTATE handle starup and shudown of app state
     
     return app
+
+
+def _handle_fastapi_validation_exception(r: Request, exc: RequestValidationError):
+    return _format_error(
+        status.HTTP_400_BAD_REQUEST,
+        error_type=errors.ErrorType.REQUEST_VALIDATION_FAILED,
+        request_validation_detail=exc.errors()
+    )
+
+def _handle_starlette_exception(r: Request, exc: StarletteHTTPException):
+    # may need to expand this in the future, mainly handles 404s
+    return _format_error(exc.status_code, message=str(exc.detail))
+
+
+def _handle_general_exception(r: Request, exc: Exception):
+    # TODO ERRORHANDLING may want to only return error message if service admin, owise generic msg
+    # TODO ERRORHANDLING map exception class to error type and status_code
+    status_code = status.HTTP_500_INTERNAL_SERVER_ERROR
+    if len(exc.args) == 1 and type(exc.args[0]) == str:
+        return _format_error(status_code, exc.args[0])
+    else:
+        return _format_error(status_code)
+        
+
+def _format_error(
+        status_code: int,
+        message: str = None,
+        error_type: errors.ErrorType = None,
+        request_validation_detail = None
+        ):
+    content = {
+        "httpcode": status_code,
+        "httpstatus": responses[status_code],
+        "time": timestamp()
+    }
+    if error_type:
+        content.update({
+            "appcode": error_type.error_code, "apperror": error_type.error_type
+        })
+    if message:
+        content.update({"message": message})
+    if request_validation_detail:
+        content.update({"request_validation_detail": request_validation_detail})
+    return JSONResponse(status_code=status_code, content=jsonable_encoder({"error": content}))

--- a/cdmtaskservice/errors.py
+++ b/cdmtaskservice/errors.py
@@ -1,0 +1,44 @@
+"""
+Error codes for exceptions thrown by the CDM task service system.
+"""
+
+from enum import Enum
+
+
+class ErrorType(Enum):
+    """
+    The type of an error, consisting of an error code and a brief string describing the type.
+    :ivar error_code: an integer error code.
+    :ivar error_type: a brief string describing the error type.
+    """
+
+    AUTHENTICATION_FAILED =      (10000, "Authentication failed")  # noqa: E222 @IgnorePep8
+    """ A general authentication error. """
+
+    NO_TOKEN =                   (10010, "No authentication token")  # noqa: E222 @IgnorePep8
+    """ No token was provided when required. """
+
+    INVALID_TOKEN =              (10020, "Invalid token")  # noqa: E222 @IgnorePep8
+    """ The token provided is not valid. """
+
+    INVALID_AUTH_HEADER =        (10030, "Invalid authentication header")  # noqa: E222 @IgnorePep8
+    """ The authentication header is not valid. """
+
+    UNAUTHORIZED =               (20000, "Unauthorized")  # noqa: E222 @IgnorePep8
+    """ The user is not authorized to perform the requested action. """
+
+    MISSING_PARAMETER =          (30000, "Missing input parameter")  # noqa: E222 @IgnorePep8
+    """ A required input parameter was not provided. """
+
+    ILLEGAL_PARAMETER =          (30001, "Illegal input parameter")  # noqa: E222 @IgnorePep8
+    """ An input parameter had an illegal value. """
+
+    REQUEST_VALIDATION_FAILED =  (30010, "Request validation failed")  # noqa: E222 @IgnorePep8
+    """ A request to a service failed validation of the request. """
+
+    UNSUPPORTED_OP =             (100000, "Unsupported operation")  # noqa: E222 @IgnorePep8
+    """ The requested operation is not supported. """
+
+    def __init__(self, error_code, error_type):
+        self.error_code = error_code
+        self.error_type = error_type

--- a/cdmtaskservice/models_errors.py
+++ b/cdmtaskservice/models_errors.py
@@ -1,0 +1,67 @@
+"""
+Pydantic models for service error structures.
+"""
+
+from pydantic import BaseModel, Field
+from typing import Optional
+from cdmtaskservice.errors import ErrorType
+
+
+class ServerErrorDetail(BaseModel):
+    httpcode: int = Field(example=500, description="The HTTP error code")
+    httpstatus: str = Field(example="INTERNAL SERVER ERROR", description="The HTTP status string")
+    time: str = Field(
+        example="2022-10-07T17:58:53.188698+00:00",
+        description="The server time in ISO8601 format"
+    )
+    message: Optional[str] = Field(
+        example="Well dang, that ain't good",
+        description="A free text string providing more information about the error"
+    )
+
+class RequestValidationDetail(BaseModel):
+    # Structure from https://github.com/tiangolo/fastapi/blob/f67b19f0f73ebdca01775b8c7e531e51b9cecfae/fastapi/openapi/utils.py#L34-L59
+    # Note I have witnessed other fields in the response as well, which apparently aren't
+    # included in the spec
+    loc: list[str | int] = Field(
+        example=["body", "data_products", 2, "version"],
+        description="The location where the validation error occurred"
+    )
+    msg: str = Field(
+        example="ensure this value has at most 20 characters",
+        description="A free text message explaining the validation problem"
+    )
+    type: str = Field(
+        example="value_error.any_str.max_length",
+        description="The type of the validation error"
+    )
+
+
+class ClientErrorDetail(ServerErrorDetail):
+    httpcode: int = Field(example=400, description="The HTTP error code")
+    httpstatus: str = Field(example="BAD REQUEST", description="The HTTP status string")
+    appcode: Optional[int] = Field(
+        example=30010,
+        description="An application code providing more specific information about an error, "
+            + "if available"
+    )
+    apperror: Optional[str] = Field(
+        example="Request validation failed",
+        description="The error string for the application error code. If the error code is "
+            + "available, the string is always available"
+    )
+    request_validation_detail: Optional[list[RequestValidationDetail]] = Field(
+        description=
+            "Information about why a request failed to pass the FastAPI validation system. "
+            + f'Included when the app error is "{ErrorType.REQUEST_VALIDATION_FAILED.error_type}".'  # @UndefinedVariable
+    )
+
+
+class ServerError(BaseModel):
+    """ An server error uncaused by the client. """
+    error: ServerErrorDetail
+
+
+class ClientError(BaseModel):
+    """ An error caused by a bad client request. """
+    error: ClientErrorDetail


### PR DESCRIPTION
Starlette errors work for 404s, which is the main use case

Validation can't be tested until an endpoint is added that requires validation

General errors can't be tested until an endpoint is added that can be forced to throw an error