### PR TITLE
Add client lifetime query parameter to client info endpoint

### DIFF
--- a/cdmtaskservice/error_mapping.py
+++ b/cdmtaskservice/error_mapping.py
@@ -8,7 +8,7 @@ from typing import NamedTuple
 from cdmtaskservice.errors import ErrorType
 from cdmtaskservice.http_bearer import MissingTokenError, InvalidAuthHeaderError
 from cdmtaskservice.kb_auth import InvalidTokenError, MissingRoleError
-from cdmtaskservice.routes import UnauthorizedError
+from cdmtaskservice.routes import UnauthorizedError, ClientLifeTimeError
 
 
 class ErrorMapping(NamedTuple):
@@ -27,6 +27,7 @@ _ERR_MAP = {
         ErrorType.INVALID_AUTH_HEADER, status.HTTP_401_UNAUTHORIZED
     ),
     UnauthorizedError: ErrorMapping(ErrorType.UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+    ClientLifeTimeError: ErrorMapping(ErrorType.CLIENT_LIFETIME, status.HTTP_400_BAD_REQUEST)
 }
 
 def map_error(err: Exception) -> tuple[ErrorType, int]:

--- a/cdmtaskservice/errors.py
+++ b/cdmtaskservice/errors.py
@@ -33,6 +33,9 @@ class ErrorType(Enum):
     ILLEGAL_PARAMETER =          (30001, "Illegal input parameter")  # noqa: E222 @IgnorePep8
     """ An input parameter had an illegal value. """
 
+    CLIENT_LIFETIME =            (30050, "Client lifetime too short")  # noqa: E222 @IgnorePep8
+    """ The client life time is shorter than requested. """
+
     REQUEST_VALIDATION_FAILED =  (30010, "Request validation failed")  # noqa: E222 @IgnorePep8
     """ A request to a service failed validation of the request. """
 

--- a/cdmtaskservice/nersc/client.py
+++ b/cdmtaskservice/nersc/client.py
@@ -74,6 +74,8 @@ class NERSCSFAPIClientProvider:
             if self._credfile_last_mod != modtime:
                 self._credfile_last_mod = modtime
                 # TODO LOGGING figure out how this is going to work and test
+                # TODO LOGGING info logs aren't showing up in rancher2
+                #              exceptions do
                 logging.getLogger(__name__).info(
                     f"Detected SFAPI credential at {self._credpath} "
                     + f"changed at {time.time()}, reloading")


### PR DESCRIPTION
Allows for a nagios check to ensure the client isn't about to expire and warn us when we need to update it