### PR TITLE
Various bugfixes due to JAWS changes and other reasons

### DIFF
--- a/cdmtaskservice/jaws/remote.py
+++ b/cdmtaskservice/jaws/remote.py
@@ -64,13 +64,13 @@ def parse_errors_json(errors_json: io.BytesIO, logpath: Path) -> list[tuple[int,
         cid = c["shardIndex"]
         if cid in id2rc:
             raise ValueError(f"Duplicate shardIndex: {cid}")
-        rc = c["returnCode"]
+        rc = c.get("returnCode")
         # never seen a structure other than this, may need changes
         err = c["failures"][0]["message"]
         id2rc[cid] = (rc, err)
         rcf, sof, sef = get_filenames_for_container(cid)
         with open(logpath / rcf, "w") as f:
-            f.write(f"{rc}\n")
+            f.write(f"{rc if rc is not None else 'container_did_not_run'}\n")
         with open(logpath / sof, "w") as f:
             f.write(c["stdoutContents"])
         with open(logpath / sef, "w") as f:

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -400,9 +400,8 @@ class NERSCJAWSRunner(JobFlow):
         """
         if _not_falsy(job, "job").state != models.JobState.ERROR_PROCESSING_SUBMITTED:
             raise InvalidJobStateError("Job must be in the error processing submitted state")
-        # TODO TEST this when JAWS works again, force an error
         async def tfunc():
-            return await self._nman.get_presigned_upload_result(job)
+            return await self._nman.get_presigned_error_log_upload_result(job)
         data = await self._get_transfer_result(
             tfunc,
             job.id,
@@ -410,7 +409,7 @@ class NERSCJAWSRunner(JobFlow):
             "getting error log upload results for",
         )
         if {i[0] for i in data} != {0}:
-            err = (f"At least one container exited with a non-zero error code. "
+            err = (f"At least one container did not start or exited with a non-zero error code. "
                    + "Please examine the logs for details.")
         else:  # will probably need to expand this as we learn about JAWS errors
             err = "An unexpected error occurred."

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -433,7 +433,9 @@ class S3File(BaseModel):
     
     file: Annotated[str, Field(
         example="mybucket/foo/bar/baz.jpg",
-        description="A path to an object in an S3 instance, starting with the bucket.",
+        description="A path to an object in an S3 instance, starting with the bucket. "
+            + "Please note that spaces are valid S3 object characters, so be careful about "
+            + "trailing spaces in the input.",
         min_length=S3_PATH_MIN_LENGTH,
         max_length=S3_PATH_MAX_LENGTH,
     )]

--- a/cdmtaskservice/refdata.py
+++ b/cdmtaskservice/refdata.py
@@ -63,7 +63,7 @@ class Refdata:
         """
         # validate before S3Paths because that returns an error mentioning an index
         # TODO CODE add a toggle to S3Paths to not include index info in error
-        validate_path(s3_path)
+        s3_path = validate_path(s3_path)
         _not_falsy(user, "user")
         if unpack:
             if not any([s3_path.endswith(ex) for ex in UNPACK_FILE_EXTENSIONS]):

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -246,7 +246,9 @@ async def get_refdata_by_path(
     r: Request,
     s3_path: Annotated[str, FastPath(
         example="refdata-bucket/checkm2/checkm2_refdata-2.4.tgz",
-        description="The S3 path to the reference data, starting with the bucket.",
+        description="The S3 path to the reference data, starting with the bucket. "
+            + "Please note that spaces are valid S3 object characters, so be careful about "
+            + "trailing spaces in the input.",
         min_length=models.S3_PATH_MIN_LENGTH,
         max_length=models.S3_PATH_MAX_LENGTH,
     )],
@@ -316,7 +318,9 @@ async def create_refdata(
     refdata_s3_path: Annotated[str, FastPath(
         example="refdata-bucket/checkm2/checkm2_refdata-2.4.tgz",
         description="The S3 path to the reference data to register, starting with the bucket. "
-            + "If the refdata consists of multiple files, they must be archived.",
+            + "If the refdata consists of multiple files, they must be archived. "
+            + "Please note that spaces are valid S3 object characters, so be careful about "
+            + "trailing spaces in the input.",
         min_length=models.S3_PATH_MIN_LENGTH,
         max_length=models.S3_PATH_MAX_LENGTH,
     )],


### PR DESCRIPTION
1. JAWS will now throw an error if a variable is present in a wdl command stanza that is not declared in the inputs.
2. A bug in error log handling was introduced during a refactor while NERSC was down.
3. Added notes regarding spaces in s3 object paths being confusing if left at the end of the path.
4. If a container doesn't start in a job, there will be no return code in the errors.json file and a KeyError will occur.