### PR TITLE
CDM-86: Cancel jobs part 1

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -356,7 +356,9 @@ def get_app_state(r: Request) -> AppState:
     """
     Get the application state from a request.
     """
-    return _get_app_state_from_app(r.app)
+    if not r.app.state._cdmstate:
+        raise ValueError("App state has not been initialized")
+    return r.app.state._cdmstate
 
 
 async def destroy_app_state(app: FastAPI):
@@ -366,12 +368,6 @@ async def destroy_app_state(app: FastAPI):
     await app.state._destroyable.destruct()
     # https://docs.aiohttp.org/en/stable/client_advanced.html#graceful-shutdown
     await asyncio.sleep(0.250)
-
-
-def _get_app_state_from_app(app: FastAPI) -> AppState:
-    if not app.state._cdmstate:
-        raise ValueError("App state has not been initialized")
-    return app.state._cdmstate
 
 
 def set_request_user(r: Request, user: CTSUser | None, token: str | None):

--- a/cdmtaskservice/condor/run_job.sh
+++ b/cdmtaskservice/condor/run_job.sh
@@ -81,4 +81,4 @@ echo "Python version: $(uv run python --version)"
 
 export PYTHONPATH=.
 
-uv run python cdmtaskservice/externalexecution/main.py
+exec uv run python cdmtaskservice/externalexecution/main.py

--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+import sys
 import time
 import traceback
 from typing import TextIO, Any
@@ -256,7 +257,8 @@ Local relative path: {loc}
             mounts=mounts,
             command=self._args.args,
             env=self._args.env,
-            post_start_callback=self._update_job_state_loop(job, models.JobState.JOB_SUBMITTED)
+            post_start_callback=self._update_job_state_loop(job, models.JobState.JOB_SUBMITTED),
+            sigterm_callback=lambda signum: sys.exit(128 + signum)
         )
         self._logr.info(f"Container exited with code {exit_code}")
         return exit_code

--- a/cdmtaskservice/jaws/client.py
+++ b/cdmtaskservice/jaws/client.py
@@ -131,7 +131,6 @@ class JAWSClient:
             self._logr.info(f"JAWS job {run_id} is already canceled - noop")
             # do nothing
         except aiohttp.client_exceptions.ClientResponseError as e:
-            # TODO JAWS handle 400 when job is already cancelled
             if e.status == 404:
                 raise NoSuchJAWSJobError(run_id) from e
             raise

--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -235,7 +235,8 @@ class JobState:
         self,
         job_id: str,
         user: CTSUser,
-        as_admin: bool = False
+        as_admin: bool = False,
+        admin_details: bool = False,
     ) -> models.Job | models.AdminJobDetails:
         """
         Get a job based on its ID. If the provided user doesn't match the job's owner,
@@ -245,9 +246,13 @@ class JobState:
         user - the user requesting the job.
         as_admin - True if the user should always have access to the job and should access
             additional job details.
+        admin_details - True if the user should access additional job details, but not have
+            special access to the job.
         """
         _not_falsy(user, "user")
-        job = await self._mongo.get_job(_require_string(job_id, "job_id"), as_admin=as_admin)
+        job = await self._mongo.get_job(
+            _require_string(job_id, "job_id"), as_admin=as_admin or admin_details
+        )
         if not as_admin and job.user != user.user:
             # reveals the job ID exists in the system but I don't see a problem with that
             raise UnauthorizedError(f"User {user.user} may not access job {job_id}")

--- a/cdmtaskservice/jobflows/state_updates.py
+++ b/cdmtaskservice/jobflows/state_updates.py
@@ -105,7 +105,7 @@ class JobFlowStateUpdates:
         
         job_id - the job to update.
         update - the update to apply.
-        update_time - the timestamp for the update
+        update_time - the timestamp for the update, defaulting to now.
         """
         _require_string(job_id, "job_id")
         _not_falsy(update, "update")

--- a/test_manual/externalexecution/container_runner_manual_executor.py
+++ b/test_manual/externalexecution/container_runner_manual_executor.py
@@ -1,0 +1,31 @@
+from pathlib import Path
+
+from cdmtaskservice.externalexecution.container_runner import run_container
+import asyncio
+import logging
+
+IMAGE = "ghcr.io/kbasetest/cts_test_image:0.1.2"
+
+STDOUT = Path("./stdout.txt")
+STDERR = Path("./stderr.txt")
+
+ARGS = ["python", "/opt/tester.py", "-s", "1000"]
+
+logging.basicConfig(level=logging.INFO)
+
+async def start_cb():
+    print("started container")
+
+
+async def main():
+    await run_container(
+        IMAGE,
+        STDOUT,
+        STDERR,
+        command=ARGS,
+        post_start_callback=start_cb(),
+        sigterm_callback=lambda signum: print(f"exited: {signum}")
+    )
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
Updates various lower level code for job canceling, as well as some minor cleanup.

* condor client:
  * adds cancel method
  * updates stats calculations to allow for canceled jobs missing fields in the ClassAd
  * explicitly specifies graceful shutdown when canceling jobs

* container runner & executor
  * Updates log streaming to use threads for both streams to prevent blocking the main loop and thus signal handling.
  * Shuts down the docker container on getting a sigterm and exits.
  * Adds a simple script for manually running the container runner
* Adds an argument to job_state.get_job to allow getting the admin details for a job, but only if the user owns the job.
* Updates the run_job script to exec the python code so signals propagate.