### PR TITLE
CDM-41: Remove get refdata by ETag methods

### DIFF
--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -56,7 +56,6 @@ FLD_JOB_TRACEBACK = "traceback"
 FLD_JOB_LOGPATH = "logpath"
 FLD_REFDATA_ID = "id"
 FLD_REFDATA_FILE = "file"
-FLD_REFDATA_ETAG = "etag"
 FLD_REFDATA_STATUSES = "statuses"
 FLD_REFDATA_CLUSTER = "cluster"
 FLD_REFDATA_TRANS_TIMES = "transition_times"
@@ -439,6 +438,7 @@ class S3File(BaseModel):
     )]
     # Don't bother validating the etag beyond length, it'll be compared to the file etag on 
     # the way in and will come from S3 on the way out
+    # TODO swap for CRC64NVME
     etag: Annotated[str | None, Field(
         example="a70a4d1732484e75434df2c08570e1b2-3",
         description="The S3 e-tag of the file. Weak e-tags are not supported. "
@@ -547,7 +547,7 @@ class JobInput(BaseModel):
             {
                 "file": "mybucket/foo/bat",
                 "data_id": "GCA_000146795.3",
-                "etag": "a70a4d1732484e75434df2c08570e1b2-3"
+                "etag": "a70a4d1732484e75434df2c08570e1b2-3"  # TODO swap for CRC64NVME
             }
         ],
         description="The S3 input files for the job, either a list of file paths as strings or a "

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -71,11 +71,6 @@ class MongoDAO:
             IndexModel([(models.FLD_REFDATA_ID, ASCENDING)], unique=True),
             # Non unique as files can be overwritten
             IndexModel([(models.FLD_REFDATA_FILE, ASCENDING)]),
-            # Not really sure about uniqueness for this one...
-            # Could make it unique to prevent refdata duplication, but that means we'd
-            # have to get the etag of the user's refdata, find the record, and use the refdata id
-            # For now just allow duplicate refdata
-            IndexModel([(models.FLD_REFDATA_ETAG, ASCENDING)]),
         ])
 
     async def save_image(self, image: models.Image):
@@ -422,14 +417,6 @@ class MongoDAO:
         """
         return await self._get_refdata(
             models.FLD_REFDATA_FILE, _require_string(s3_path, "s3_path"),
-        )
-
-    async def get_refdata_by_etag(self, etag: str) -> list[models.ReferenceData]:
-        """
-        Get reference data by the refdata Etag. Returns at most 1000 records.
-        """
-        return await self._get_refdata(
-            models.FLD_REFDATA_ETAG, _require_string(etag, "etag"),
         )
 
     # sorts by field ascending, so make sure there's an index for that field

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -517,8 +517,8 @@ class NERSCManager:
                 #              This allows JAWS / Cromwell to cache the files if they have the
                 #              same path, which they won't if there's a job ID in the mix
                 "outputpath": str(sc / Path(meta.path).name if refdata else sc / meta.path),
-                "etag": meta.e_tag,
-                "partsize": meta.effective_part_size,
+                "etag": meta.e_tag,  # TODO CHECKSUMS swap for crc64NVME
+                "partsize": meta.effective_part_size,  # TODO CHECKSUMS remove
                 "size": meta.size,
                 "unpack": unpack,
             } for url, meta in zip(presigned_urls, objects)
@@ -713,6 +713,8 @@ class NERSCManager:
             return []
         return [_JOB_MANIFESTS / f"{_MANIFEST_FILE_PREFIX}{c}" for c in range(1, count + 1)]
 
+    # TODO CHECKSUMS need to add a task to calculate crc64nvmes @ NERSC
+    #                try just a blocking task for now, YAGNI async
     async def upload_JAWS_job_files(
         self,
         job: models.Job,

--- a/cdmtaskservice/refdata.py
+++ b/cdmtaskservice/refdata.py
@@ -134,10 +134,3 @@ class Refdata:
         """
         # pass through method, don't want the routes talking directly to mongo
         return await self._mongo.get_refdata_by_path(_require_string(s3_path, "s3_path"))
-    
-    async def get_refdata_by_etag(self, etag: str) -> list[models.ReferenceData]:
-        """
-        Get reference data based on the S3 Etag. Returns at most 1000 records.
-        """
-        # also a passthrough method
-        return await self._mongo.get_refdata_by_etag(_require_string(etag, "etag"))

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -214,7 +214,7 @@ class RefData(BaseModel):
     description="Get information about reference data available for containers in the system "
         + "in no particular order. Returns at most 1000 records."
 )
-async def get_refdata(r: Request) -> models.ReferenceData:
+async def get_refdata(r: Request) -> RefData:
     refdata = app_state.get_app_state(r).refdata
     rd = await refdata.get_refdata()
     return RefData(data=rd)
@@ -250,33 +250,13 @@ async def get_refdata_by_path(
         min_length=models.S3_PATH_MIN_LENGTH,
         max_length=models.S3_PATH_MAX_LENGTH,
     )],
-) -> models.ReferenceData:
+) -> RefData:
     refdata = app_state.get_app_state(r).refdata
     rd = await refdata.get_refdata_by_path(s3_path)
     return RefData(data=rd)
 
 
-@ROUTER_REFDATA.get(
-    "/etag/{s3_etag}",
-    response_model=RefData,
-    summary="Get reference data information by the S3 Etag",
-    description="Get information about reference data available for containers by the "
-        + "reference data Etag. Returns at most 1000 records."
-)
-async def get_refdata_by_etag(
-    r: Request,
-    s3_etag: Annotated[str, FastPath(
-        example="a70a4d1732484e75434df2c08570e1b2-3",
-        description="The S3 Etag of the file.",
-        min_length=models.ETAG_MIN_LENGTH,
-        max_length=models.ETAG_MAX_LENGTH,
-    )],
-) -> models.ReferenceData:
-    # TODO CHECKSUMS swap this method for a full object checksum, etags are useless here
-    refdata = app_state.get_app_state(r).refdata
-    rd = await refdata.get_refdata_by_etag(s3_etag)
-    return RefData(data=rd)
-
+# TODO CHECKSUM FEATURE add get refdata by crc64nvme if needed... YAGNI
 
 @ROUTER_ADMIN.post(
     "/images/{image_id:path}",

--- a/cdmtaskservice/s3/client.py
+++ b/cdmtaskservice/s3/client.py
@@ -50,7 +50,7 @@ class S3ObjectMeta:
     
     @property
     def effective_part_size(self):
-        # TODO CRC remove - need to update nersc manager first
+        # TODO CHECKSUMS remove - need to update nersc manager first
         return self.size
 
 

--- a/cdmtaskservice/s3/remote.py
+++ b/cdmtaskservice/s3/remote.py
@@ -20,7 +20,7 @@ from typing import Any, Awaitable
 # Probably not necessary, but could look into aiofiles for some of these methods
 # Potential future (minor) performance improvement, but means more installs on remote clusters
 
-# TODO CRC need to check CRC on download
+# TODO CHECKSUMS need to check CRC on download
 
 
 _EXT_GZ = ".gz"
@@ -102,9 +102,9 @@ def _check_file(infile: Path):
 async def download_presigned_url(
     session: aiohttp.ClientSession,
     url: str,
-    partsize: int,
+    partsize: int,  # TODO CHECKSUMS remove
     outputpath: Path,
-    etag: str = None,
+    etag: str = None,  # TODO CHECKSUMS swap for crc64nvme
     insecure_ssl: bool = False,
     timeout_sec: int = 600,
 ):
@@ -209,7 +209,7 @@ async def upload_presigned_url(
                                ) from e
 
 
-# TODO CRC need to update nersc jaws runner to presign including the CRCs
+# TODO CHECKSUMS need to update nersc jaws runner to presign including the CRCs
 async def _process_uploads(
     sess: aiohttp.ClientSession,
     root: Path,


### PR DESCRIPTION
Pointless since the same file contents can have different ETags if the part sizes aren't identical