### PR TITLE
Refactor resource destruction on app exit or startup error

### DIFF
--- a/cdmtaskservice/app.py
+++ b/cdmtaskservice/app.py
@@ -182,10 +182,8 @@ def create_app():
     """
     Create the CDM task service application
     """
-
-    logging.getLogger(__name__).info(
-        f"Server starting", extra={"version": VERSION, "git_commit": GIT_COMMIT}
-    )
+    logr = logging.getLogger(__name__)
+    logr.info(f"Server starting", extra={"version": VERSION, "git_commit": GIT_COMMIT})
     with open(os.environ[_KB_DEPLOYMENT_CONFIG], "rb") as cfgfile:
         cfg = CDMTaskServiceConfig(cfgfile, VERSION)
     cfg.print_config(sys.stdout)  # maybe should redo the service config in json...?
@@ -218,10 +216,12 @@ def create_app():
     app.include_router(routes.ROUTER_EXTERNAL_EXEC)
 
     async def build_app_wrapper():
+        logr.info("Running app state build")
         await app_state.build_app(app, cfg, SERVICE_NAME)
     app.add_event_handler("startup", build_app_wrapper)
 
     async def clean_app_wrapper():
+        logr.info("Running app state destroy")
         await app_state.destroy_app_state(app)
     app.add_event_handler("shutdown", clean_app_wrapper)
     
@@ -232,10 +232,8 @@ def create_refdata_app():
     """
     Create the CDM refdata service application
     """
-
-    logging.getLogger(__name__).info(
-        f"Refdata server starting", extra={"version": VERSION, "git_commit": GIT_COMMIT}
-    )
+    logr = logging.getLogger(__name__)
+    logr.info(f"Refdata server starting", extra={"version": VERSION, "git_commit": GIT_COMMIT})
     with open(os.environ[_KB_DEPLOYMENT_CONFIG], "rb") as cfgfile:
         cfg = CDMRefdataServiceConfig(cfgfile)
     cfg.print_config(sys.stdout)  # maybe should redo the service config in json...?
@@ -262,10 +260,12 @@ def create_refdata_app():
     app.include_router(refroutes.ROUTER_REFDATA)
 
     async def build_app_wrapper():
+        logr.info("Running app state build")
         await app_state.build_refdata_app(app, cfg, REFDATA_SERVICE_NAME)
     app.add_event_handler("startup", build_app_wrapper)
 
     async def clean_app_wrapper():
+        logr.info("Running app state destroy")
         await app_state.destroy_app_state(app)
     app.add_event_handler("shutdown", clean_app_wrapper)
     

--- a/cdmtaskservice/resource_destructor.py
+++ b/cdmtaskservice/resource_destructor.py
@@ -1,0 +1,41 @@
+"""
+Class to manage resources that need to be destroyed on shutdown or error.
+"""
+
+import logging
+from typing import Awaitable, Callable
+
+from cdmtaskservice.arg_checkers import require_string as _require_string, not_falsy as _not_falsy
+import asyncio
+
+
+class ResourceDestructor:
+    """
+    Register and destroy resources.
+    """
+    
+    def __init__(self):
+        """ Create the resource destructor. """
+        self._resources = []  # allow resources with the same name
+    
+    def register(self, name: str, destructor: Awaitable | Callable[[], None]):
+        """
+        Register a resource for eventual destruction.
+        
+        name - the name of the resource for logging purposes.
+        destructor - a sync function to be called or an aysnc awaitable to awaited to destroy
+            the resource.
+        """
+        self._resources.append(
+            (_require_string(name, "name"), _not_falsy(destructor, "destructor"))
+        )
+    
+    async def destruct(self):
+        # don't worry about multiple calls for now, add fixes if needed later
+        logr = logging.getLogger(__name__)
+        for name, destructor in self._resources:
+            logr.info(f"Destroying {name}")
+            if asyncio.iscoroutine(destructor):
+                await destructor
+            else:
+                destructor()

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -22,4 +22,7 @@ PORT=${KBCTS_PORT:-5000}
 # and scaling via adding more containers. If we need to run multiple processes, use guvicorn as
 # a process manager as described in the FastAPI docs
 # https://fastapi.tiangolo.com/deployment/docker/#replication-number-of-processes
-uvicorn --host 0.0.0.0 --port "$PORT" --factory $APP_FACTORY
+
+# exec so that tini properly forwards signals directly to uvicorn without bash getting its
+# greasy mitts in the way
+exec uvicorn --host 0.0.0.0 --port "$PORT" --factory $APP_FACTORY

--- a/test/resource_destructor_test.py
+++ b/test/resource_destructor_test.py
@@ -1,0 +1,7 @@
+# TODO TEST add tests
+
+from cdmtaskservice import resource_destructor  # @UnusedImport
+
+
+def test_noop():
+    pass


### PR DESCRIPTION
Was getting way too confusing and easy to miss stuff (and stuff was missed). Now just register the resource right after creating it and appropriate destruction is guaranteed; shouldn't have to debug annoying unclosed resource warnings with no line numbers