### PR TITLE
make auth roles consistent as bools vs CTSRoles

### DIFF
--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -61,7 +61,7 @@ def _ensure_admin(user: CTSUser, err_msg: str):
 
 
 def _ensure_executor(user: CTSUser, err_msg: str):
-    if not user.is_external_executor():
+    if not user.is_external_executor:
         raise UnauthorizedError(err_msg)
 
 
@@ -71,7 +71,7 @@ def _ensure_refdata_service(user: CTSUser, err_msg: str):
 
 
 def _ensure_admin_or_executor(user: CTSUser, err_msg: str):
-    if not user.is_full_admin() and not user.is_external_executor():
+    if not user.is_full_admin() and not user.is_external_executor:
         raise UnauthorizedError(err_msg)
 
 


### PR DESCRIPTION
While figuring out how auth roles should be presented to users and modeled internally, at least make the external executor role a bool like the other non-user roles.