### PR TITLE
CDM-67: Add notification for job created + more

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -130,6 +130,7 @@ async def build_app(
             mongodao,
             s3,
             images,
+            kafka_notifier,
             refdata,
             coman,
             flowman,

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -181,14 +181,14 @@ class NERSCJAWSRunner(JobFlow):
     async def _update_job_state(self, job_id: str, update: JobUpdate):
         # may want to factor this to a shared module if we ever support other flows
         # TODO TEST will need to mock out uuid
-        update_id = str(uuid.uuid4())
+        trans_id = str(uuid.uuid4())
         # TODO TEST will need a way to mock out timestamps
         update_time = timestamp.utcdatetime()
         async def cb():
-            await self._mongo.job_update_sent(job_id, update_id)
-        await self._mongo.update_job_state(job_id, update, update_time, update_id=update_id)
+            await self._mongo.job_update_sent(job_id, trans_id)
+        await self._mongo.update_job_state(job_id, update, update_time, trans_id)
         await self._kafka.update_job_state(
-            job_id, update.new_state, update_time, update_id=update_id, callback=cb()
+            job_id, update.new_state, update_time, trans_id, callback=cb()
         )
         # TODO KAFKA on startup, check for unsent messages, send, and set flag
 

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -37,6 +37,8 @@ FLD_IMAGE_DIGEST = "digest"
 FLD_IMAGE_TAG = "tag"
 FLD_JOB_JOB_INPUT = "job_input"
 FLD_JOB_INPUT_RUNTIME = "runtime"
+FLD_JOB_STATE_TRANSITION_ID = "trans_id"
+FLD_JOB_STATE_TRANSITION_NOTIFICATiON_SENT = "notif_sent"
 FLD_JOB_NERSC_DETAILS = "nersc_details"
 FLD_NERSC_DETAILS_DL_TASK_ID = "download_task_id"
 FLD_NERSC_DETAILS_UL_TASK_ID = "upload_task_id"
@@ -860,11 +862,45 @@ class JAWSDetails(BaseModel):
             + "failures.")]
 
 
+class AdminJobStateTransition(JobStateTransition):
+    
+    trans_id: Annotated[str, Field(
+        description="An opaque, unique ID identifying this state transition"
+    )]
+    # Only allows for one notification system... YAGNI
+    notif_sent: Annotated[bool, Field(
+        description="Whether an update has been sent to the notification system for "
+        + "this state transition."
+    )]
+
 class AdminJobDetails(Job):
     """
     Information about a job with added details of interest to service administrators.
     """
     # Output only model, no validation
+    transition_times: Annotated[list[AdminJobStateTransition], Field(
+        examples=[[
+            {
+                "state": JobState.CREATED.value,
+                "time": "2024-10-24T22:35:40Z",
+                "trans_id": "foo",
+                "notif_sent": True,
+            },
+            {
+                "state": JobState.UPLOAD_SUBMITTED.value,
+                "time": "2024-10-24T22:35:41Z",
+                "trans_id": "bar",
+                "notif_sent": True,
+            },
+            {
+                "state": JobState.JOB_SUBMITTING,
+                "time": "2024-10-24T22:47:67Z",
+                "trans_id": "baz",
+                "notif_sent": False, 
+            },
+        ]],
+        description="A list of job state transitions."
+    )]
     nersc_details: NERSCDetails | None = None
     jaws_details: JAWSDetails | None = None
     admin_error: Annotated[str | None, Field(


### PR DESCRIPTION
* Allow admins to see transition IDs and notification send states
* Make transition IDs required
* rename update_id to trans_id to line up with the transition_times key for the subobjects