### PR TITLE
CDM-51: Add a MVP list images endpoint

### DIFF
--- a/cdmtaskservice/images.py
+++ b/cdmtaskservice/images.py
@@ -62,6 +62,13 @@ class Images:
         Get an image.
         """
         return await self._process_image(imagename, self._mongo.get_image)
+    
+    async def get_images(self) -> list[models.Image]:
+        """
+        Get images in the service in no particluar order. Returns at most 1000 images.
+        """
+        # Pass through method
+        return await self._mongo.get_images()
 
     async def delete_image(self, imagename: str):
         """

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -113,7 +113,23 @@ class MongoDAO:
         doc, err = await self._process_image(name, digest, tag, self._col_images.find_one)
         if not doc:
             raise NoSuchImageError(f"No image {name} {err} exists in the system.")
+        return self._to_image(doc)
+    
+    def _to_image(self, doc: dict[str, Any]) -> models.Image:
         return models.Image.model_construct(**self._clean_doc(doc))
+
+    async def get_images(self) -> list[models.Image]:
+        """
+        Get images in the service in no particular order. At most 1000 images are returned.
+        """
+        # TODO FEATURE IMAGE paging - not really needed until > 1000 images
+        # TODO FEATURE IMAGE sorting and filtering - not really needed until > 1000 images
+        # For now osrting and filtering can be done client side. Seems likely we'll never have
+        # 1000 active images
+        images = []
+        async for d in self._col_images.find().limit(1000):
+            images.append(self._to_image(d))
+        return images
 
     async def delete_image(self, name: str, digest: str | None = None, tag: str | None = None):
         """

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -163,18 +163,33 @@ _ANN_IMAGE_ID = Annotated[str, FastPath(
 )]
 
 
+
+class Images(BaseModel):
+    """ The response to a request to get images in the system. """
+    data: Annotated[list[models.Image], Field(description="The images.")]
+    # if we add paging / sorting / filtering, could add more info here
+
+
+@ROUTER_IMAGES.get(
+    "/",
+    response_model=Images,
+    summary="Get images",
+    description="Get images registered in the service. At most 1000 are returned "
+        + "in no particular order.",
+)
+async def get_images(r: Request):
+    images = await app_state.get_app_state(r).images.get_images()
+    return Images(data=images)
+
+
 @ROUTER_IMAGES.get(
     "/{image_id:path}",
     response_model=models.Image,
     summary="Get an image by name",
     description="Get an image previously registered to the system by the image name. "
-        + "If a digest and tag are provided the tag is ignored."
+        + "If a digest and tag are provided the tag is ignored.",
 )
-async def get_image(
-    r: Request,
-    image_id: _ANN_IMAGE_ID,
-    # Public for now - any reason for these to be private to KBase staff?
-):
+async def get_image(r: Request, image_id: _ANN_IMAGE_ID):
     return await app_state.get_app_state(r).images.get_image(image_id)
 
 


### PR DESCRIPTION
Lists up to 1000 images, which will probably be all we need for a good long time.

If needed later we could add sorting / filtering / paging.