### PR TITLE
CDM-276: Add default refdata mount point to image registration

### DIFF
--- a/cdmtaskservice/images.py
+++ b/cdmtaskservice/images.py
@@ -2,14 +2,19 @@
 Methods for registering, deleting, and listing images.
 """
 
+import re
 from typing import Awaitable
 
 from cdmtaskservice import models
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy
+from cdmtaskservice.exceptions import IllegalParameterError
 from cdmtaskservice.image_remote_lookup import DockerImageInfo, parse_image_name
 from cdmtaskservice.mongo import MongoDAO
 from cdmtaskservice.refdata import Refdata
 from cdmtaskservice.timestamp import utcdatetime
+
+
+_ABSPATH_REGEX = re.compile(models.ABSOLUTE_PATH_REGEX)
 
 
 class Images:
@@ -29,7 +34,11 @@ class Images:
         self._ref = _not_falsy(refdata, "refdata")
         
     async def register(
-        self, imagename: str, username: str, refdata_id: str = None
+        self,
+        imagename: str,
+        username: str,
+        refdata_id: str = None,
+        default_refdata_mount_point: str = None
     ) -> models.Image:
         """
         Register an image to the service.
@@ -37,7 +46,18 @@ class Images:
         imagename - the name of the docker image, e.g. gchr.io/kbase/checkm2:6.7.1
         username - the name of the user registering the image.
         refdata_id - the ID of reference data to associate with the image.
+        default_refdata_mount_point - the default mount point for refdata in an image container.
+            Must be am absolute path with at least one path element.
         """
+        if default_refdata_mount_point:
+            if not refdata_id:
+                raise IllegalParameterError(
+                    "If a refdata mount point is provided a refdata ID must be provided."
+                )
+            if not _ABSPATH_REGEX.fullmatch(default_refdata_mount_point):
+                raise IllegalParameterError(
+                    "Refdata mount points must be absolute paths with at least one path element."
+                )
         if refdata_id:  # ensure refdata exists
             await self._ref.get_refdata_by_id(refdata_id)
         normedname = await self._iminfo.normalize_image_name(imagename)
@@ -52,7 +72,8 @@ class Images:
             entrypoint=entrypoint,
             registered_by=username,
             registered_on=utcdatetime(),
-            refdata_id=refdata_id or None,  # ensure not empty string, etc.
+            refdata_id=refdata_id,
+            default_refdata_mount_point=default_refdata_mount_point,
         )
         await self._mongo.save_image(img)
         return img

--- a/cdmtaskservice/jaws/wdl.py
+++ b/cdmtaskservice/jaws/wdl.py
@@ -62,7 +62,7 @@ def generate_wdl(
     # If the manifest file name / path changes that'll break the JAWS cache, need to think
     # about that
     # How often will jobs run with identical manifest files though? Maybe MD5 based caching?
-    if relative_refdata_path and not job.job_input.params.refdata_mount_point:
+    if relative_refdata_path and not job.get_refdata_mount_point():
         raise ValueError(
             "If a refdata path is supplied, a mount point for the job must be supplied"
         )
@@ -137,7 +137,7 @@ def _generate_wdl(job: Job, workflow_name: str, manifests: bool, relative_refdat
     fi"""
     if relative_refdata_path:
         refdata_mount = f'''
-    dynamic_refdata: "{relative_refdata_path}:{job.job_input.params.refdata_mount_point}"'''
+    dynamic_refdata: "{relative_refdata_path}:{job.get_refdata_mount_point()}"'''
 
     return f"""
 version {_WDL_VERSION}

--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -188,10 +188,10 @@ class JobState:
     async def _check_refdata(self, job_input: models.JobInput, image: models.Image):
         if not image.refdata_id:
             return
-        if not job_input.params.refdata_mount_point:
+        if not job_input.params.refdata_mount_point and not image.default_refdata_mount_point:
             raise IllegalParameterError(
                 "Image for job requires reference data but no refdata mount point "
-                + "is specified in the job input parameters"
+                + "is specified in the job input parameters or the image details"
         )
         refdata = await self._ref.get_refdata_by_id(image.refdata_id)
         refstatus = refdata.get_status_for_cluster(job_input.cluster)


### PR DESCRIPTION
Makes specifying the mount point optional when running a job