### PR TITLE
CDM-292: Delete refdata archive post unpack

### DIFF
--- a/cdmtaskservice/images.py
+++ b/cdmtaskservice/images.py
@@ -72,7 +72,7 @@ class Images:
             entrypoint=entrypoint,
             registered_by=username,
             registered_on=utcdatetime(),
-            refdata_id=refdata_id,
+            refdata_id=refdata_id or None,  # ensure not empty string, etc.
             default_refdata_mount_point=default_refdata_mount_point,
         )
         await self._mongo.save_image(img)

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -546,7 +546,7 @@ class NERSCManager:
                 "unpack": unpack,
             } for url, meta in zip(presigned_urls, objects)
         ]
-        return io.BytesIO(json.dumps({"file-transfers": manifest}).encode())
+        return io.BytesIO(json.dumps({"file-transfers": manifest}, indent=4).encode())
     
     def _create_upload_manifest(
         self,
@@ -567,7 +567,7 @@ class NERSCManager:
                 "file": str(file),
             } for url, file in zip(presigned_urls, remote_files)
         ]
-        return io.BytesIO(json.dumps({"file-transfers": manifest}).encode())
+        return io.BytesIO(json.dumps({"file-transfers": manifest}, indent=4).encode())
     
     def _base_manifest(self, op: str, concurrency: int, insecure_ssl: bool):
         return {

--- a/cdmtaskservice/s3/remote.py
+++ b/cdmtaskservice/s3/remote.py
@@ -261,16 +261,19 @@ async def _process_download(
         timeout_sec=timeout_sec,
     )
     if unpack:
-        op = str(outputpath).lower()
-        if op.endswith(_EXT_TGZ) or op.endswith(_EXT_TARGZ):
-            return _extract_tar(outputpath)
-        elif op.endswith(_EXT_GZ):
-            return _extract_gz(outputpath)
-        else:
-            raise ValueError(
-                f"Unsupported unpack file type for file {outputpath}. " +
-                f"Only {', '.join(UNPACK_FILE_EXTENSIONS)} are supported."
-            )
+        try:
+            op = str(outputpath).lower()
+            if op.endswith(_EXT_TGZ) or op.endswith(_EXT_TARGZ):
+                return _extract_tar(outputpath)
+            elif op.endswith(_EXT_GZ):
+                return _extract_gz(outputpath)
+            else:
+                raise ValueError(
+                    f"Unsupported unpack file type for file {outputpath}. " +
+                    f"Only {', '.join(UNPACK_FILE_EXTENSIONS)} are supported."
+                )
+        finally:
+            outputpath.unlink(missing_ok=True)
 
 
 async def _process_downloads(


### PR DESCRIPTION
Also make data transfer manifests more readable and restore empty string checking to refdata IDs in images, which was mistakenly removed