### PR TITLE
Fix bug with image lookup with tag

### DIFF
--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -582,11 +582,14 @@ class Image(BaseModel):
     Information about a Docker image.
     """
     # This is an outgoing data structure only so we don't add validators
-    normed_name: Annotated[str, Field(
-        example="ghcr.io/kbase/collections"
-            +"@sha256:c9291c94c382b88975184203100d119cba865c1be91b1c5891749ee02193d380",
+    name: Annotated[str, Field(
+        example="ghcr.io/kbase/collections",
         description="The normalized name of the a docker image, consisting of the "
-            + "host, path, and digest.",
+            + "host and path.",
+    )]
+    digest: Annotated[str, Field(
+        example="@sha256:c9291c94c382b88975184203100d119cba865c1be91b1c5891749ee02193d380",
+        description="The image digest.",
     )]
     entrypoint: Annotated[list[str], Field(
         example=["checkm2", "predict"],

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -45,5 +45,9 @@ class MongoDAO:
         await self._col_images.create_indexes([
             IndexModel([(_FLD_IMAGE_NAME, ASCENDING), (_FLD_IMAGE_HASH, ASCENDING)], unique=True),
             # Only allow one instance of a tag per image name to avoid confusion
-            IndexModel([(_FLD_IMAGE_NAME, ASCENDING), (_FLD_IMAGE_TAG, ASCENDING)], unique=True),
+            IndexModel(
+                [(_FLD_IMAGE_NAME, ASCENDING), (_FLD_IMAGE_TAG, ASCENDING)],
+                unique=True,
+                sparse=True  # tags are optional
+            ),
         ])

--- a/test/image_remote_lookup_test.py
+++ b/test/image_remote_lookup_test.py
@@ -13,6 +13,21 @@ from cdmtaskservice.image_remote_lookup import (
 from test_common import config as testcfg
 from conftest import assert_exception_correct
 
+# no longer pushing to dockerhub so this shouldn't change, unlike ghcr
+_SHA_WS_DOCKER_LATEST = "sha256:8a3eaf76ce3506da4113510221218cab0867462986c61025f0b50d18b08de7b6"
+_SHA_WS_DOCkER_0_10_2 = "sha256:285b1229730192eac5b502c44bfffff98e9840057821d1a26bed47a05bc44874"
+_SHA_WS_0_14_1 = "sha256:66f6bb4a503e83867d1160f34b9b0349f54c33ca04f61ccd30ebd997976b46b3"
+_SHA_WS_0_14_2 = "sha256:e3d1db28c88f08cfbe632f0184da0a03e2016d8d11f1e800ea0ec98c6ccb2082"
+_SHA_WS_0_15_0 = "sha256:7e41821daf50abcd511654ddd9bdf66ed6374a30a1d62547631e79dcbe4ad92e"
+
+
+def test_NormedImageName():
+    nim = NormedImageName(name="foo", tag="bar", digest="sha256:stuff")
+    assert nim.name == "foo"
+    assert nim.tag == "bar"
+    assert nim.digest == "sha256:stuff"
+    assert nim.name_with_digest == "foo@sha256:stuff"
+
 
 @pytest.mark.asyncio
 async def test_create_fail_invalid_crane_path():
@@ -32,41 +47,36 @@ async def test_create_fail_invalid_crane_path():
 
 @pytest.mark.asyncio
 async def test_narmalize_image_name():
-    ws0_15_0_sha = "sha256:7e41821daf50abcd511654ddd9bdf66ed6374a30a1d62547631e79dcbe4ad92e"
-    ws0_10_2_sha = "sha256:285b1229730192eac5b502c44bfffff98e9840057821d1a26bed47a05bc44874"
-    # no longer pushing to dockerhub so this shouldn't change, unlike ghcr
-    ws_docker_latest = "sha256:8a3eaf76ce3506da4113510221218cab0867462986c61025f0b50d18b08de7b6"
     testset = {
         "ghcr.io/kbase/workspace_deluxe:0.15.0":
             NormedImageName(
-                normedname="ghcr.io/kbase/workspace_deluxe@" + ws0_15_0_sha, tag="0.15.0"
+                name="ghcr.io/kbase/workspace_deluxe", digest=_SHA_WS_0_15_0, tag="0.15.0"
             ),
-        "ghcr.io/kbase/workspace_deluxe@" + ws0_15_0_sha:
+        "ghcr.io/kbase/workspace_deluxe@" + _SHA_WS_0_15_0:
+            NormedImageName(name="ghcr.io/kbase/workspace_deluxe", digest=_SHA_WS_0_15_0),
+        "ghcr.io/kbase/workspace_deluxe:0.15.0@" + _SHA_WS_0_15_0:
             NormedImageName(
-                normedname="ghcr.io/kbase/workspace_deluxe@" + ws0_15_0_sha,
-                olddigest=ws0_15_0_sha
-            ),
-        "ghcr.io/kbase/workspace_deluxe:0.15.0@" + ws0_15_0_sha:
-            NormedImageName(
-                normedname="ghcr.io/kbase/workspace_deluxe@" + ws0_15_0_sha,
+                name="ghcr.io/kbase/workspace_deluxe",
+                digest=_SHA_WS_0_15_0,
                 tag="0.15.0",
-                olddigest=ws0_15_0_sha
             ),
         # this tests all non alphanum chars other than @ and uppercase
         "kbase/workspace_deluxe:0.10.2-hotfix":
             NormedImageName(
-                normedname="docker.io/kbase/workspace_deluxe@" + ws0_10_2_sha, tag="0.10.2-hotfix"
+                name="docker.io/kbase/workspace_deluxe",
+                digest=_SHA_WS_DOCkER_0_10_2,
+                tag="0.10.2-hotfix"
             ),
         "kbase/workspace_deluxe": 
-            NormedImageName(normedname="docker.io/kbase/workspace_deluxe@" + ws_docker_latest),
+            NormedImageName(name="docker.io/kbase/workspace_deluxe", digest=_SHA_WS_DOCKER_LATEST),
         "kbase/workspace_deluxe:latest":
             NormedImageName(
-                normedname="docker.io/kbase/workspace_deluxe@" + ws_docker_latest, tag="latest"
+                name="docker.io/kbase/workspace_deluxe", digest=_SHA_WS_DOCKER_LATEST, tag="latest"
             ),
         "ubuntu:noble-20240827.1":
             NormedImageName(
-                normedname="docker.io/library/ubuntu@sha256:"
-                    +"dfc10878be8d8fc9c61cbff33166cb1d1fe44391539243703c72766894fa834a",
+                name="docker.io/library/ubuntu",
+                digest="sha256:dfc10878be8d8fc9c61cbff33166cb1d1fe44391539243703c72766894fa834a",
                 tag="noble-20240827.1"
             ),
     }
@@ -78,8 +88,13 @@ async def test_narmalize_image_name():
 
 @pytest.mark.asyncio
 async def test_get_entrypoint_from_name():
+    ws_entrypoint = ["/kb/deployment/bin/dockerize"]
     testset = {
-        "ghcr.io/kbase/workspace_deluxe:0.15.0": ["/kb/deployment/bin/dockerize"],
+        "kbase/workspace_deluxe": ws_entrypoint,
+        "kbase/workspace_deluxe:latest": ws_entrypoint,
+        "ghcr.io/kbase/workspace_deluxe:0.15.0": ws_entrypoint,
+        "ghcr.io/kbase/workspace_deluxe@" + _SHA_WS_0_15_0: ws_entrypoint,
+        "ghcr.io/kbase/workspace_deluxe:0.15.0@" + _SHA_WS_0_15_0: ws_entrypoint,
         "ghcr.io/kbaseapps/kb_quast:pr-36": ["./scripts/entrypoint.sh"],
         "library/ubuntu:24.04": None,
         "ghcr.io/kbase/collections:checkm2_0.1.6":
@@ -136,6 +151,48 @@ async def test_image_methods_fail():
     for k, v in testset.items():
         await _image_methods_fail(dii, k, v)
 
+
+@pytest.mark.asyncio
+async def test_normalize_image_name_fail():
+    """Tests failure modes that only occur with this method rather than all methods. """ 
+    testset = {
+        "kbase/workspace_deluxe@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            "Failed to access information for image docker.io/kbase/workspace_deluxe@"
+            + f"{_SHA_WS_0_14_2}. Image was not found on the host"),
+        "kbase/workspace_deluxe:latest@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            "The digest for image docker.io/kbase/workspace_deluxe:latest, "
+            + f"{_SHA_WS_DOCKER_LATEST}, does not equal the expected digest, {_SHA_WS_0_14_2}"),
+        "ghcr.io/kbase/workspace_deluxe:0.14.3@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            "Failed to access information for image ghcr.io/kbase/workspace_deluxe:0.14.3. "
+            + "Image was not found on the host"),
+        "ghcr.io/kbase/workspace_deluxe:0.14.1@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            f"The digest for image ghcr.io/kbase/workspace_deluxe:0.14.1, {_SHA_WS_0_14_1}, "
+            + f"does not equal the expected digest, {_SHA_WS_0_14_2}"),
+    }
+    dii = await DockerImageInfo.create(testcfg.CRANE_EXE_PATH)
+    for k, v in testset.items():
+        with pytest.raises(ImageInfoError) as got:
+            await dii.normalize_image_name(k)
+        assert_exception_correct(got.value, v)
+
+
+
+@pytest.mark.asyncio
+async def test_get_entrypoint_from_name_fail():
+    """Tests failure modes that only occur with this method rather than all methods. """
+    testset = {
+        "kbase/workspace_deluxe@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            "Failed to access information for image docker.io/kbase/workspace_deluxe@"
+            + f"{_SHA_WS_0_14_2}. Manifest is unknown"),
+        "ghcr.io/kbase/workspace_deluxe:0.14.3@" + _SHA_WS_0_14_2: ImageInfoFetchError(
+            "Failed to access information for image ghcr.io/kbase/workspace_deluxe:0.14.3. "
+            + "Manifest is unknown"),
+    }
+    dii = await DockerImageInfo.create(testcfg.CRANE_EXE_PATH)
+    for k, v in testset.items():
+        with pytest.raises(ImageInfoError) as got:
+            await dii.get_entrypoint_from_name(k)
+        assert_exception_correct(got.value, v)
 
 @pytest.mark.asyncio
 async def test_image_methods_fail_bad_chars():


### PR DESCRIPTION
crane or the server seems to ignore the tag if a sha is provided, which means non-existent tags could be recorded in the CTS.

Also separate out the digest and image name throughout the service for easier parsing and make the tag index sparse in Mongo since it's optional.