### PR TITLE
Add input / output file counts to job

### DIFF
--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -101,6 +101,7 @@ class JobState:
             job_input=ji,
             user=user.user,
             image=image,
+            input_file_count=len(new_input),
             state=models.JobState.CREATED,
             transition_times=[models.JobStateTransition(
                 state=models.JobState.CREATED, time=utcdatetime()

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -48,6 +48,7 @@ FLD_JOB_JAWS_DETAILS = "jaws_details"
 FLD_JAWS_DETAILS_RUN_ID = "run_id"
 FLD_JOB_CPU_HOURS = "cpu_hours"
 FLD_JOB_OUTPUTS = "outputs"
+FLD_JOB_OUTPUT_FILE_COUNT = "output_file_count"
 FLD_JOB_LOGPATH = "logpath"
 FLD_REFDATA_FILE = "file"
 FLD_REFDATA_STATUSES = "statuses"
@@ -782,6 +783,7 @@ class Job(BaseModel):
     job_input: JobInput
     user: Annotated[str, Field(example="myuserid", description="The user that ran the job.")]
     image: Image
+    input_file_count: Annotated[int, Field(example=42, description="The number of input files.")]
     state: Annotated[JobState, Field(example=JobState.COMPLETE.value)]
     # hmm, should this be a dict vs a list of tuples?
     transition_times: Annotated[list[JobStateTransition], Field(
@@ -802,6 +804,9 @@ class Job(BaseModel):
     ] = None
     # May need to assemble jobs manually if path validation is too expensive.
     outputs: list[S3File] | None = None
+    output_file_count: Annotated[int | None, Field(
+        example=24, description="The number of output files, if available."
+    )] = None
     error: Annotated[str | None, Field(
         example="The front fell off",
         description="A description of the error that occurred."

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -365,7 +365,10 @@ class MongoDAO:
         """
         out = [o.model_dump() for o in _not_falsy(output, "output")]
         await self._update_job_state(
-            job_id, state, time, current_state=current_state, set_={models.FLD_JOB_OUTPUTS: out}
+            job_id, state, time, current_state=current_state, set_={
+                models.FLD_JOB_OUTPUTS: out,
+                models.FLD_JOB_OUTPUT_FILE_COUNT: len(out),
+            }
         )
 
     async def set_job_error(


### PR DESCRIPTION
In anticipation of omitting files when listing jobs, too much data if we're listing 1000 jobs at a time