### PR TITLE
CDM-378: Transfer container logs back to SCHEDD

### DIFF
--- a/cdmtaskservice/condor/run_job.sh
+++ b/cdmtaskservice/condor/run_job.sh
@@ -23,12 +23,6 @@ echo "PATH=$PATH"
 echo "PWD=$PWD"
 
 ###
-# For some reason setting transfer_output_files to the empty string isn't working. We touch
-# an empty file so that job output doesn't get transferred.
-###
-touch __DUMMY_OUTPUT__
-
-###
 # Put pip and uv on the path, since they're installed for the user only
 ###
 export PATH=$HOME/.local/bin:$PATH


### PR DESCRIPTION
Debugging purposes, otherwise the logs are deleted