### PR TITLE
Don't require JAWS api version specification by the user

### DIFF
--- a/cdmtaskservice/jaws/client.py
+++ b/cdmtaskservice/jaws/client.py
@@ -63,6 +63,7 @@ class JAWSClient:
         url = _require_string(url, "url")
         if not url.endswith("/"):
             url += "/"
+        url += "api/v2/"
         self._sess = aiohttp.ClientSession(
             base_url=url,
             headers={"Authorization": f"Bearer {_require_string(token, 'token')}"}

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -70,7 +70,7 @@ remote_code_dir = "{{ KBCTS_NERSC_REMOTE_CODE_DIR or "/global/cfs/cdirs/kbase/cd
 [JAWS]
 
 # The JAWS Central server URL.
-url = "{{ KBCTS_JAWS_URL or "https://jaws-api.jgi.doe.gov/api/v2" }}"
+url = "{{ KBCTS_JAWS_URL or "https://jaws-api.jgi.doe.gov/" }}"
 
 # The JGI JAWS token to use to run jobs. This can be obtained from a JAWS representative.
 # Note that all the services in a service group (see the Services block) should have the same

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -38,7 +38,7 @@ services:
       - KBCTS_NERSC_JAWS_PERMUTTER_STAGING_DIR=/pscratch/sd/k/kbjaws/kbase-prod/
       - KBCTS_SFAPI_CRED_PATH=/creds/sfapi_creds
       - KBCTS_NERSC_REMOTE_CODE_DIR=/global/cfs/cdirs/kbase/cdm_task_service
-      - KBCTS_JAWS_URL=https://jaws-api.jgi.doe.gov/api/v2
+      - KBCTS_JAWS_URL=https://jaws-api.jgi.doe.gov/
       # Don't commit your token to github please
       - KBCTS_JAWS_TOKEN=dont_check_tokens_into_vcs_please
       - KBCTS_JAWS_GROUP=kbase


### PR DESCRIPTION
Client should choose version