### PR TITLE
Add a cancel method to the JAWS client and handle canceled jobs

### DIFF
--- a/cdmtaskservice/jobflows/lawrencium_jaws.py
+++ b/cdmtaskservice/jobflows/lawrencium_jaws.py
@@ -91,6 +91,13 @@ class LawrenciumJAWSRunner(NERSCJAWSRunner):
             logging.getLogger(__name__).info(
                 "waiting for JAWS to complete refdata handling stuff"
             )
+            # Note on eventual retries - JAWS writes a file to note that the transfer is
+            # done, whether it succeeded or failed. The file path is based on the file that the
+            # s3 remote code writes when refdata is staged. Therefore on a retry, these files
+            # will already exist and so setting up a SFAPI callback for them will trigger the
+            # callback immediately. Either the files need to be deleted or a file with a new
+            # filename needs to be written (maybe insert _attempt_# or something into the name).
+            
             # BLOCKED waiting for JAWS features / debugging
             # TODO LRC REFDATA set up a callback @ NERSC for the refata complete file marker.that
             #        pings the service to tell it the refdata transfer to LRC is complete

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -316,6 +316,13 @@ class NERSCJAWSRunner(JobFlow):
                 job.id, submitting_error_processing(cpu_hours=jaws_info["cpu_hours"])
             )
             await self._coman.run_coroutine(self._upload_container_logs(job, jaws_info))
+        elif res == jaws_client.JAWSResult.CANCELED:
+            await self._update_job_state(job.id, error(
+                "The job was unexpectedly canceled",
+                "JAWS reported the job as canceled",
+                cpu_hours=jaws_info["cpu_hours"],
+            ))
+            
         elif res == jaws_client.JAWSResult.SYSTEM_ERROR:
             # there's no way to force a jaws system error that I'm aware of, will need to
             # test via unit tests


### PR DESCRIPTION
Not yet integrated into the service as a whole, but helpful for coders.