### PR TITLE
CDM-325: Refactor authentication to delay role checking

### DIFF
--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -144,7 +144,7 @@ class CDMTaskServiceConfig:
         # may want to allow service admins to override
         self.allowed_s3_paths = sorted({
             f"{p.rstrip('/')}/" for p in _get_list_string(config, _SEC_JOBS, "allowed_s3_paths")
-        }) or None
+        })
         self.container_s3_log_dir = _get_string_required(
             config, _SEC_JOBS, "container_s3_log_dir"
         ).rstrip("/") + "/"

--- a/cdmtaskservice/error_mapping.py
+++ b/cdmtaskservice/error_mapping.py
@@ -12,12 +12,13 @@ from cdmtaskservice.exceptions import (
     InvalidAuthHeaderError,
     InvalidJobStateError,
     InvalidReferenceDataStateError,
+    InvalidUserError,
     UnauthorizedError,
 )
 from cdmtaskservice.http_bearer import MissingTokenError
 from cdmtaskservice.images import NoEntrypointError
 from cdmtaskservice.image_remote_lookup import ImageNameParseError, ImageInfoFetchError
-from cdmtaskservice.kb_auth import InvalidTokenError, MissingRoleError, InvalidUserError
+from cdmtaskservice import kb_auth
 from cdmtaskservice.mongo import (
     ImageTagExistsError,
     ImageDigestExistsError,
@@ -53,9 +54,9 @@ class ErrorMapping(NamedTuple):
 _ERR_MAP = {
     MissingTokenError: ErrorMapping(ErrorType.NO_TOKEN, _H401),
     InvalidAuthHeaderError: ErrorMapping(ErrorType.INVALID_AUTH_HEADER, _H401),
-    InvalidTokenError: ErrorMapping(ErrorType.INVALID_TOKEN, _H401),
+    kb_auth.InvalidTokenError: ErrorMapping(ErrorType.INVALID_TOKEN, _H401),
+    kb_auth.InvalidUserError: ErrorMapping(ErrorType.INVALID_USERNAME, _H400),
     InvalidUserError: ErrorMapping(ErrorType.INVALID_USERNAME, _H400),
-    MissingRoleError: ErrorMapping(ErrorType.UNAUTHORIZED, _H403),
     UnauthorizedError: ErrorMapping(ErrorType.UNAUTHORIZED, _H403),
     ClientLifeTimeError: ErrorMapping(ErrorType.CLIENT_LIFETIME, _H400),
     S3BucketInaccessibleError: ErrorMapping(ErrorType.S3_BUCKET_INACCESSIBLE, _H403),

--- a/cdmtaskservice/exceptions.py
+++ b/cdmtaskservice/exceptions.py
@@ -25,3 +25,6 @@ class UnauthorizedError(Exception):
 
 class InvalidAuthHeaderError(Exception):
     """ An error thrown when an authorization header is invalid. """
+
+class InvalidUserError(Exception):
+    """ An error thrown when a provided user identifier is invalid. """

--- a/cdmtaskservice/http_bearer.py
+++ b/cdmtaskservice/http_bearer.py
@@ -11,7 +11,7 @@ from fastapi.security.http import HTTPBase
 from typing import Optional
 
 from cdmtaskservice import app_state
-from cdmtaskservice import kb_auth
+from cdmtaskservice.user import CTSUser
 
 # Modified from https://github.com/tiangolo/fastapi/blob/e13df8ee79d11ad8e338026d99b1dcdcb2261c9f/fastapi/security/http.py#L100
 # Basically the only reason for this class is to get the UI to work with auth.
@@ -38,12 +38,12 @@ class KBaseHTTPBearer(HTTPBase):
         self.scheme_name = scheme_name or self.__class__.__name__
         self.optional = optional
 
-    async def __call__(self, request: Request) -> kb_auth.KBaseUser:
+    async def __call__(self, request: Request) -> CTSUser:
         user = app_state.get_request_user(request)
         if not user and not self.optional:
             raise MissingTokenError("Authorization header required")
         return user
 
 
-class MissingTokenError(kb_auth.AuthenticationError):
+class MissingTokenError(Exception):
     """ An error thrown when a token is expected but not provided. """

--- a/cdmtaskservice/refdata.py
+++ b/cdmtaskservice/refdata.py
@@ -4,7 +4,6 @@ Manages refdata at remote sites.
 
 import uuid
 
-from cdmtaskservice import kb_auth
 from cdmtaskservice import models
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy, require_string as _require_string
 from cdmtaskservice.coroutine_manager import CoroutineWrangler
@@ -15,6 +14,7 @@ from cdmtaskservice.s3.client import S3Client
 from cdmtaskservice.s3.paths import S3Paths, validate_path
 from cdmtaskservice.s3.remote import UNPACK_FILE_EXTENSIONS
 from cdmtaskservice.timestamp import utcdatetime
+from cdmtaskservice.user import CTSUser
 
 
 class Refdata:
@@ -45,7 +45,7 @@ class Refdata:
     async def create_refdata(
         self,
         s3_path: str,
-        user: kb_auth.KBaseUser,
+        user: CTSUser,
         crc64nvme: str = None,
         unpack: bool = False
     ) -> models.ReferenceData:

--- a/cdmtaskservice/user.py
+++ b/cdmtaskservice/user.py
@@ -1,0 +1,105 @@
+"""
+Classes for dealing with CTS users.
+"""
+
+from dataclasses import dataclass, field
+from enum import Enum
+
+from cdmtaskservice.arg_checkers import not_falsy as _not_falsy, require_string
+from cdmtaskservice.kb_auth import KBaseAuth
+from cdmtaskservice.exceptions import UnauthorizedError
+
+
+class CTSRole(str, Enum):
+    """ A role for the service a user may possess. """
+    
+    FULL_ADMIN = "full_admin"
+    # add roles as needed
+
+
+@dataclass(frozen=True)
+class CTSUser:
+    """
+    Represents a user of the CTS system.
+
+    Attributes:
+        user - the name of the user.
+        roles - the set of roles assigned to the user.
+        is_kbase_staff - whether the user is a KBase staff member.
+        has_nersc_account - whether the user has a NERSC account.
+    """
+    user: str
+    roles: frozenset[CTSRole] = field(default_factory=frozenset)
+    is_kbase_staff: bool = False
+    has_nersc_account: bool = False
+
+    def __post_init__(self):
+        # Convert roles to frozenset if it isn't one already
+        if not isinstance(self.roles, frozenset):
+            object.__setattr__(self, 'roles', frozenset(self.roles))
+        # TODO CODE check args aren't None. Creating class here so YAGNI for now
+
+    def is_full_admin(self):
+        """ Returns true if the user is a service admin with full rights to everything. """
+        return CTSRole.FULL_ADMIN in self.roles
+
+
+# Illegal user name in kbase and hopefully everywhere else
+SERVICE_USER = CTSUser(user="**** SERVICE ****")
+
+
+class CTSAuth:
+    """ An authentication class for the CTS. """
+    
+    def __init__(
+            self,
+            kbaseauth: KBaseAuth,
+            service_admin_roles: set[str],
+            is_kbase_staff_role: str,
+            has_nersc_account_role: str,
+    ):
+        """
+        Create the auth client.
+        
+        kbaseauth - a KBase authentication client.
+        service_admin_roles - KBase auth roles that designates that a user is a service admin
+            with full rights to everything.
+        is_kbase_staff_role - a KBase auth role that designates that a user is a KBase staff
+            member.
+        has_nersc_account_role - a KBase auth role that designates that a user has a NERSC
+            account.
+        """
+        # In the future this mey need changes to support other auth sources...?
+        self._kbauth = _not_falsy(kbaseauth, "kbaseauth")
+        # TODO CODE check contents are non-whitespace only strings
+        self._admin_roles = _not_falsy(service_admin_roles, "service_admin_roles")
+        self._kbstaff_role = require_string(is_kbase_staff_role, "is_kbase_staff_role")
+        self._nersc_role = require_string(has_nersc_account_role, "has_nersc_account_role")
+
+
+    async def is_valid_kbase_user(self, user: str, token: str) -> bool:
+        """
+        Check if a user name is valid in the KBase auth service.
+        
+        user - the user name to check.
+        token - a token to provide to the auth service to allow accessing the lookup endpoint.
+        
+        Throws an exception if the user name is illegally formatted.
+        """
+        # passthrough method
+        return await self._kbauth.is_valid_user(user, token)
+
+    async def get_kbase_user(self, token: str) -> CTSUser:
+        """ Get a CTS user given a KBase token. """
+        # this will def need rethinking if we ever support more auth sources
+        user = await self._kbauth.get_user(token)
+        user = CTSUser(
+            user=user.user,
+            roles={CTSRole.FULL_ADMIN} if user.roles & self._admin_roles else {},
+            is_kbase_staff=self._kbstaff_role in user.roles,
+            has_nersc_account=self._nersc_role in user.roles,
+        )
+        # ensure admins have all roles necessary to use any part of the system
+        if user.is_full_admin() and (not user.is_kbase_staff or not user.has_nersc_account):
+            raise UnauthorizedError("Service admins must be KBase staff and have NERSC accounts")
+        return user

--- a/test/user_test.py
+++ b/test/user_test.py
@@ -1,0 +1,7 @@
+# TODO TEST add tests
+
+from cdmtaskservice import user  # @UnusedImport
+
+
+def test_noop():
+    pass


### PR DESCRIPTION
... until a job flow is determined, since different flows may require different roles (e.g. the upcoming KBase H/W job flow)

Also mostly isolate the KBase auth client from the rest of the service so that if it ever becomes pip installable it can be easily refactored out