### PR TITLE
CDM-298: Add NERSC-side file cache in the JAWS staging area

### DIFF
--- a/cdmtaskservice/app.py
+++ b/cdmtaskservice/app.py
@@ -35,16 +35,11 @@ from cdmtaskservice.timestamp import utcdatetime
 from cdmtaskservice.exceptions import InvalidAuthHeaderError
 
 
-# TODO FEATURE nersc file caching:
-#                  * put files directly in jaws staging area
-#                  * cache via md5 or e tag of file to prevent duplicate downloads
-#                  * download temp file then move to standard location to prevent data corruption
 # TODO FEATURE cleanup files:
 #                  * jaws results
 #                  * refdata d/l manifest & result files in scratch
 #                  * various job files in scratch
 #                  * refdata jaws transfer notification files when implemented for lawrencium
-#                  * refdata tar / gz files post unpack
 #                  * refdata not associated with images, need to keep the refdata mongo doc
 #                       around since it's associdated with jobs, and could be used to restage
 # TODO FEATURE GPU support
@@ -188,7 +183,7 @@ def create_app():
         f"Server starting", extra={"version": VERSION, "git_commit": GIT_COMMIT}
     )
     with open(os.environ[_KB_DEPLOYMENT_CONFIG], "rb") as cfgfile:
-        cfg = CDMTaskServiceConfig(cfgfile)
+        cfg = CDMTaskServiceConfig(cfgfile, VERSION)
     cfg.print_config(sys.stdout)  # maybe should redo the service config in json...?
     sys.stdout.flush()
 

--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -15,7 +15,6 @@ from typing import NamedTuple
 
 from fastapi import FastAPI, Request
 from cdmtaskservice import logfields
-from cdmtaskservice import sites
 from cdmtaskservice.config import CDMTaskServiceConfig
 from cdmtaskservice.coroutine_manager import CoroutineWrangler
 from cdmtaskservice.image_remote_lookup import DockerImageInfo
@@ -36,7 +35,6 @@ from cdmtaskservice.refdata import Refdata
 from cdmtaskservice.s3.client import S3Client
 from cdmtaskservice.s3.paths import validate_path
 from cdmtaskservice.timestamp import utcdatetime
-from cdmtaskservice.version import VERSION
 
 # The main point of this module is to handle all the application state in one place
 # to keep it consistent and allow for refactoring without breaking other code
@@ -250,11 +248,10 @@ async def _build_NERSC_flow_deps(
         # TODO MULTICLUSTER service won't start if perlmutter is down, need to make it more dynamic
         nerscman = await NERSCManager.create(
             sfapi_client.get_client,
-            Path(cfg.nersc_remote_code_dir) / VERSION,
+            cfg.get_nersc_paths(),
             cfg.nersc_jaws_user,
             cfg.jaws_token,
             cfg.jaws_group,
-            Path(cfg.jaws_refdata_root_dir),
             service_group=cfg.service_group,
         )
         logr.info("Done")

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -250,12 +250,6 @@ class NERSCJAWSRunner(JobFlow):
             presigned = await self._s3ext.presign_get_urls(paths)
             callback_url = get_download_complete_callback(self._callback_root, job.id)
             # TODO PERF config / set concurrency
-            # TODO PERF CACHING if the same files are used for a different job they're d/ld again
-            #                   Instead d/l to a shared file location by etag or something
-            #                   Need to ensure atomic writes otherwise 2 processes trying to
-            #                   d/l the same file could corrupt it
-            #                   Either make cache in JAWS staging area, in which case files
-            #                   will be deleted automatically by JAWS, or need own file deletion
             # TODO DISKSPACE will need to clean up job downloads @ NERSC
             task_id = await self._nman.download_s3_files(
                 job.id, objmeta, presigned, callback_url, insecure_ssl=self._s3insecure

--- a/cdmtaskservice/nersc/paths.py
+++ b/cdmtaskservice/nersc/paths.py
@@ -1,0 +1,52 @@
+"""
+A data class for paths used by the NERSC manager.
+
+"""
+
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from cdmtaskservice.arg_checkers import require_string as _require_string
+
+
+def _validate_and_convert_path(value: str, field_name: str) -> Path:
+    path = Path(_require_string(value, "field_name"))
+    if not path.is_absolute():
+        raise ValueError(f"{field_name} must be an absolute path: got '{value}'")
+    return path.resolve()
+
+
+@dataclass(frozen=True)
+class NERSCPaths:
+    """ The set of configurable paths upon which the NERSC manager operates. """
+    
+    code_path: Path = field(init=False)
+    """The path in which to store remote code at NERSC. It is advised to
+    include version information in the path to avoid code conflicts.
+    """
+
+    jaws_refdata_root_dir: Path = field(init=False)
+    """The root directory for reference data configured for the JAWS 'kbase` site."""
+
+    jaws_staging_dir_dtns: Path = field(init=False)
+    """The JAWS staging directory for the `kbase` site on a NERSC DTN."""
+
+    jaws_staging_dir_perlmutter: Path = field(init=False)
+    """The JAWS staging directory for the `kbase` site on the NERSC Perlmutter system."""
+
+    def __init__(
+        self,
+        code_path: str,
+        jaws_refdata_root_dir: str,
+        jaws_staging_dir_dtns: str,
+        jaws_staging_dir_perlmutter: str
+    ):
+        fields = {
+            'code_path': code_path,
+            'jaws_refdata_root_dir': jaws_refdata_root_dir,
+            'jaws_staging_dir_dtns': jaws_staging_dir_dtns,
+            'jaws_staging_dir_perlmutter': jaws_staging_dir_perlmutter,
+        }
+        for name, value in fields.items():
+            path = _validate_and_convert_path(value, name)
+            object.__setattr__(self, name, path)  # bypass frozen

--- a/cdmtaskservice/s3/client.py
+++ b/cdmtaskservice/s3/client.py
@@ -26,7 +26,7 @@ _WRITE_TEST_FILENAME = (
 )
 
 
-class S3ObjectMeta:  # TODO CODE this could be a NamedTuple - what about __slots__?
+class S3ObjectMeta:
     """ Metadata about an object in S3 storage. """
     
     __slots__ = ["path", "e_tag", "size", "crc64nvme"]

--- a/cdmtaskservice/version.py
+++ b/cdmtaskservice/version.py
@@ -2,4 +2,4 @@
 The version of the KBase CDM task service software.
 '''
 
-VERSION = "0.1.0-prototype4"
+VERSION = "0.1.0-prototype5"

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -30,6 +30,23 @@ user = "{{ KBCTS_NERSC_JAWS_USER or "" }}"
 # The JAWS installation is expected to be configured to use this directory to look up refdata.
 refdata_root_dir = "{{ KBCTS_NERSC_JAWS_REFDATA_DIR or "" }}"
 
+# The JAWS site staging directory at NERSC on a Data Transfer Node.
+# Note that currently the CTS is hard coded to use the `kbase` site at NERSC Perlmutter.
+# This is typically something like
+# `/global/pscratch/sd/<JAWS site user first letter>/<JAWS site user>/<site>-prod/`
+jaws_staging_dir_dtn = "{{
+	 KBCTS_NERSC_JAWS_DTN_STAGING_DIR or "/global/pscratch/sd/k/kbjaws/kbase-prod/"
+ }}"
+
+# The JAWS site staging directory at NERSC on the Perlmutter system.
+# This is the equivalent directory to the DTN staging directory.
+# Note that currently the CTS is hard coded to use the `kbase` site at NERSC Perlmutter.
+# This is typically something like
+# `/pscratch/sd/<JAWS site user first letter>/<JAWS site user>/<site>-prod/`
+jaws_staging_dir_perlmutter = "{{
+	KBCTS_NERSC_JAWS_PERMUTTER_STAGING_DIR or "/pscratch/sd/k/kbjaws/kbase-prod/"
+}}"
+
 [NERSC]
 
 # The path to a NERSC Superfacility API (SFAPI) credential file. The file is expected to have

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -24,6 +24,8 @@ services:
       - KBCTS_HAS_NERSC_ACCOUNT_ROLE=HAS_NERSC_ACCOUNT
       - KBCTS_NERSC_JAWS_USER=cdm_ts
       - KBCTS_NERSC_JAWS_REFDATA_DIR=/global/dna/kbase/reference/jaws
+      - KBCTS_NERSC_JAWS_DTN_STAGING_DIR=/global/pscratch/sd/k/kbjaws/kbase-prod/
+      - KBCTS_NERSC_JAWS_PERMUTTER_STAGING_DIR=/pscratch/sd/k/kbjaws/kbase-prod/
       - KBCTS_SFAPI_CRED_PATH=/creds/sfapi_creds
       - KBCTS_NERSC_REMOTE_CODE_DIR=/global/cfs/cdirs/kbase/cdm_task_service
       - KBCTS_JAWS_URL=https://jaws-api.jgi.doe.gov/api/v2

--- a/test/nersc/nersc_paths_test.py
+++ b/test/nersc/nersc_paths_test.py
@@ -1,0 +1,7 @@
+# TODO TEST add tests
+
+from cdmtaskservice.nersc import paths  # @UnusedImport
+
+
+def test_noop():
+    pass


### PR DESCRIPTION
The PR does two things:

* Adds a file cache so the same file isn't downloaded multiple times
    * It's possible that if multiple jobs start downloading the same file at the same time multiple file downloads could occur, but fixing that would take a file lock, which means lock cleanup after fails, which adds a lot of complexity just to fix a rare event where the impact is just more IO
* Moves the file location into the JAWS staging area, which has 2 benefits
    * JAWS manages cache expiration
    * The JAWS client will no longer copy files into the staging area, saving some IO and time