### PR TITLE
Add cpu hours limit on job submission

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -108,7 +108,7 @@ async def build_app(
             flowman.register_flow(models.Cluster.PERLMUTTER_JAWS, nerscjawsflow)
         imginfo = await DockerImageInfo.create(Path(cfg.crane_path).expanduser().absolute())
         images = Images(mongodao, imginfo)
-        job_state = JobState(mongodao, s3, images, coman, flowman, logbuk)
+        job_state = JobState(mongodao, s3, images, coman, flowman, logbuk, cfg.job_max_cpu_hours)
         app.state._mongo = mongocli
         app.state._coroman = coman
         app.state._jaws_cli = jaws_client

--- a/cdmtaskservice/arg_checkers.py
+++ b/cdmtaskservice/arg_checkers.py
@@ -33,19 +33,16 @@ def require_string(string: str, name: str):
     return string.strip()
 
 
-def check_int(num: int, name: str, minimum: int = 1):
+def check_num(num: int | float, name: str, minimum: int | float = 1) -> int | float:
     """
-    Check an integer argument is not None and is greater than some value.
+    Check an integer or float argument is not None and is greater than some value.
     
-    num - the number to check. Must None or an integer.
+    num - the number to check. Must None, a float, or an integer.
     name - the name of the argument to use in exceptions.
-    minimum - the minimum allowed value of the integer.
+    minimum - the minimum allowed value of the number.
     
-    returns the integer.
+    returns the number.
     """
-    # Converted this to float as well but realized we just want ints in all the current use
-    # cases. Leave it as it for now. Not typechecking since we assume the programmer is reading
-    # the type hints
     if num is None:
         raise ValueError(f"{name} is required")
     if num < minimum:

--- a/cdmtaskservice/error_mapping.py
+++ b/cdmtaskservice/error_mapping.py
@@ -6,7 +6,11 @@ from fastapi import status
 from typing import NamedTuple
 
 from cdmtaskservice.errors import ErrorType
-from cdmtaskservice.exceptions import UnauthorizedError, InvalidJobStateError
+from cdmtaskservice.exceptions import (
+    IllegalParameterError,
+    InvalidJobStateError,
+    UnauthorizedError,
+)
 from cdmtaskservice.http_bearer import MissingTokenError, InvalidAuthHeaderError
 from cdmtaskservice.images import NoEntrypointError
 from cdmtaskservice.image_remote_lookup import ImageNameParseError, ImageInfoFetchError
@@ -64,6 +68,7 @@ _ERR_MAP = {
     NoSuchJobError: ErrorMapping(ErrorType.NO_SUCH_JOB, _H404),
     InvalidJobStateError: ErrorMapping(ErrorType.INVALID_JOB_STATE, _H400),
     InactiveJobFlowError: ErrorMapping(ErrorType.JOB_FLOW_INACTIVE, _H400),
+    IllegalParameterError: ErrorMapping(ErrorType.ILLEGAL_PARAMETER, _H400),
 }
 
 

--- a/cdmtaskservice/exceptions.py
+++ b/cdmtaskservice/exceptions.py
@@ -7,5 +7,9 @@ class UnauthorizedError(Exception):
     """ An exception thrown when a user attempts a forbidden action. """
 
 
+class IllegalParameterError(Exception):
+    """ An exception thrown when an input parameter is illegal. """
+
+
 class InvalidJobStateError(Exception):
     """ An exception thrown when a job is in an invalid state to perform an operation. """

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -4,7 +4,6 @@ Pydantic models for the CTS.
 
 import datetime
 from enum import Enum
-import math
 from pathlib import Path
 from pydantic import (
     BaseModel,
@@ -15,7 +14,7 @@ from pydantic import (
     field_validator,
     model_validator,
 )
-from typing import Annotated, Self, NamedTuple
+from typing import Annotated, Self
 
 from cdmtaskservice.arg_checkers import contains_control_characters
 from cdmtaskservice.s3.paths import validate_path, validate_bucket_name, S3PathSyntaxError
@@ -616,6 +615,13 @@ class JobInput(BaseModel):
             files.append(infiles[:fcount])
             infiles = infiles[fcount:]
         return files
+    
+    def get_total_compute_time_sec(self) -> float:
+        """
+        Return the total compute time as seconds for the job, calculated as
+        cpus * containers * runtime.
+        """ 
+        return self.cpus * self.num_containers * self.runtime.total_seconds()
 
 
 class JobState(str, Enum):

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -23,7 +23,7 @@ from cdmtaskservice import models
 from cdmtaskservice.arg_checkers import (
     not_falsy as _not_falsy,
     require_string as _require_string,
-    check_int as _check_int,
+    check_num as _check_num,
 )
 from cdmtaskservice.jaws import (
     wdl,
@@ -466,7 +466,7 @@ class NERSCManager:
     def _base_manifest(self, op: str, concurrency: int, insecure_ssl: bool):
         return {
             "op": op,
-            "concurrency": _check_int(concurrency, "concurrency"),
+            "concurrency": _check_num(concurrency, "concurrency"),
             "insecure-ssl": insecure_ssl,
             "min-timeout-sec": _MIN_TIMEOUT_SEC,
             "sec-per-GB": _SEC_PER_GB,
@@ -524,7 +524,7 @@ class NERSCManager:
         job - the job to process
         file_download_concurrency - the number of files at one time to download to NERSC.
         """
-        _check_int(file_download_concurrency, "file_download_concurrency")
+        _check_num(file_download_concurrency, "file_download_concurrency")
         if not _not_falsy(job, "job").job_input.inputs_are_S3File():
             raise ValueError("Job files must be S3File objects")
         cli = self._client_provider()
@@ -628,7 +628,7 @@ class NERSCManager:
         _not_falsy(job, "job")
         _not_falsy(files_to_urls, "files_to_urls")
         cburl = _require_string(callback_url, "callback_url")
-        _check_int(concurrency, "concurrency")
+        _check_num(concurrency, "concurrency")
         outfilepath = Path(
             _require_string(jaws_output_dir, "jaws_output_dir")) / jaws_output.OUTPUTS_JSON_FILE
         cli = self._client_provider()
@@ -689,7 +689,7 @@ class NERSCManager:
         _not_falsy(job, "job")
         _not_falsy(files_to_urls, "files_to_urls")
         cburl = _require_string(callback_url, "callback_url")
-        _check_int(concurrency, "concurrency")
+        _check_num(concurrency, "concurrency")
         errfilepath = Path(
             _require_string(jaws_output_dir, "jaws_output_dir")) / ERRORS_JSON_FILE
         logs = []

--- a/cdmtaskservice/s3/client.py
+++ b/cdmtaskservice/s3/client.py
@@ -12,7 +12,11 @@ from botocore.parsers import ResponseParserError
 import logging
 from typing import Any, Self
 
-from cdmtaskservice.arg_checkers import not_falsy, check_int, require_string
+from cdmtaskservice.arg_checkers import (
+    not_falsy as _not_falsy,
+    check_num as _check_num,
+    require_string as _require_string,
+)
 from cdmtaskservice.s3.paths import S3Paths, validate_bucket_name
 
 
@@ -136,9 +140,9 @@ class S3Client:
         config: dict[str, Any],
         insecure_ssl: bool,
     ):
-        self._url = require_string(endpoint_url, "endpoint_url")
-        self._ak = require_string(access_key, "access_key")
-        self._sk = require_string(secret_key, "secret_key")
+        self._url = _require_string(endpoint_url, "endpoint_url")
+        self._ak = _require_string(access_key, "access_key")
+        self._sk = _require_string(secret_key, "secret_key")
         self._config = Config(**config) if config else None
         self._sess = get_session()
         self._insecure_ssl = insecure_ssl
@@ -236,7 +240,7 @@ class S3Client:
         bucket - the name of the bucket.
         """
         # TODO TEST add tests around invalid bucket names
-        bucket = validate_bucket_name(require_string(bucket, "bucket"))
+        bucket = validate_bucket_name(_require_string(bucket, "bucket"))
         async def write(client, buk=bucket):
             # apparently this is how you check write access to a bucket. Yuck
             await client.put_object(Bucket=buk, Key=_WRITE_TEST_FILENAME, Body="test")
@@ -252,8 +256,8 @@ class S3Client:
         paths - the paths to query
         concurrency - the number of simultaneous connections to S3
         """
-        not_falsy(paths, "paths")
-        check_int(concurrency, "concurrency")
+        _not_falsy(paths, "paths")
+        _check_num(concurrency, "concurrency")
         funcs = []
         for buk, key, path in paths.split_paths(include_full_path=True):
             async def head(client, buk=buk, key=key):  # bind the current value of the variables
@@ -284,8 +288,8 @@ class S3Client:
         paths - the paths in question.
         expiration_sec - the expiration time of the urls.
         """
-        not_falsy(paths, "paths")
-        check_int(expiration_sec, "expiration_sec")
+        _not_falsy(paths, "paths")
+        _check_num(expiration_sec, "expiration_sec")
         results = []
         async with self._client() as client:
             for buk, key in paths.split_paths():
@@ -308,8 +312,8 @@ class S3Client:
         paths - the paths in question.
         expiration_sec - the expiration time of the urls.
         """
-        not_falsy(paths, "paths")
-        check_int(expiration_sec, "expiration_sec")
+        _not_falsy(paths, "paths")
+        _check_num(expiration_sec, "expiration_sec")
         results = []
         async with self._client() as client:
             for buk, key in paths.split_paths():

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -78,13 +78,6 @@ access_secret = "{{ KBCTS_S3_ACCESS_SECRET or "" }}"
 # to Man in the Middle attacks.
 allow_insecure = "{{ KBCTS_S3_ALLOW_INSECURE or "false"}}"
 
-[Logging]
-
-# An S3 path, starting with the bucket, to where container log files should be uploaded from jobs.
-# Must contain a key. Must be writable by the service and readable by users who need to see
-# their job logs.
-container_s3_log_dir = "{{ KBCTS_CONTAINER_S3_LOG_DIR or "" }}"
-
 [MongoDB]
 
 # The connection parameters for MongoDB. User and password are optional. Retry writes
@@ -96,6 +89,19 @@ mongo_db = "{{ KBCTS_MONGO_DB or "cdmtaskservice" }}"
 mongo_user = "{{ KBCTS_MONGO_USER or "" }}"
 mongo_pwd = "{{ KBCTS_MONGO_PWD or "" }}"
 mongo_retrywrites = "{{ KBCTS_MONGO_RETRYWRITES or "" }}"
+
+[Jobs]
+
+# The maximum CPU hours allowed per job, calculated as
+# the number of CPUs * the number of containers * the time per container.
+max_cpu_hours = {{ KBCTS_JOB_MAX_CPU_HOURS or 100 }}
+
+[Logging]
+
+# An S3 path, starting with the bucket, to where container log files should be uploaded from jobs.
+# Must contain a key. Must be writable by the service and readable by users who need to see
+# their job logs.
+container_s3_log_dir = "{{ KBCTS_CONTAINER_S3_LOG_DIR or "" }}"
 
 [Images]
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -41,7 +41,6 @@ services:
       - KBCTS_S3_ACCESS_KEY=miniouser
       - KBCTS_S3_ACCESS_SECRET=miniopassword
       - KBCTS_S3_ALLOW_INSECURE=true
-      - KBCTS_CONTAINER_S3_LOG_DIR=cts-logs/container_logs
       # TODO DOCKERUPGRADE switch back when host mode no longer needed
       - KBCTS_MONGO_HOST=mongodb://localhost:27017
       #- KBCTS_MONGO_HOST=mongodb://mongodb:27017
@@ -53,6 +52,8 @@ services:
       # - KBCTS_MONGO_USER=root
       # - KBCTS_MONGO_PWD=secret
       - KBCTS_MONGO_RETRYWRITES=false
+      - KBCTS_JOB_MAX_CPU_HOURS=200
+      - KBCTS_CONTAINER_S3_LOG_DIR=cts-logs/container_logs
       - KBCTS_SERVICE_ROOT_URL=https://ci.kbase.us/services/cts
     volumes:
       - ./tmp_creds:/creds

--- a/test/arg_checkers_test.py
+++ b/test/arg_checkers_test.py
@@ -1,6 +1,6 @@
 from pytest import raises
 
-from cdmtaskservice.arg_checkers import not_falsy, require_string, check_int
+from cdmtaskservice.arg_checkers import not_falsy, require_string, check_num
 
 
 def test_not_falsy():
@@ -24,34 +24,38 @@ def test_require_string_fail():
             require_string(o, "c3po")
 
 
-def test_check_int():
-    for o in [1, 2, 5, 10, 100]:
-        assert check_int(o, "name") == o
+def test_check_num():
+    for o in [1, 2, 5, 10, 100, 1.000, 1.124153, 2.0, 5.0, 10.0, 16.165155, 100.0]:
+        assert check_num(o, "name") == o
 
 
-def test_check_int_with_min():
+def test_check_num_with_min():
     test_set = {
         100: 100,
         -98: -156161,
         894: 893,
         12161662: 12161662,
+        781441.141: 781441.141,
+        82.1516: 82.1515,
     }
     for k, v in test_set.items():
-        assert check_int(k, "name", minimum=v) == k
+        assert check_num(k, "name", minimum=v) == k
 
 
-def test_check_int_fail_None():
+def test_check_num_fail_None():
     with raises(ValueError, match="^JEJ is required"):
-        check_int(None, "JEJ")
+        check_num(None, "JEJ")
 
 
-def test_check_int_fail_minimum():
+def test_check_num_fail_minimum():
     test_set = {
         100: 101,
         -98: 156161,
         894: 895,
         12161662: 12161663,
+        0.00000099: 0.000001,
+        0.01: 10000000.01
     }
     for k, v in test_set.items():
         with raises(ValueError, match=f"^Luke must be >= {v}$"):
-            check_int(k, "Luke", minimum=v)
+            check_num(k, "Luke", minimum=v)


### PR DESCRIPTION
100 hours default is very conservative, but we can bump that up easily. By way of contrast, 1 NERSC node hour is 256 cpu hours assuming you're using the entire node