### PR TITLE
CDM-346: Disallow manifest files for the kbase job flow

### DIFF
--- a/cdmtaskservice/error_mapping.py
+++ b/cdmtaskservice/error_mapping.py
@@ -14,12 +14,13 @@ from cdmtaskservice.exceptions import (
     InvalidReferenceDataStateError,
     InvalidUserError,
     UnauthorizedError,
-    UnavailableJobFlowError,
     UnavailableResourceError,
+    UnsupportedOperationError,
 )
 from cdmtaskservice.http_bearer import MissingTokenError
 from cdmtaskservice.images import NoEntrypointError
 from cdmtaskservice.image_remote_lookup import ImageNameParseError, ImageInfoFetchError
+from cdmtaskservice.jobflows.flowmanager import InactiveJobFlowError, UnavailableJobFlowError
 from cdmtaskservice import kb_auth
 from cdmtaskservice.mongo import (
     ImageTagExistsError,
@@ -38,7 +39,6 @@ from cdmtaskservice.s3.client import (
     S3PathNotFoundError,
 )
 from cdmtaskservice.s3.paths import S3PathSyntaxError
-from cdmtaskservice.jobflows.flowmanager import InactiveJobFlowError
 
 _H400 = status.HTTP_400_BAD_REQUEST
 _H401 = status.HTTP_401_UNAUTHORIZED
@@ -84,6 +84,7 @@ _ERR_MAP = {
     InactiveJobFlowError: ErrorMapping(ErrorType.JOB_FLOW_INACTIVE, _H400),
     UnavailableJobFlowError: ErrorMapping(ErrorType.JOB_FLOW_UNAVAILABLE, _H400),
     IllegalParameterError: ErrorMapping(ErrorType.ILLEGAL_PARAMETER, _H400),
+    UnsupportedOperationError: ErrorMapping(ErrorType.UNSUPPORTED_OP, _H400),
 }
 
 

--- a/cdmtaskservice/exceptions.py
+++ b/cdmtaskservice/exceptions.py
@@ -35,8 +35,5 @@ class UnavailableResourceError(Exception):
     """ An error thrown when a resouce is unavailable. """
 
 
-class UnavailableJobFlowError(Exception):
-    """
-    An error thrown when a job flow cannot be used due to unavailable resources or
-    startup errors.
-    """
+class UnsupportedOperationError(Exception):
+    """ An error thrown when an unsupported operation is requested. """

--- a/cdmtaskservice/jobflows/flowmanager.py
+++ b/cdmtaskservice/jobflows/flowmanager.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass
 from typing import Awaitable, Callable
 
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy
-from cdmtaskservice.exceptions import UnavailableJobFlowError
 from cdmtaskservice.mongo import MongoDAO
 from cdmtaskservice import sites
 
@@ -66,7 +65,9 @@ class JobFlowManager():
                 )
             return floworerr.jobflow
         else:
-            raise ValueError(f"Job flow for cluster {cluster.value} is not registered")
+            raise UnavailableJobFlowError(
+                f"Job flow for cluster {cluster.value} is not registered"
+            )
     
     async def list_available_clusters(self) -> set[sites.Cluster]:
         """
@@ -107,5 +108,13 @@ class JobFlowManager():
         """
         await self._mongo.set_site_inactive(_not_falsy(cluster, "cluster"))
 
+
 class InactiveJobFlowError(Exception):
     """ Thrown when an inactive job flow is requested. """ 
+
+
+class UnavailableJobFlowError(Exception):
+    """
+    An error thrown when a job flow cannot be used due to unavailable resources or
+    startup errors.
+    """

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -19,6 +19,7 @@ from cdmtaskservice.exceptions import (
     UnauthorizedError,
     InvalidJobStateError,
     InvalidReferenceDataStateError,
+    UnsupportedOperationError,
 )
 from cdmtaskservice.jobflows.flowmanager import JobFlow, JobFlowOrError
 from cdmtaskservice.jobflows.s3config import S3Config
@@ -85,6 +86,11 @@ class KBaseRunner(JobFlow):
         if not user.is_kbase_staff:
             raise UnauthorizedError(
                 f"To use the {self.CLUSTER.value} site, you must be a KBase staff member."
+            )
+        param = job_input.params.get_file_parameter()
+        if param and param.type is models.ParameterType.MANIFEST_FILE:
+            raise UnsupportedOperationError(  # Implement if requested by users
+                f"Manifest files are not currently supported for the {self.CLUSTER.value} job flow"
             )
         update_time = utcdatetime()
         # It's possible but unlikely that we'll save these subjobs and then the main job
@@ -166,25 +172,25 @@ class KBaseRunner(JobFlow):
 
     async def download_complete(self, job: models.AdminJobDetails):
         """ Throws an exception as this method is not supported. """
-        raise UnauthorizedError(
+        raise UnsupportedOperationError(
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
         
     async def job_complete(self, job: models.AdminJobDetails):
         """ Throws an exception as this method is not supported. """
-        raise UnauthorizedError(
+        raise UnsupportedOperationError(
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
         
     async def upload_complete(self, job: models.AdminJobDetails):
         """ Throws an exception as this method is not supported. """
-        raise UnauthorizedError(
+        raise UnsupportedOperationError(
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
     
     async def error_log_upload_complete(self, job: models.AdminJobDetails):
         """ Throws an exception as this method is not supported. """
-        raise UnauthorizedError(
+        raise UnsupportedOperationError(
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
         

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -239,7 +239,8 @@ class SubmitJobResponse(BaseModel):
     "/",
     response_model=SubmitJobResponse,
     summary="Submit a job",
-    description="Submit a job to the system."
+    description="Submit a job to the system.\n\n"
+        + "Note that currently the kbase job flow does not support manifest files."
 )
 async def submit_job(
     r: Request,


### PR DESCRIPTION
... for now. I suspect there's not going to be much call for them; implement when people actually want them.

Also some exception cleanup around the job flow manager.