### PR TITLE
CDM-278: Fix mongo refdata update bug

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -117,7 +117,6 @@ async def build_app(
         s3 = await S3Client.create(
             cfg.s3_url, cfg.s3_access_key, cfg.s3_access_secret, insecure_ssl=cfg.s3_allow_insecure
         )
-        logr.info("Done")
         s3_external = await S3Client.create(
             cfg.s3_external_url,
             cfg.s3_access_key,
@@ -125,6 +124,7 @@ async def build_app(
             insecure_ssl=cfg.s3_allow_insecure,
             skip_connection_check=not cfg.s3_verify_external_url
         )
+        logr.info("Done")
         await _check_paths(s3, logr, cfg)
         logr.info("Initializing MongoDB client...")
         mongocli = await get_mongo_client(cfg)

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -115,7 +115,7 @@ mongo_retrywrites = "{{ KBCTS_MONGO_RETRYWRITES or "" }}"
 
 # S3 paths where users are allowed to read / write job files, starting with the bucket.
 # Bucket only paths are allowed.
-# If omitted, users can read and write to any locations where the S3 can read and write
+# If omitted, users can read and write to any locations where the service can read and write
 # except for the log directory (configured below).
 # Paths may not be prefixes or suffixes of each other or the log directory.
 # To specify multiple paths, separate them with a comma. This means that commas


### PR DESCRIPTION
It seems as though the refdata update method wasn't reliable - it was working fine for a while, but today with no changes it started updating the wrong cluster. Updated the method to make it more explicit and modern about what subdocument it should be updating.