### PR TITLE
Include unavailable reason in sites endpoint

### DIFF
--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -23,7 +23,7 @@ logging.basicConfig(level=logging.INFO)
 
 
 class Executor:
-    """ The executor. """
+    """ The executor. Note that the executor is not concurrency safe. """
     
     def __init__(self, cfg: Config):
         """ Create the executor from the configuration. """


### PR DESCRIPTION
Eases debugging startup issues for sites.

Also don't list sites that aren't registered in the flow manager at all.