### PR TITLE
Fix callback logic attempt #2

### DIFF
--- a/cdmtaskservice/version.py
+++ b/cdmtaskservice/version.py
@@ -2,4 +2,4 @@
 The version of the KBase CDM task service software.
 '''
 
-VERSION = "0.1.0-prototype3"
+VERSION = "0.1.0-prototype4"


### PR DESCRIPTION
The prior attempt polled the NERSC task CTS server side to wait for it to finish, which it never would since the task code was waiting for the request to return, which in turn was sitting there polling, so fun with deadlocks.

Instead, use the result file written by the remote code to determine whether the data transfer is complete, which is now written out prior to the callback execution, so the task can still be running when the server decides to proceed with the data transfer completion routine.