### PR TITLE
Don't include job keys with null values in mongo or output

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -155,7 +155,7 @@ class MongoDAO:
     async def save_job(self, job: models.Job):
         """ Save a job. Job IDs are expected to be unique."""
         _not_falsy(job, "job")
-        jobd = job.model_dump()
+        jobd = job.model_dump(exclude_none=True)
         jobi = jobd[models.FLD_JOB_JOB_INPUT]
         jobi[models.FLD_JOB_INPUT_RUNTIME] = jobi[models.FLD_JOB_INPUT_RUNTIME].total_seconds()
         # don't bother checking for duplicate key exceptions since the service is supposed
@@ -416,8 +416,8 @@ class MongoDAO:
         """
         # TODO RETRIES will need to clear the error fields when attempting a retry
         set_ = {
-            models.FLD_COMMON_ERROR: user_error,
-            models.FLD_COMMON_ADMIN_ERROR: admin_error,
+            models.FLD_COMMON_ERROR: _require_string(user_error, "user_error"),
+            models.FLD_COMMON_ADMIN_ERROR: _require_string(admin_error, "admin_error"),
             models.FLD_COMMON_TRACEBACK: traceback,
             models.FLD_JOB_LOGPATH: logpath
         }
@@ -598,8 +598,8 @@ class MongoDAO:
         """
         # TODO RETRIES will need to clear the error fields when attempting a retry
         await self._update_refdata_state(cluster, refdata_id, state, time, set_={
-            models.FLD_COMMON_ERROR: user_error,
-            models.FLD_COMMON_ADMIN_ERROR: admin_error,
+            models.FLD_COMMON_ERROR: _require_string(user_error, "user_error"),
+            models.FLD_COMMON_ADMIN_ERROR: _require_string(admin_error, "admin_error"),
             models.FLD_COMMON_TRACEBACK: traceback,
         })
 

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -139,6 +139,7 @@ _ANN_JOB_ID = Annotated[str, FastPath(
 @ROUTER_JOBS.get(
     "/{job_id}",
     response_model=models.Job,
+    response_model_exclude_none=True,
     summary="Get a job",
     description="Get a job. Only the submitting user may view the job."
 )
@@ -345,6 +346,7 @@ async def create_refdata(
 @ROUTER_ADMIN.get(
     "/jobs/{job_id}",
     response_model=models.AdminJobDetails,
+    response_model_exclude_none=True,
     summary="Get a job as an admin",
     description="Get any job, regardless of ownership, with additional details about the job run."
 )


### PR DESCRIPTION
Don't confuse user with irrelevant keys in job output (especially for `Parameter`) and save space by dropping data ID key from potentially thousands of file mappings

Also add missing checks for error strings on input to mongo