### PR TITLE
Fix regression in handling errored KBase jobs

### DIFF
--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -319,7 +319,7 @@ class KBaseRunner(JobFlow):
 
     async def _error_job(self, job: models.AdminJobDetails):
         cpu_hours, cpu_factor, max_mem = await self._get_condor_stats(job)
-        exit_codes = await self.get_exit_codes(job)
+        exit_codes = await self._mongo.get_exit_codes_for_subjobs(job.id)
         # if any exit codes are present and > 0, a container failed. Exit codes can be None
         # if the container never ran
         err_exit = set(exit_codes) - {0, None}


### PR DESCRIPTION
Regression from 8f024372e255c57a9ee83014c630d209cbb46816 where get_exit_codes was moved from the kbase job flow to job_state