### PR TITLE
CDM-41: Update checksum to crc64nvme & include in presign

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       matrix:
         include:
           - python-version: "3.11"
-            minio: "2024-10-02T17-50-41Z"  # minimum supported version
+            minio: "2025-02-07T23-21-09Z"  # minimum supported version
             mc: "2024-08-13T05-33-17Z"
 
     steps:

--- a/Pipfile
+++ b/Pipfile
@@ -7,6 +7,7 @@ name = "pypi"
 # TODO Updating aiobotocore causes tests to fail, investigate
 aiobotocore = "==2.15.2"
 aiohttp = "==3.11.11"
+awscrt = "==0.23.10"
 bidict = "==0.23.1"
 cacheout = "==0.16.0"
 docker-image-py = "==0.1.13"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b61fd100cdebf01b305cd362d54490764639965c485caf039c120acb50e1a0ca"
+            "sha256": "3f12886497e2e8a75a445aeb67e257581cc3cf9f428dcd0ae0520fb91304909b"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -26,11 +26,11 @@
         },
         "aiohappyeyeballs": {
             "hashes": [
-                "sha256:5fdd7d87889c63183afc18ce9271f9b0a7d32c2303e394468dd45d514a757745",
-                "sha256:a980909d50efcd44795c4afeca523296716d50cd756ddca6af8c65b996e27de8"
+                "sha256:147ec992cf873d74f5062644332c539fcd42956dc69453fe5204195e560517e1",
+                "sha256:9b05052f9042985d32ecbe4b59a77ae19c006a78f1344d7fdad69d28ded3d0b0"
             ],
-            "markers": "python_version >= '3.8'",
-            "version": "==2.4.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.4.6"
         },
         "aiohttp": {
             "hashes": [
@@ -168,6 +168,52 @@
             ],
             "markers": "python_version >= '3.9'",
             "version": "==1.4.1"
+        },
+        "awscrt": {
+            "hashes": [
+                "sha256:009d84d7e4a0b3f411668a023a1a4fac7a99c49f9b4c3fcb8cd63696f2cc9c2f",
+                "sha256:0ed1ef4bb6f637b2f694f5406ce865b25a3d465547437a7b56f7d20aadd7c848",
+                "sha256:144b8b6ff0414d9968706e53adcd68b73609fc4c4b9ff53234abea9fbf2f42b5",
+                "sha256:19b40930f98c89590fee6bc184de5a93bb530fb14b8958f8c2a76b5e8ca567ce",
+                "sha256:23d2dfeaa0b62bb3bad569cec03a959bdbf62e9123ad1f235bfacb61d420f8d0",
+                "sha256:2d494ce3bd38d5936f52c1fb0118150979398e59da02c9283272a7bd12be4ab9",
+                "sha256:30286b70ef6522e56893058c787397a17dfd52391b04d8824dbcc0031d0cf8cb",
+                "sha256:3394be3eb699099a6bcd7d8a72c0310f5572e18d88b303569256730be8878f0e",
+                "sha256:40510a342c03f27e82310e0e6f1ff0bdc5d5f69543122aacf642729eb96b7f7c",
+                "sha256:4b8a0cf23dc7207d8b5642752a7e029ed20e73ef4c1ed4558b186202de13fa9d",
+                "sha256:5af570e9cd4311764cba292deece0674530c4cc84cb1ebaddf7d3c9127e9ba7d",
+                "sha256:61134caf33e015bd11313d1ad2545b7b386b6b4365005d210f8d83a2459418c8",
+                "sha256:69831cd707460a836cff0cadd3a72f37c7733644c680e0f2109b9172b7a8a1f7",
+                "sha256:6be2e6acca683960174422a4714972cb58803e00dc9cd06de9a7b9fe94fbb28f",
+                "sha256:6d1f66aeddcc50089296d0af57686a9af856920669fe3c0ee393b696ad9f044d",
+                "sha256:6fc647622533ad3fcbfe7a0e7238efce26fee105d8f37980a05e7d54550253d3",
+                "sha256:778f1fb58b7a45671d1918fff51c8e0872e4c708e5a2bb9b4a42686021b33b12",
+                "sha256:7835909b0851a4161f967b6238cc80ed4bff4f2732d3da15f523f377b6ee008d",
+                "sha256:8e386abd3f50da0126862b96fecac2b70d5c5c38184fc471ac87c6007799c9ea",
+                "sha256:8f948ecd60280361b32f91d7bd3a957bc15033c83231bb1f8b9d9781b1daf81b",
+                "sha256:920ac0167b81f5b5a1edd6ae2e50b058515e9f21c71164d5ee1e3d03deb6f1c5",
+                "sha256:96bccc0ca78ec61248c04aad2e74e883b2d3dba829c17f2ceb38ecf3613236fb",
+                "sha256:9c9525ee8c75e2825ef40fc6e6b561ee1bd845341ba7dc8acc80db4fc15e001e",
+                "sha256:a0245955b08d3e9e2ecc8a0f0a71b52aaca696056f8e7150e70a2bbbf3cb6f5e",
+                "sha256:a4f7db90de9b50ef940a81610cc2ab44c8e2298331ca295fd7a31509e06c4b2d",
+                "sha256:a60694b053646d8a389a78e0e2a60dcc95fcfb794d95b9b1c0691f0341c4531f",
+                "sha256:aab1f84ae3e6042620313e6c92212992ca11441373f9d527e907735bb1f581e9",
+                "sha256:b93c43b646400c56a97be7c3b676795c3d760ca6ef10296bf8ee990a8ab1b540",
+                "sha256:bd716bb7862702c173c75aba0fb4c789bdce915e7731a87c5d628c5496e3d73a",
+                "sha256:c09a19fa74811b34a0090a6b83dde9425224df63f832590435de99faa971523e",
+                "sha256:c572430d2d7854ed1e251181ffc3df6f226d65fdb1c20359eb08917e22da3331",
+                "sha256:c98b8e4c832544d325b6ae4e1ef1ca4f7a23c88034c1b512320f60e886f25246",
+                "sha256:ca2c16abc35f658a067633ff20d07a7e20dd57c4b4803666ef57ea33ba9de4b5",
+                "sha256:ccef158f36fb8683da3a9d0477a6d102f3d8ff3e879030181f726e0786815a00",
+                "sha256:d40a2b55e9b7944f7546e3b8a6200880c435ef097007be87c22624ae2d7bd1ac",
+                "sha256:d869194e27168fe14b09303979b3b7384c0d97baf7977f835855c55628bcd11e",
+                "sha256:db2e13b7d3bdab40e17d797d055b6809fd69ebe2f0e052537207af4df4b95671",
+                "sha256:e3b3314b5c9ca12351f27ed871bca10b69521dd63dce18adce4a01af97c8f674",
+                "sha256:e3c392aa29b1bb06478e57a7ba97c4896d8d9e417c73be89bf17e51bc2d48ec6",
+                "sha256:f7e7092673c785850631a9a92eae5f98bac5d74addfb99b88f2adb8d98f09e44"
+            ],
+            "index": "pypi",
+            "version": "==0.23.10"
         },
         "bidict": {
             "hashes": [
@@ -382,36 +428,40 @@
         },
         "cryptography": {
             "hashes": [
-                "sha256:1923cb251c04be85eec9fda837661c67c1049063305d6be5721643c22dd4e2b7",
-                "sha256:37d76e6863da3774cd9db5b409a9ecfd2c71c981c38788d3fcfaf177f447b731",
-                "sha256:3c672a53c0fb4725a29c303be906d3c1fa99c32f58abe008a82705f9ee96f40b",
-                "sha256:404fdc66ee5f83a1388be54300ae978b2efd538018de18556dde92575e05defc",
-                "sha256:4ac4c9f37eba52cb6fbeaf5b59c152ea976726b865bd4cf87883a7e7006cc543",
-                "sha256:62901fb618f74d7d81bf408c8719e9ec14d863086efe4185afd07c352aee1d2c",
-                "sha256:660cb7312a08bc38be15b696462fa7cc7cd85c3ed9c576e81f4dc4d8b2b31591",
-                "sha256:708ee5f1bafe76d041b53a4f95eb28cdeb8d18da17e597d46d7833ee59b97ede",
-                "sha256:761817a3377ef15ac23cd7834715081791d4ec77f9297ee694ca1ee9c2c7e5eb",
-                "sha256:831c3c4d0774e488fdc83a1923b49b9957d33287de923d58ebd3cec47a0ae43f",
-                "sha256:84111ad4ff3f6253820e6d3e58be2cc2a00adb29335d4cacb5ab4d4d34f2a123",
-                "sha256:8b3e6eae66cf54701ee7d9c83c30ac0a1e3fa17be486033000f2a73a12ab507c",
-                "sha256:9e6fc8a08e116fb7c7dd1f040074c9d7b51d74a8ea40d4df2fc7aa08b76b9e6c",
-                "sha256:a01956ddfa0a6790d594f5b34fc1bfa6098aca434696a03cfdbe469b8ed79285",
-                "sha256:abc998e0c0eee3c8a1904221d3f67dcfa76422b23620173e28c11d3e626c21bd",
-                "sha256:b15492a11f9e1b62ba9d73c210e2416724633167de94607ec6069ef724fad092",
-                "sha256:be4ce505894d15d5c5037167ffb7f0ae90b7be6f2a98f9a5c3442395501c32fa",
-                "sha256:c5eb858beed7835e5ad1faba59e865109f3e52b3783b9ac21e7e47dc5554e289",
-                "sha256:cd4e834f340b4293430701e772ec543b0fbe6c2dea510a5286fe0acabe153a02",
-                "sha256:d2436114e46b36d00f8b72ff57e598978b37399d2786fd39793c36c6d5cb1c64",
-                "sha256:eb33480f1bad5b78233b0ad3e1b0be21e8ef1da745d8d2aecbb20671658b9053",
-                "sha256:eca27345e1214d1b9f9490d200f9db5a874479be914199194e746c893788d417",
-                "sha256:ed3534eb1090483c96178fcb0f8893719d96d5274dfde98aa6add34614e97c8e",
-                "sha256:f3f6fdfa89ee2d9d496e2c087cebef9d4fcbb0ad63c40e821b39f74bf48d9c5e",
-                "sha256:f53c2c87e0fb4b0c00fa9571082a057e37690a8f12233306161c8f4b819960b7",
-                "sha256:f5e7cb1e5e56ca0933b4873c0220a78b773b24d40d186b6738080b73d3d0a756",
-                "sha256:f677e1268c4e23420c3acade68fac427fffcb8d19d7df95ed7ad17cdef8404f4"
+                "sha256:00918d859aa4e57db8299607086f793fa7813ae2ff5a4637e318a25ef82730f7",
+                "sha256:1e8d181e90a777b63f3f0caa836844a1182f1f265687fac2115fcf245f5fbec3",
+                "sha256:1f9a92144fa0c877117e9748c74501bea842f93d21ee00b0cf922846d9d0b183",
+                "sha256:21377472ca4ada2906bc313168c9dc7b1d7ca417b63c1c3011d0c74b7de9ae69",
+                "sha256:24979e9f2040c953a94bf3c6782e67795a4c260734e5264dceea65c8f4bae64a",
+                "sha256:2a46a89ad3e6176223b632056f321bc7de36b9f9b93b2cc1cccf935a3849dc62",
+                "sha256:322eb03ecc62784536bc173f1483e76747aafeb69c8728df48537eb431cd1911",
+                "sha256:436df4f203482f41aad60ed1813811ac4ab102765ecae7a2bbb1dbb66dcff5a7",
+                "sha256:4f422e8c6a28cf8b7f883eb790695d6d45b0c385a2583073f3cec434cc705e1a",
+                "sha256:53f23339864b617a3dfc2b0ac8d5c432625c80014c25caac9082314e9de56f41",
+                "sha256:5fed5cd6102bb4eb843e3315d2bf25fede494509bddadb81e03a859c1bc17b83",
+                "sha256:610a83540765a8d8ce0f351ce42e26e53e1f774a6efb71eb1b41eb01d01c3d12",
+                "sha256:6c8acf6f3d1f47acb2248ec3ea261171a671f3d9428e34ad0357148d492c7864",
+                "sha256:6f76fdd6fd048576a04c5210d53aa04ca34d2ed63336d4abd306d0cbe298fddf",
+                "sha256:72198e2b5925155497a5a3e8c216c7fb3e64c16ccee11f0e7da272fa93b35c4c",
+                "sha256:887143b9ff6bad2b7570da75a7fe8bbf5f65276365ac259a5d2d5147a73775f2",
+                "sha256:888fcc3fce0c888785a4876ca55f9f43787f4c5c1cc1e2e0da71ad481ff82c5b",
+                "sha256:8e6a85a93d0642bd774460a86513c5d9d80b5c002ca9693e63f6e540f1815ed0",
+                "sha256:94f99f2b943b354a5b6307d7e8d19f5c423a794462bde2bf310c770ba052b1c4",
+                "sha256:9b336599e2cb77b1008cb2ac264b290803ec5e8e89d618a5e978ff5eb6f715d9",
+                "sha256:a2d8a7045e1ab9b9f803f0d9531ead85f90c5f2859e653b61497228b18452008",
+                "sha256:b8272f257cf1cbd3f2e120f14c68bff2b6bdfcc157fafdee84a1b795efd72862",
+                "sha256:bf688f615c29bfe9dfc44312ca470989279f0e94bb9f631f85e3459af8efc009",
+                "sha256:d9c5b9f698a83c8bd71e0f4d3f9f839ef244798e5ffe96febfa9714717db7af7",
+                "sha256:dd7c7e2d71d908dc0f8d2027e1604102140d84b155e658c20e8ad1304317691f",
+                "sha256:df978682c1504fc93b3209de21aeabf2375cb1571d4e61907b3e7a2540e83026",
+                "sha256:e403f7f766ded778ecdb790da786b418a9f2394f36e8cc8b796cc056ab05f44f",
+                "sha256:eb3889330f2a4a148abead555399ec9a32b13b7c8ba969b72d8e500eb7ef84cd",
+                "sha256:f4daefc971c2d1f82f03097dc6f216744a6cd2ac0f04c68fb935ea2ba2a0d420",
+                "sha256:f51f5705ab27898afda1aaa430f34ad90dc117421057782022edf0600bec5f14",
+                "sha256:fd0ee90072861e276b0ff08bd627abec29e32a53b2be44e41dbcdf87cbee2b00"
             ],
             "markers": "python_version >= '3.7' and python_full_version not in '3.9.0, 3.9.1'",
-            "version": "==44.0.0"
+            "version": "==44.0.1"
         },
         "dnspython": {
             "hashes": [


### PR DESCRIPTION
2^32 times better than crc32.

Must be included in the presign fields or it'll be rejected by Minio.