### PR TITLE
Clean up dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM python:3.11
+FROM python:3.11 as build
 
 ENV CRANE_VER=v0.20.2
-
-RUN mkdir -p /cdmtaskservice && mkdir -p /craneinstall
 
 # Install crane
 
@@ -12,27 +10,36 @@ WORKDIR /craneinstall
 # Note that the provenance verification step is broken, which wasted an hour or two of time
 # https://github.com/google/go-containerregistry/issues/1982
 RUN curl -sL https://github.com/google/go-containerregistry/releases/download/$CRANE_VER/go-containerregistry_Linux_x86_64.tar.gz > go-containerregistry.tar.gz \ 
-    && tar -zxvf go-containerregistry.tar.gz \
-    && mv ./crane /cdmtaskservice \
-    && rm -r /craneinstall
+    && tar -zxvf go-containerregistry.tar.gz
 
-ENV KBCTS_CRANE_PATH=/cdmtaskservice/crane
+# Write the git commit for the service
+
+WORKDIR /git
+COPY .git /git
+RUN GITCOMMIT=$(git rev-parse HEAD) && echo "GIT_COMMIT=\"$GITCOMMIT\"" > /git/git_commit.py
+
+FROM python:3.11
 
 # install pipenv
 RUN pip install --upgrade pip && \
     pip install pipenv
 
-WORKDIR /cdmtaskservice
+WORKDIR /pip
 
 # install deps
 COPY Pipfile* ./
 RUN pipenv sync --system
 
-COPY ./ /cdmtaskservice
+RUN mkdir /cts
+COPY cdmtaskservice /cts/cdmtaskservice
+COPY scripts/* /cts
+COPY cdmtaskservice_config.toml.jinja /cts
 
-# Write the git commit for the service
-ARG VCS_REF=no_git_commit_passed_to_build
-RUN echo "GIT_COMMIT=\"$VCS_REF\"" > cdmtaskservice/git_commit.py
+COPY --from=build /craneinstall/crane /cts
+COPY --from=build /git/git_commit.py /cts/cdmtaskservice/
+ENV KBCTS_CRANE_PATH=/cts/crane
 
-ENTRYPOINT ["scripts/entrypoint.sh"]
+WORKDIR /cts
+
+ENTRYPOINT ["/cts/entrypoint.sh"]
 


### PR DESCRIPTION
* Don't depend on a build variable for the git hash
* Only copy in necessary files vs. whole repo