### PR TITLE
CDM-378: Remove Condor output remaps

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -178,8 +178,6 @@ class CondorClient:
             "error": f"cts-{job.id}-$(container_number).err",
             "log": f"cts-{job.id}-$(container_number).log",
             "transfer_output_files": f"{logprefix}.out, {logprefix}.err",
-            "transfer_output_remaps": f"{logprefix}.out = cts/{job.id}/{logprefix}.out; "
-                + f"{logprefix}.err = cts/{job.id}/{logprefix}.err",
             "request_cpus": str(job.job_input.cpus),
             "request_memory": mem,
             # request_disk needed?


### PR DESCRIPTION
Doesn't seem to work in older versions of condor:

```
failed to write to file
/condor_shared/cts/ci/cts/634f5e67-240f-422e-bf2f-8c3653feae5f/container_log_634f5e67-240f-422e-bf2f-8c3653feae5f-1.out:
(errno 2) No such file or directory
```