### PR TITLE
Fix Image de/serialization in mongo

### DIFF
--- a/cdmtaskservice/kb_auth.py
+++ b/cdmtaskservice/kb_auth.py
@@ -102,8 +102,7 @@ class KBaseAuth:
 
     async def get_user(self, token: str) -> KBaseUser:
         """
-        Get a username from a token as well as the user's administration status.
-        Verifies the user has all the required roles set in the create() method.
+        Get a username from a token as well as the user's custom roles.
         
         token - The user's token.
         

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -10,6 +10,7 @@ from pydantic import (
     ConfigDict,
     conlist,
     Field,
+    field_serializer,
     field_validator,
     HttpUrl,
     model_validator,
@@ -762,6 +763,12 @@ class ImageUsage(BaseModel):
             + "suggested but not required.",
         max_length=10000,
     )] = None
+    
+    @field_serializer("urls")
+    def serialize_urls(self, urls: list[HttpUrl]) -> list[str] | None:
+        if not urls:
+            return None
+        return [str(u) for u in urls]
 
 
 class Image(ImageUsage, JobImage):
@@ -956,6 +963,7 @@ class AdminJobStateTransition(JobStateTransition):
         description="Whether an update has been sent to the notification system for "
         + "this state transition."
     )]
+
 
 class AdminJobDetails(Job):
     """

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -178,7 +178,7 @@ class MongoDAO:
         """
         _not_falsy(image, "image")
         try:
-            await self._col_images.insert_one(image.model_dump(mode="json"))
+            await self._col_images.insert_one(image.model_dump())
         except DuplicateKeyError as e:
             if _INDEX_TAG in e.args[0]:
                 raise ImageTagExistsError(f"The tag {image.tag} for image {image.name} "
@@ -208,7 +208,7 @@ class MongoDAO:
         return self._to_image(doc)
     
     def _to_image(self, doc: dict[str, Any]) -> models.Image:
-        return models.Image.model_construct(**self._clean_doc(doc))
+        return models.Image.model_validate(self._clean_doc(doc))
 
     async def get_images(self) -> list[models.Image]:
         """


### PR DESCRIPTION
`mode="json"` is the wrong way to go since it serializes datetimes to strings, which we don't want. Instead make a custom serializer for HttpUrls, which was causing mongo to choke.

Similarly, use model_validate instead of model_construct so that the strings are turned into HttpUrls correctly.

Also a minor doc fix