### PR TITLE
Fix potential race condition w/ s3 etags

### DIFF
--- a/cdmtaskservice/job_submit.py
+++ b/cdmtaskservice/job_submit.py
@@ -88,7 +88,8 @@ class JobSubmit:
         )
         # TDDO JOBSUBMIT if reference data is required, is it staged?
         await self._mongo.save_job(job)
-        await self._coman.run_coroutine(self._runners[job.job_input.cluster].start_job(job))
+        # Pass in the meta to avoid potential race conditions w/ etag changes
+        await self._coman.run_coroutine(self._runners[job.job_input.cluster].start_job(job, meta))
         return job_id
 
 


### PR DESCRIPTION
Unlikely, but possible that a file could be overwritten between the 1st and 2nd meta fetch. Therefore the change wouldn't be detected and the job record etag wouldn't match the etag of the file that was actually processed