### PR TITLE
CDM-345: Add the kbase job flow preflight method.

### DIFF
--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -244,7 +244,7 @@ class CDMTaskServiceConfig:
             f"JAWS group: {self.jaws_group}",
             f"HTCondor exe path: {self.condor_exe_path}",
             f"HTCondor exe url override: {self.condor_exe_url_override}",
-            f"HTCondor intialdir: {self.condor_initialdir}",
+            f"HTCondor initialdir: {self.condor_initialdir}",
             f"HTCondor client group: {self.condor_clientgroup}",
             f"Code archive path: {self.code_archive_path}",
             f"Code archive url override: {self.code_archive_url_override}",

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -107,11 +107,6 @@ class NERSCJAWSRunner(JobFlow):
         self._callback_root = _require_string(service_root_url, "service_root_url")
         self._on_refdata_complete = on_refdata_complete
     
-    @classmethod
-    def get_cluster(cls) -> sites.Cluster:
-        """ Get the cluster on which this job flow manager operates. """
-        return cls.CLUSTER
-    
     async def _handle_exception(
         self, e: Exception, entity_id: str, errtype: str, refdata: bool = False
     ):
@@ -209,12 +204,13 @@ class NERSCJAWSRunner(JobFlow):
             self.CLUSTER, refdata_id, update, timestamp.utcdatetime()
         )
 
-    def precheck(self, user: CTSUser, job_input: models.JobInput):
+    async def preflight(self, user: CTSUser, job_id: str, job_input: models.JobInput):
         """
         Check that the inputs to a job are acceptable prior to running a job. Will throw an
         error if the inputs don't meet requirements.
         
         user - the user running the job.
+        job_id - the job's ID.
         job_input - the job input.
         """
         _not_falsy(user, "user")


### PR DESCRIPTION
Checks the user is kbase staff and sets up the subjobs after all the other checks are complete and the only thing left to do is save the main job document.

Also removes an unused method from the NERSC job flows.