### PR TITLE
CDM-403: Push s3 file paths and CRCs to the service from Condor

### DIFF
--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -851,6 +851,9 @@ class SubJob(_JobBase):
         examples=[0, 255],
         description="The container exit code, if available."
     )] = None
+    outputs: Annotated[list[S3File] | None, Field(
+        description="The files produced by the container stored in S3, if available."
+    )] = None
     admin_error: Annotated[str | None, Field(
         examples=["The back fell off"],
         description="A description of the error that occurred oriented towards service "
@@ -1039,10 +1042,6 @@ class AdminJobDetails(Job):
 
 class ContainerUpdate(BaseModel):
     
-    new_state: Annotated[JobState, Field(
-        examples=[JobState.JOB_SUBMITTED.value],
-        description="The new state for the container / subjob."
-    )]
     time: Annotated[datetime.datetime, Field(
         examples=[utcdatetime()],
         description="The time the state transition occurred."
@@ -1051,6 +1050,10 @@ class ContainerUpdate(BaseModel):
         examples=[0, 255],
         description="The container exit code. Ignored if the new state isn't "
             + "error processing submitting or upload submitting."
+    )] = None
+    outputs: Annotated[list[S3File] | None, Field(
+        description="The files produced by the container stored in S3. Ignored if the new state "
+            + "isn't job complete."
     )] = None
     admin_error: Annotated[str | None, Field(
         examples=["The top fell off"],

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -1069,7 +1069,7 @@ async def _callback_handling(
 
 
 @ROUTER_EXTERNAL_EXEC.put(
-    "/external_exec/{job_id}/container/{container_num}/update",
+    "/external_exec/{job_id}/container/{container_num}/update/{new_state}",
     status_code=status.HTTP_204_NO_CONTENT,
     response_class=Response,
     summary="Update a container's state.",
@@ -1079,6 +1079,10 @@ async def update_container(
     r: Request,
     job_id: _ANN_JOB_ID,
     container_num: _ANN_CONTAINER_NUMBER,
+    new_state: Annotated[models.JobState, FastPath(
+        openapi_examples={"job_submitted": {"value": models.JobState.JOB_SUBMITTED}},
+        description="The new state for the container / subjob.",
+    )],
     update: models.ContainerUpdate,
     user: CTSUser=Depends(_AUTH),
 ):
@@ -1086,7 +1090,7 @@ async def update_container(
     appstate = app_state.get_app_state(r)
     job = await appstate.job_state.get_job(job_id, user, as_admin=True)
     flow =  await appstate.jobflow_manager.get_flow(job.job_input.cluster)
-    await flow.update_container_state(job, container_num, update)
+    await flow.update_container_state(job, container_num, new_state, update)
 
 
 @ROUTER_EXTERNAL_EXEC.get(


### PR DESCRIPTION
Also:

* Add the new state to the container update route. Makes the url and logs more indicative of what's happening.
* Fix a bug where if no containers were held when a job completed get_condor_stats would throw a ValueError.
* Fix a bug where container specific exit codes and errors were being set on the main job.
* Add the condor stats to the complete state generation function for future use.