### PR TITLE
Fix missing shell quote

### DIFF
--- a/cdmtaskservice/jaws/wdl.py
+++ b/cdmtaskservice/jaws/wdl.py
@@ -296,7 +296,7 @@ def _handle_container_num(p: Parameter, container_num: int) -> str | list[str]:
         else:
             param = [shlex.quote(flag), cn]
     else:
-        param = cn
+        param = shlex.quote(cn)
     return param
 
 

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -290,7 +290,7 @@ class Parameters(BaseModel):
     
     Specifying files as part of arguments to a job can be done in three ways:
     
-    * If the entrypoint command takes a glob or a directory as an argument, that glob or
+    * If the entrypoint command takes a directory as an argument, that
       directory can be specified literally in an argument. All files will be available in the
       input mount point, with paths resulting from the path in S3 as well as the input_roots
       parameter from the job input.


### PR DESCRIPTION
When adding the prefix & suffix to container number, missed adding a shell quote. Previously wasn't needed since it was just a number.

Also remove note about supporting globbing, since shell quoting disables globbing. May want to rethink this if there's a call for globbing as we currently have 2 layers of protection - the restricted characters in models.py and the shell quoting in wdl.py.