### PR TITLE
CDM-403: Push output files from Condor to S3

### DIFF
--- a/cdmtaskservice/externalexecution/main.py
+++ b/cdmtaskservice/externalexecution/main.py
@@ -4,9 +4,11 @@ import asyncio
 import sys
 
 from cdmtaskservice.externalexecution.executor import run_executor
+import logging
 
 
 if __name__ == "__main__":
+    logging.basicConfig(level=logging.INFO)
     res = asyncio.run(run_executor(sys.stderr))  # allow testing via replacing streams
     if not res:
         sys.exit(1)


### PR DESCRIPTION
Also fix a bug where the job would fail to error out correctly if the condor job failed, since jobs are held indefinitely which counds as running since they stay in the queue