### PR TITLE
CDM-378: Add more wdl tests and protections

### DIFF
--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -16,6 +16,7 @@ from pydantic import (
     model_validator,
     StringConstraints,
 )
+import re
 from typing import Annotated, Self
 
 from cdmtaskservice.arg_checkers import (
@@ -81,7 +82,9 @@ CRC64NVME_B64ENC_LENGTH=12
 
 # https://en.wikipedia.org/wiki/Filename#Comparison_of_filename_limitations
 # POSIX fully portable filenames
+PATH_REGEX = r"^/?(?:[\w.-]+/)*[\w.-]+/?$"
 ABSOLUTE_PATH_REGEX = r"^/(?:[\w.-]+/)*[\w.-]+/?$"
+PATH_REGEX_COMPILED = re.compile(PATH_REGEX)
 
 
 def _validate_bucket_name(bucket: str, index: int = None) -> str:


### PR DESCRIPTION
Lock down the nanifest file paths and local NERSC file paths. Since the service is in control of those this is safe. Manifest file paths are just manifest-n while the local file paths are just the jaws cache prefix plus some hex characters for checksum based caching

Add more tests around quoting S3 filenames, which are out of control of the service and can contain anything (sigh)