### PR TITLE
CDM-41: Update S3 client to pull CRC64NVME checksum if it exists

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,8 @@ sfapi-client = "==0.4.1"
 uvicorn = {version = "==0.34.0", extras = ["standard"]}
 
 [dev-packages]
+# for debugging
+boto3 = "==1.36.21"
 coverage = "==7.6.10"
 ipython = "==8.31.0"
 pytest = "==8.3.4"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "796548a7f4e44a23bdfb3e9cc877468afe2405b0b80ca3b9591d8bc98ac87a09"
+            "sha256": "f741527524d7f14a5603c1ba161174a2452d5bc73611c3e22b8070982be295d8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -1959,6 +1959,22 @@
             "markers": "python_version >= '3.8'",
             "version": "==3.0.0"
         },
+        "boto3": {
+            "hashes": [
+                "sha256:41eb2b73eb612d300e629e3328b83f1ffea0fc6633e75c241a72a76746c1db26",
+                "sha256:f94faa7cf932d781f474d87f8b4c14a033af95ac1460136b40d75e7a30086ef0"
+            ],
+            "index": "pypi",
+            "version": "==1.36.21"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:536ab828e6f90dbb000e3702ac45fd76642113ae2db1b7b1373ad24104e89255",
+                "sha256:775b835e979da5c96548ed1a0b798101a145aec3cd46541d62e27dda5a94d7f8"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.36.3"
+        },
         "coverage": {
             "hashes": [
                 "sha256:05fca8ba6a87aabdd2d30d0b6c838b50510b56cdcfc604d40760dae7153b73d9",
@@ -2067,6 +2083,14 @@
             "markers": "python_version >= '3.6'",
             "version": "==0.19.2"
         },
+        "jmespath": {
+            "hashes": [
+                "sha256:02e2e4cc71b5bcab88332eebf907519190dd9e6e82107fa7f83b1003a6252980",
+                "sha256:90261b206d6defd58fdd5e85f478bf633a2901798906be2ad389150c5c60edbe"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.0.1"
+        },
         "matplotlib-inline": {
             "hashes": [
                 "sha256:8423b23ec666be3d16e16b60bdd8ac4e86e840ebd1dd11a30b9f117f2fa0ab90",
@@ -2161,6 +2185,30 @@
             "index": "pypi",
             "version": "==6.0.0"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3",
+                "sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==2.9.0.post0"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:3b39185cb72f5acc77db1a58b6e25b977f28d20496b6e58d6813d75f464d632f",
+                "sha256:be6ecb39fadd986ef1701097771f87e4d2f821f27f6071c872143884d2950fbc"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.11.2"
+        },
+        "six": {
+            "hashes": [
+                "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274",
+                "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.17.0"
+        },
         "stack-data": {
             "hashes": [
                 "sha256:836a778de4fec4dcd1dcd89ed8abff8a221f58308462e1c4aa2a3cf30148f0b9",
@@ -2183,6 +2231,14 @@
             ],
             "markers": "python_version >= '3.8'",
             "version": "==4.12.2"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df",
+                "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d"
+            ],
+            "markers": "python_version >= '3.10'",
+            "version": "==2.3.0"
         },
         "wcwidth": {
             "hashes": [


### PR DESCRIPTION
The checksum isn't returned with a part size request, so remove part size. ETag calculations will break for files > 1 part in the nersc manager / remote code until they're updated to CRC64.