### PR TITLE
Download files to NERSC on job submission

### DIFF
--- a/cdmtaskservice/callback_url_paths.py
+++ b/cdmtaskservice/callback_url_paths.py
@@ -1,0 +1,20 @@
+"""
+A module for determining paths for callback URLs for the service.
+"""
+
+
+_CALLBACK = "callback"
+_DOWNLOAD_COMPLETE = "download"
+
+
+def get_download_complete_callback(root_url: str = None, job_id: str = None):
+    """
+    Get a url or path for a service callback to communicate that a download is complete.
+    
+    root_url - prepend the path with the given root url.
+    job_id - suffix the path with a job ID.
+    """
+    cb = [root_url] if root_url else []
+    cb += [_CALLBACK, _DOWNLOAD_COMPLETE]
+    cb += [job_id] if job_id else []
+    return "/".join(cb)

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -2,10 +2,15 @@
 Manages running jobs at NERSC using the JAWS system.
 """
 
+import logging
+
+from cdmtaskservice import models
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy, require_string as _require_string
 from cdmtaskservice.job_state import JobState
 from cdmtaskservice.nersc.manager import NERSCManager
 from cdmtaskservice.s3.client import S3Client
+from cdmtaskservice.s3.paths import S3Paths
+from cdmtaskservice.callback_url_paths import get_download_complete_callback
 
 # Not sure how other flows would work and how much code they might share. For now just make
 # this work and pull it apart / refactor later.
@@ -50,3 +55,45 @@ class NERSCJAWSRunner:
         self._jtoken = _require_string(jaws_token, "jaws_token")
         self._jgroup = _require_string(jaws_group, "jaws_group")
         self._callback_root = _require_string(service_root_url, "service_root_url")
+
+    async def start_job(self, job: models.Job):
+        """
+        Start running a job. It is expected that the Job has been persisted to the data
+        storage system and is in the created state. It is further assumed that the input files
+        are of the S3File type, not bare strings.
+        """
+        if _not_falsy(job, "job").state != models.JobState.CREATED:
+            raise ValueError("job must be in the created state")
+        logr = logging.getLogger(__name__)
+        # TODO PERF this validates the file paths yet again. Maybe the way to go is just have
+        #           a validate method on S3Paths which can be called or not as needed, with
+        #           a validated state boolean
+        paths = S3Paths([p.file for p in job.job_input.input_files])
+        try:
+            # This is making an S3 call again after the call in job_submit. If that's too expensive
+            # pass in the S3meta as well
+            # TODO PERF config / set concurrency
+            # TODO NOW pass this in to avoid race conditions w/ etags
+            meta = await self._s3.get_object_meta(paths)
+            # TODO RELIABILITY config / set expiration time
+            presigned = await self._s3ext.presign_get_urls(paths)
+            callback_url = get_download_complete_callback(self._callback_root, job.id)
+            # TODO PERF config / set concurrency
+            # TODO PERF CACHING if the same files are used for a different job they're d/ld again
+            #                   Instead d/l to a shared file location by etag or something
+            #                   Need to ensure atomic writes otherwise 2 processes trying to
+            #                   d/l the same file could corrupt it
+            #                   Either make cache in JAWS staging area, in which case files
+            #                   will be deleted automatically by JAWS, or need own file deletion
+            # TODO DISKSPACE will need to clean up job downloads @ NERSC
+            # TODO LOGGING make the remote code log summary of results and upload and store
+            # TODO NOW how get remote paths at next step? 
+            # TODO NOW store task IDs
+            task_id = await self._nman.download_s3_files(
+                job.id, meta, presigned, callback_url, insecure_ssl=self._s3insecure
+            )
+        except Exception as e:
+            # TODO LOGGING figure out how logging it going to work etc.
+            logr.exception(f"Error starting download for job {job.id}")
+            # TODO IMPORTANT ERRORHANDLING update job state to ERROR w/ message and don't raise
+            raise e

--- a/cdmtaskservice/nersc/remote.py
+++ b/cdmtaskservice/nersc/remote.py
@@ -30,13 +30,16 @@ def process_data_transfer_manifest(manifest_file_path: str, callback_url: str):
     # TODO TEST add tests for this and its dependency functions, including logging
     # Potential performance improvement could include a shared cross job cache for files
     #    only useful if jobs are reusing the same files, whcih seems def possible
+    # TODO LOGGINNG logging doesn't work
+    # TODO IMPORTANT ERRORHANDLING write an output file that can be read by the CTS
+    #                sfapi tasks only last for 10 minutes after completions
     log = logging.getLogger(__name__)
     try:
         with open(manifest_file_path) as f:
             manifest = json.load(f)
         asyncio.run(s3_pdtm(manifest["file-transfers"]))
     finally:
-        log.info(f"pinging callback url {callback_url}")
+        log.info(f"Pinging callback url {callback_url}")
         ret = requests.get(callback_url)
         if ret.status_code < 200 or ret.status_code > 299:
             log.error(ret.text)

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -11,6 +11,11 @@ services:
       dockerfile: Dockerfile
     ports:
       - 5000:5000
+    #extra_hosts:
+      # TODO DOCKERUPGRADE after upgrading docker switch from host mode
+      # See https://stackoverflow.com/a/43541732/643675
+      #- "host.docker.internal:host-gateway"
+    network_mode: host
     depends_on:
       - mongodb
       - minio
@@ -25,12 +30,19 @@ services:
       # Don't commit your token to github please
       - KBCTS_JAWS_TOKEN=tokengoeshere
       - KBCTS_JAWS_GROUP=kbase
-      - KBCTS_S3_URL=http://minio:9000
+      # TODO DOCKERUPGRADE after upgrading docker switch to host.docker.internal
+      - KBCTS_S3_URL=http://localhost:9002
+      #- KBCTS_S3_URL=http://host.docker.internal:9002
+      # local Minio, only useful if not running jobs on NERSC
+      #- KBCTS_S3_URL=http://minio:9000
       - KBCTS_S3_EXTERNAL_URL=https://ci.berkeley.kbase.us:9000
       - KBCTS_VERIFY_S3_EXTERNAL_URL=false
       - KBCTS_S3_ACCESS_KEY=miniouser
       - KBCTS_S3_ACCESS_SECRET=miniopassword
-      - KBCTS_MONGO_HOST=mongodb://mongodb:27017
+      - KBCTS_S3_ALLOW_INSECURE=true
+      # TODO DOCKERUPGRADE switch back when host mode no longer needed
+      - KBCTS_MONGO_HOST=mongodb://localhost:27017
+      #- KBCTS_MONGO_HOST=mongodb://mongodb:27017
       - KBCTS_MONGO_DB=cdmtaskservice
       # TODO MONGOAUTH need to add a user to the cmdtaskservice db before this works out
       #                of the box.

--- a/test/callback_url_paths_test.py
+++ b/test/callback_url_paths_test.py
@@ -1,0 +1,7 @@
+# TODO TEST add tests
+
+from cdmtaskservice import callback_url_paths  # @UnusedImport
+
+
+def test_noop():
+    pass


### PR DESCRIPTION
Job submission code kicks off a coroutine that runs a task at NERSC to do the download. This allows the submission code to return to the user as soon as sanity checks are complete and state is saved.

Had to switch the download target from the DTNs to the login node since for some reason `$SCRATCH` and `module` aren't available.

Also had to switch the docker compose to host network mode so that the service could access the ssh tunnel to Minio.