### PR TITLE
CDM-88: Add anti-clobbering feature

### DIFF
--- a/cdmtaskservice/jaws/wdl.py
+++ b/cdmtaskservice/jaws/wdl.py
@@ -274,7 +274,7 @@ def _process_parameter(
             case ParameterType.MANIFEST_FILE:  # implies manifest file is not None
                 param = _handle_manifest(job, manifest, param.get_flag())
             case ParameterType.CONTAINTER_NUMBER:
-                param = _handle_container_num(param.get_flag(), container_num)
+                param = _handle_container_num(param, container_num)
             case _:
                 # should be impossible but make code future proof
                 raise ValueError(f"Unexpected parameter type: {_}")
@@ -283,9 +283,12 @@ def _process_parameter(
     return [param] if as_list and not isinstance(param, list) else param
 
 
-def _handle_container_num(flag: str | None, container_num: int) -> str | list[str]:
+def _handle_container_num(p: Parameter, container_num: int) -> str | list[str]:
     # similar to the function below
-    cn = str(container_num)
+    pre = p.container_num_prefix if p.container_num_prefix else ""
+    suf = p.container_num_suffix if p.container_num_suffix else ""
+    cn = f"{pre}{container_num}{suf}"
+    flag = p.get_flag()
     if flag:
         if flag.endswith("="):
             # TODO TEST not sure if this will work

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -207,6 +207,14 @@ class Parameter(BaseModel):
         min_length=1,
         max_length=1000,
     )] = None
+    container_num_prefix: Annotated[ArgumentString | None, Field(
+        example="/output/job-",
+        description="A string that will be prepended to the container number."
+    )] = None
+    container_num_suffix: Annotated[ArgumentString | None, Field(
+        example="_output",
+        description="A string that will be appended to the container number."
+    )] = None
     
     def get_flag(self):
         """

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -264,7 +264,7 @@ class NERSCManager:
                 deps = " ".join(
                     # may need to do something else if module doesn't have __version__
                     [f"{mod.__name__}=={mod.__version__}" for mod in _PIP_DEPENDENCIES])
-                logr.info(f"Installing pip mudules @ NERSC: {deps}")
+                logr.info(f"Installing pip modules @ NERSC: {deps}")
                 command = (
                     f"{_DT_WORKAROUND}; "
                     + f"{_PYTHON_LOAD_HACK}; "

--- a/cdmtaskservice/s3/remote.py
+++ b/cdmtaskservice/s3/remote.py
@@ -363,6 +363,8 @@ async def _run_tasks(
 # These arg checkers are duplicated in other places, but we want to minimize the number of files
 # we have to transfer to the remote cluster and they're simple enough that duplication isn't
 # a huge problem
+# TODO CODE the above is now outdated, we're pushing the arg checkers code to nersc.
+#           remove the arg checkers below
 
 
 def _require_string(string: str, name: str):


### PR DESCRIPTION
Allows a user to specify the container number as part of a path, or any allowable string. The primary use case is including it as part of an output path to avoid containers overwriting each other