### PR TITLE
Remove scratch sharing and JAWS --quiet flag

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -74,7 +74,6 @@ async def build_app(
     nerscman = await NERSCManager.create(
         sfapi_client.get_client,
         Path(cfg.nersc_remote_code_dir) / VERSION,
-        cfg.nersc_file_group,
         cfg.jaws_token,
         cfg.jaws_group,
     )

--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -32,7 +32,6 @@ class CDMTaskServiceConfig:
         as the remaining lines.
     sfapi_user: str - the user name of the user accociated with the credentials.
     nersc_remote_code_dir: str - the location at NERSC to upload remote code.
-    nersc_file_group: str - the NERSC group with which downloaded files must be shared. 
     jaws_token: str - the JAWS token used to run jobs.
     jaws_group: str - the JAWS group used to run jobs.
     s3_url: str - the URL of the S3 instance to use for data storage.
@@ -79,7 +78,6 @@ class CDMTaskServiceConfig:
         self.sfapi_cred_path = _get_string_required(config, _SEC_NERSC, "sfapi_cred_path")
         self.sfapi_user = _get_string_required(config, _SEC_NERSC, "sfapi_user")
         self.nersc_remote_code_dir = _get_string_required(config, _SEC_NERSC, "remote_code_dir")
-        self.nersc_file_group = _get_string_required(config, _SEC_NERSC, "file_group")
         self.jaws_token = _get_string_required(config, _SEC_JAWS, "token")
         self.jaws_group = _get_string_required(config, _SEC_JAWS, "group")
         self.s3_url = _get_string_required(config, _SEC_S3, "url")
@@ -118,7 +116,6 @@ class CDMTaskServiceConfig:
             f"NERSC client credential path: {self.sfapi_cred_path}",
             f"NERSC client user: {self.sfapi_user}",
             f"NERSC remote code dir: {self.nersc_remote_code_dir}",
-            f"NERSC file group: {self.nersc_file_group}",
             "JAWS token: REDACTED FOR THE NATIONAL SECURITY OF GONDWANALAND",
             f"JAWS group: {self.jaws_group}",
             f"S3 URL: {self.s3_url}",

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -30,17 +30,12 @@ sfapi_cred_path = "{{ KBCTS_SFAPI_CRED_PATH or "" }}"
 # The user associated with the client credentials. The user's default shell must be bash.
 # If the client credentials are updated but the user doesn't match they will not be accepted.
 # It is advised to create a collaboration user for the service.
-# The user's scratch directory will be shared with the file_group below.
 # The jaws.conf file will be created in the user's home directory on service startup, overwriting
 # any extant file.
 sfapi_user = "{{ KBCTS_SFAPI_USER or "" }}"
 
 # Where to store remote code at NERSC. This must be writeable by the service account.
 remote_code_dir = "{{ KBCTS_NERSC_REMOTE_CODE_DIR or "/global/cfs/cdirs/kbase/cdm_task_service" }}"
-
-# The group with which to share downloaded data files. The JAWS user that will run jobs must
-# be in the same group so it can read the input files.
-file_group = "{{ KBCTS_NERSC_FILE_GROUP or "kbase" }}"
 
 [JAWS]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -27,7 +27,6 @@ services:
       - KBCTS_SFAPI_CRED_PATH=/creds/sfapi_creds
       - KBCTS_SFAPI_USER=cdm_ts
       - KBCTS_NERSC_REMOTE_CODE_DIR=/global/cfs/cdirs/kbase/cdm_task_service
-      - KBCTS_NERSC_FILE_GROUP=kbase
       # Don't commit your token to github please
       - KBCTS_JAWS_TOKEN=tokengoeshere
       - KBCTS_JAWS_GROUP=kbase


### PR DESCRIPTION
Was overzealous here, didn't consider that the jaws client does the copying and it's running as the service, so no sharing needed. Also the jaws `--quiet` flag only affect stderr, so it's fine to leave it out