### PR TITLE
Add general error handling to the nersc jaws flow

### DIFF
--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -59,7 +59,7 @@ class JobState:
         image = await self._mongo.get_image(parsedimage.name, digest=parsedimage.digest, tag=tag)
         await self._s3.has_bucket(job_input.output_dir.split("/", 1)[0])
         paths = [f.file if isinstance(f, models.S3File) else f for f in job_input.input_files]
-        # TODO PERF may wan to make concurrency configurable here
+        # TODO PERF may want to make concurrency configurable here
         # TODO PERF this checks the file path syntax again, consider some way to avoid
         meta = await self._s3.get_object_meta(S3Paths(paths))
         new_input = []

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -46,6 +46,9 @@ FLD_NERSC_DETAILS_UL_TASK_ID = "upload_task_id"
 FLD_JOB_JAWS_DETAILS = "jaws_details"
 FLD_JAWS_DETAILS_RUN_ID = "run_id"
 FLD_JOB_OUTPUTS = "outputs"
+FLD_JOB_ERROR = "error"
+FLD_JOB_ADMIN_ERROR = "admin_error"
+FLD_JOB_TRACEBACK = "traceback"
 
 
 # https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
@@ -671,7 +674,7 @@ class Image(BaseModel):
 
 
 class S3FileOutput(BaseModel):
-    """ Am output file in an S3 instance. """
+    """ An output file in an S3 instance. """
 
     # no validators since this is an outgoing data structure only
     file: Annotated[str, Field(
@@ -706,13 +709,17 @@ class Job(BaseModel):
         description="A list of tuples of (job_state, time_job_state_entered)."
     )]
     outputs: list[S3FileOutput] | None = None
-    # TODO ERRORHANDLING add error field and class
+    error: Annotated[str | None, Field(
+        example="The front fell off",
+        description="A description of the error that occurred."
+    )] = None
 
 
 class NERSCDetails(BaseModel):
     """
     Details about a job run at NERSC.
     """
+    # TODO NERSC more details, logs, etc.
     download_task_id: Annotated[list[str], Field(
         description="IDs for a tasks run via the NERSC SFAPI to download files from an S3 "
             + "instance to NERSC. Note that task details only persist for ~10 minutes past "
@@ -739,5 +746,10 @@ class AdminJobDetails(Job):
     Information about a job with added details of interest to service administrators.
     """
     nersc_details: NERSCDetails | None = None
-    # TODO NERSC more details, logs, etc.
     jaws_details: JAWSDetails | None = None
+    admin_error: Annotated[str | None, Field(
+        example="The back fell off",
+        description="A description of the error that occurred oriented towards service "
+            + "admins, potentially including more details."
+    )] = None
+    traceback: Annotated[str | None, Field(description="The error's traceback.")] = None

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -41,7 +41,7 @@ from cdmtaskservice.s3.client import S3ObjectMeta, S3PresignedPost
 # TODO CLEANUP clean up old code versions @NERSC somehow. Not particularly important
 
 _DT_TARGET = Machine.dtns
-# TDOO NERSCUIPDATE delete the following line when DTN downloads work normally.
+# TODO NERSCUPDATE delete the following line when DTN downloads work normally.
 #       See https://nersc.servicenowservices.com/sp?sys_id=ad33e85f1b5a5610ac81a820f54bcba0&view=sp&id=ticket&table=incident
 _DT_WORKAROUND = "source /etc/bashrc"
 

--- a/cdmtaskservice/s3/paths.py
+++ b/cdmtaskservice/s3/paths.py
@@ -55,7 +55,7 @@ class S3Paths:
             yield parts
 
 
-# TDOO TEST add tests for public method
+# TODO TEST add tests for public method
 # TODO S3PATHS allow accepting model paths to the constructor here so they aren't validated 2x 
 def validate_path(path: str, index: int = None) -> str:
     """
@@ -94,7 +94,7 @@ def validate_path(path: str, index: int = None) -> str:
     return f"{bucket}/{key}"
 
 
-# TDOO TEST add tests for public method
+# TODO TEST add tests for public method
 def validate_bucket_name(bucket_name: str, index: int = None):
     """
     Validate an S3 bucket name.

--- a/cdmtaskservice/s3/remote.py
+++ b/cdmtaskservice/s3/remote.py
@@ -194,7 +194,7 @@ async def upload_presigned_url(
                                ) from e
 
 
-# TDOO CODE could merge this with the above method and add a toggle... eh
+# TODO CODE could merge this with the above method and add a toggle... eh
 async def upload_presigned_url_with_crc32(
     session: aiohttp.ClientSession,
     url: str,

--- a/test/nersc/nersc_remote_test.py
+++ b/test/nersc/nersc_remote_test.py
@@ -1,4 +1,4 @@
-# TDOO TEST add tests
+# TODO TEST add tests
 
 from cdmtaskservice.nersc import remote  # @UnusedImport
 


### PR DESCRIPTION
When in a non-awaited coroutine, catch any errors and update the job, since otherwise errors just get logged by the coroutine manager and forgetten about

Also fix some spelling errors