### PR TITLE
CDM-379: Add methods to get container exit codes

### DIFF
--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -64,7 +64,7 @@ class Executor:
             self._args = ArgumentGenerator(job).get_container_arguments(self._cfg.container_number)
             await self._download_files(job)
             await self._update_job_state_loop(job, models.JobState.JOB_SUBMITTING)
-            exit_code = await self._run_container(job)
+            exit_code = await self._run_container(job)  # updates to JOB_SUBMITTED
             if exit_code > 0:
                 await self._update_job_state_loop(
                     job, models.JobState.ERROR_PROCESSING_SUBMITTING, exit_code=exit_code

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -137,6 +137,12 @@ class KBaseRunner(JobFlow):
             return await self._mongo.get_subjob(job_id, container_num)
         return await self._mongo.get_subjobs(job_id)
 
+    async def get_exit_codes(self, job: models.Job) -> list[int | None]:
+        """
+        Get the exit codes of the containers / subjobs for a job.
+        """
+        return await self._mongo.get_exit_codes_for_subjobs(_not_falsy(job, "job").id)
+
     async def get_job_external_runner_status(
         self,
         job: models.AdminJobDetails,

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -166,6 +166,13 @@ class NERSCJAWSRunner(JobFlow):
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
 
+    async def get_exit_codes(self, job: models.Job) -> list[int | None]:
+        """
+        Get the exit codes of the containers / subjobs for a job.
+        """
+        ecs = await self._mongo.get_exit_codes_for_standard_job(_not_falsy(job, "job").id)
+        return ecs if ecs else [None] * job.job_input.num_containers
+
     async def get_job_external_runner_status(
         self,
         job: models.AdminJobDetails,


### PR DESCRIPTION
Can't test the JAWS exit code saving code since JAWS is not running jobs correctly at the moment, will add later