### PR TITLE
Ensure JAWS user and NERSC user are the same

### DIFF
--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -7,6 +7,7 @@ import tomllib
 from typing import BinaryIO, TextIO
 
 _SEC_AUTH = "Authentication"
+_SEC_NERSC_JAWS = "NERSC_JAWS"
 _SEC_NERSC = "NERSC"
 _SEC_JAWS = "JAWS"
 _SEC_S3 = "S3"
@@ -27,10 +28,11 @@ class CDMTaskServiceConfig:
         a full admin for the CDM task service
     kbase_staff_role: str - the Auth2 custom role indicating a user is a member of KBase staff.
     has_nersc_account_role: str - the Auth2 custom role indicating a user has a NERSC account.
+    nersc_jaws_user: str - the user name of the user associated with the NERSC and JAWS
+        credentials.
     sfapi_cred_path: str - the path to a NERSC Superfacility API credential file. The file is
         expected to have the client ID as the first line and the client private key in PEM format
         as the remaining lines.
-    sfapi_user: str - the user name of the user accociated with the credentials.
     nersc_remote_code_dir: str - the location at NERSC to upload remote code.
     jaws_url: str - the URL of the JAWS Central service.
     jaws_token: str - the JAWS token used to run jobs.
@@ -76,8 +78,8 @@ class CDMTaskServiceConfig:
         self.has_nersc_account_role = _get_string_required(
             config, _SEC_AUTH, "has_nersc_account_role"
         )
+        self.nersc_jaws_user = _get_string_required(config, _SEC_NERSC_JAWS, "user")
         self.sfapi_cred_path = _get_string_required(config, _SEC_NERSC, "sfapi_cred_path")
-        self.sfapi_user = _get_string_required(config, _SEC_NERSC, "sfapi_user")
         self.nersc_remote_code_dir = _get_string_required(config, _SEC_NERSC, "remote_code_dir")
         self.jaws_url = _get_string_required(config, _SEC_JAWS, "url")
         self.jaws_token = _get_string_required(config, _SEC_JAWS, "token")
@@ -115,8 +117,8 @@ class CDMTaskServiceConfig:
             f"Authentication full admin roles: {self.auth_full_admin_roles}",
             f"Authentication KBase staff role: {self.kbase_staff_role}",
             f"Authentication has NERSC account role: {self.has_nersc_account_role}",
+            f"NERSC / JAWS user: {self.nersc_jaws_user}",
             f"NERSC client credential path: {self.sfapi_cred_path}",
-            f"NERSC client user: {self.sfapi_user}",
             f"NERSC remote code dir: {self.nersc_remote_code_dir}",
             f"JAWS Central URL: {self.jaws_url}",
             "JAWS token: REDACTED FOR THE NATIONAL SECURITY OF GONDWANALAND",

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -15,6 +15,16 @@ kbase_staff_role = "{{ KBCTS_KBASE_STAFF_ROLE or "KBASE_STAFF"}}"
 # This role is required to use the CDM task service.
 has_nersc_account_role = "{{ KBCTS_HAS_NERSC_ACCOUNT_ROLE or "HAS_NERSC_ACCOUNT"}}"
 
+[NERSC_JAWS]
+
+# The username of the NERSC user that will interact with the Superfacility API and JAWS.
+# This user must match the SFAPI credentials in the NERSC block below and the token in the JAWS
+# block.
+# The NERSC user's default shell must be bash.
+# If the client credentials are updated but the user doesn't match they will not be accepted.
+# It is advised to create a collaboration user for the service.
+user = "{{ KBCTS_NERSC_JAWS_USER or "" }}"
+
 [NERSC]
 
 # The path to a NERSC Superfacility API (SFAPI) credential file. The file is expected to have
@@ -26,13 +36,6 @@ has_nersc_account_role = "{{ KBCTS_HAS_NERSC_ACCOUNT_ROLE or "HAS_NERSC_ACCOUNT"
 # been approved for the user, the service periodically checks for updates to this file and
 # reloads the contents if changed.
 sfapi_cred_path = "{{ KBCTS_SFAPI_CRED_PATH or "" }}"
-
-# The user associated with the client credentials. The user's default shell must be bash.
-# If the client credentials are updated but the user doesn't match they will not be accepted.
-# It is advised to create a collaboration user for the service.
-# The jaws.conf file will be created in the user's home directory on service startup, overwriting
-# any extant file.
-sfapi_user = "{{ KBCTS_SFAPI_USER or "" }}"
 
 # Where to store remote code at NERSC. This must be writeable by the service account.
 remote_code_dir = "{{ KBCTS_NERSC_REMOTE_CODE_DIR or "/global/cfs/cdirs/kbase/cdm_task_service" }}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,8 +24,8 @@ services:
       - KBCTS_KBASE_AUTH2_ADMIN_ROLES=CDM_TASK_SERVICE_ADMIN
       - KBCTS_KBASE_STAFF_ROLE=KBASE_STAFF
       - KBCTS_HAS_NERSC_ACCOUNT_ROLE=HAS_NERSC_ACCOUNT
+      - KBCTS_NERSC_JAWS_USER=cdm_ts
       - KBCTS_SFAPI_CRED_PATH=/creds/sfapi_creds
-      - KBCTS_SFAPI_USER=cdm_ts
       - KBCTS_NERSC_REMOTE_CODE_DIR=/global/cfs/cdirs/kbase/cdm_task_service
       - KBCTS_JAWS_URL=https://jaws-api.jgi.doe.gov/api/v2
       # Don't commit your token to github please


### PR DESCRIPTION
This is important since the SFAPI / NERSC user will be used to delete JAWS results chmoded to the JAWS user