### PR TITLE
CDM-346: Determine files per container and local locations

### DIFF
--- a/cdmtaskservice/externalexecution/main.py
+++ b/cdmtaskservice/externalexecution/main.py
@@ -7,4 +7,4 @@ from cdmtaskservice.externalexecution.executor import run_executor
 
 
 if __name__ == "__main__":
-    asyncio.run(run_executor(sys.stdout, sys.stderr))  # allow testing via replacing streams
+    asyncio.run(run_executor(sys.stderr))  # allow testing via replacing streams


### PR DESCRIPTION
Tested with and without `input_roots` set in the job_input