### PR TITLE
Rename operations that aren't S3 specific

### DIFF
--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -21,7 +21,7 @@ from cdmtaskservice.jaws import client as jaws_client
 from cdmtaskservice.jaws.poller import poll as poll_jaws
 from cdmtaskservice.mongo import MongoDAO
 from cdmtaskservice.nersc.manager import NERSCManager
-from cdmtaskservice.s3.client import S3Client, S3ObjectMeta, S3PresignedPost
+from cdmtaskservice.s3.client import S3Client, S3ObjectMeta, PresignedPost
 from cdmtaskservice.s3.paths import S3Paths
 
 # Not sure how other flows would work and how much code they might share. For now just make
@@ -212,7 +212,7 @@ class NERSCJAWSRunner:
     
     async def _upload_files(self, job: models.AdminJobDetails, jaws_info: dict[str, Any]):
 
-        async def presign(output_files: list[Path]) -> list[S3PresignedPost]:
+        async def presign(output_files: list[Path]) -> list[PresignedPost]:
             root = job.job_input.output_dir
             # TODO PERF this parses the paths yet again
             # TODO RELIABILITY config / set expiration time
@@ -250,7 +250,7 @@ class NERSCJAWSRunner:
         """
         if _not_falsy(job, "job").state != models.JobState.UPLOAD_SUBMITTED:
             raise InvalidJobStateError("Job must be in the upload submitted state")
-        err = await self._nman.get_s3_upload_result(job)
+        err = await self._nman.get_presigned_upload_result(job)
         if err:
             await self._handle_transfer_exception(job, "Upload", err)
         await self._coman.run_coroutine(self._upload_complete(job))

--- a/cdmtaskservice/s3/client.py
+++ b/cdmtaskservice/s3/client.py
@@ -62,11 +62,14 @@ class S3ObjectMeta:
         return self.part_size or self.size
 
 
-class S3PresignedPost:
+# This isn't technically S3 specific but leave it here since it's the only place it gets
+# produced
+class PresignedPost:
     """
-    A presigned url and fields for posting data to an S3 instance.
+    A presigned url and fields for posting data.
     
-    See https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html#generating-a-presigned-url-to-upload-a-file
+    For an S3 example, see
+    https://boto3.amazonaws.com/v1/documentation/api/latest/guide/s3-presigned-urls.html#generating-a-presigned-url-to-upload-a-file
     """
     
     __slots__ = ["url", "fields"]
@@ -81,7 +84,7 @@ class S3PresignedPost:
         # again input checking is a little pointless here
         self.url = url
         self.fields = fields
-    
+
 
 class S3Client:
     """
@@ -286,7 +289,7 @@ class S3Client:
         self,
         paths: S3Paths,
         expiration_sec: int = 3600
-    ) -> list[S3PresignedPost]:
+    ) -> list[PresignedPost]:
         """
         Presign urls to allow posting to s3 paths. Does not check for overwrites.
         
@@ -300,7 +303,7 @@ class S3Client:
             for buk, key in paths.split_paths():
                 ret = await client.generate_presigned_post(
                     Bucket=buk, Key=key, ExpiresIn=expiration_sec)
-                results.append(S3PresignedPost(ret["url"], ret["fields"]))
+                results.append(PresignedPost(ret["url"], ret["fields"]))
         return results
 
 


### PR DESCRIPTION
File download is still S3 specific since it's dealing with S3 paths and etags