### PR TITLE
CDM-458: Add mongo methods for cleaning up refdata transient files

### DIFF
--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -581,6 +581,8 @@ class NERSCJAWSRunner(JobFlow):
         """
         Clean up refdata staging files at the remote compute site.
         
+        If any files do not exist they are silently ignored.
+        
         refdata - the refdata to clean up.
         force - perform the clean up even if the refdata staging isn't in a terminal state.
             This may cause undefined behavior.
@@ -589,6 +591,6 @@ class NERSCJAWSRunner(JobFlow):
         # sort of global issues and ensures that ReferenceData is not modified before passing
         # it to the flow
         refstate = _not_falsy(refdata, "refdata").get_status_for_cluster(self.CLUSTER)
-        if not force and refstate.state not in models.REFDATA_TERMINAL_STATES:
+        if not force and not refstate.state.is_terminal():
             raise IllegalParameterError("Refdata is not in a terminal state and cannot be cleaned")
         await self._nman.clean_refdata(refdata)

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -1105,9 +1105,15 @@ class ReferenceDataState(str, Enum):
     DOWNLOAD_SUBMITTED = "download_submitted"
     COMPLETE = "complete"
     ERROR = "error"
+    
+    @classmethod
+    def terminal_states(cls) -> set[Self]:
+        """ Return the set of terminal states. """
+        return {cls.COMPLETE, cls.ERROR}
 
-
-REFDATA_TERMINAL_STATES = {ReferenceDataState.COMPLETE, ReferenceDataState.ERROR}
+    def is_terminal(self) -> bool:
+        """ Return True if this state is a terminal state. """
+        return self in self.terminal_states()
 
 
 class RefDataStateTransition(BaseModel):
@@ -1155,12 +1161,17 @@ class AdminReferenceDataStatus(ReferenceDataStatus):
     administrators.
     """
     # This is an outgoing structure only so we don't add validators
+    cleaned: Annotated[bool, Field(
+        description="Whether any refdata intermediate data has been cleaned up. E.g. "
+            + "download manifests and results, etc."
+    )] = False
     nersc_download_task_id: Annotated[list[str] | None, Field(
+        default_factory=list,
         description="IDs for tasks run via the NERSC SFAPI to download files from an S3 "
             + "instance to NERSC. Note that task details only persist for ~10 minutes past "
             + "completion in the SFAPI. Multiple tasks indicate job retries after failures. "
             + "Only present if the refdata is being downloaded to NERSC."
-    )] = None
+    )]
     admin_error: Annotated[str | None, Field(
         examples=["The back fell off"],
         description="A description of the error that occurred oriented towards service "

--- a/cdmtaskservice/nersc/manager.py
+++ b/cdmtaskservice/nersc/manager.py
@@ -1002,6 +1002,8 @@ class NERSCManager:
         Remove any files at NERSC associat4ed with staging the reference data. Does not remove
         the reference data itself or the NERSC -> LRC sync notification file read by JAWS.
         
+        If any files do not exist they are silently ignored.
+        
         Note that running this method on reference data where staging is not in a terminal
         state may result in undefined behavior.
         """

--- a/cdmtaskservice/refdata.py
+++ b/cdmtaskservice/refdata.py
@@ -85,7 +85,7 @@ class Refdata:
         # TDOO REFDATA if a cluster isn't available, need a way to start staging later
         clusters = await self._flowman.list_usable_clusters()
         for c in  clusters:
-            statuses.append(models.ReferenceDataStatus(
+            statuses.append(models.AdminReferenceDataStatus(
                 cluster=c,
                 state=models.ReferenceDataState.CREATED,
                 transition_times=[models.RefDataStateTransition(
@@ -96,7 +96,7 @@ class Refdata:
             # TODO REFDATA add a way to automatically restart refdata staging and just save
             #              to mongo to be restarted later
             raise ValueError("No job flows are available")
-        rd = models.ReferenceData(
+        rd = models.AdminReferenceData(
             id=str(uuid.uuid4()),  # TODO TEST for testing we'll need to set up a mock for this
             file=s3_path,
             crc64nvme=meta.crc64nvme,
@@ -123,7 +123,7 @@ class Refdata:
         cluster - the site to recover.
         """
         _require_string(refdata_id, "refdata_id")
-        update = models.ReferenceDataStatus(
+        update = models.AdminReferenceDataStatus(
             cluster=_not_falsy(cluster, "cluster"),
             state=models.ReferenceDataState.CREATED,
             transition_times=[models.RefDataStateTransition(

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -52,6 +52,7 @@ def mondb(mongo) -> AsyncIOMotorDatabase:
     yield mcli[MONGO_TEST_DB]
 
     mcli.close()
+    time.sleep(1)  # causes mongo connect failures after 32 tests otherwise
 
 
 @pytest.fixture(scope="module")

--- a/test/controllers/mongo.py
+++ b/test/controllers/mongo.py
@@ -50,7 +50,7 @@ class MongoController:
         if self._outfile:
             self._outfile.close()
         if delete_temp_files and self.temp_dir:
-            shutil.rmtree(self.temp_dir)
+            shutil.rmtree(self.temp_dir, ignore_errors=True)
 
     def clear_database(self, db_name, drop_indexes=False):
         if drop_indexes:

--- a/test/models_test.py
+++ b/test/models_test.py
@@ -91,3 +91,18 @@ def test_job_state_is_canceling():
     
     for s, term in expected.items():
         assert s.is_canceling() is term
+
+
+def test_refdata_state_terminal_states():
+    assert models.ReferenceDataState.terminal_states() == {
+        models.ReferenceDataState.ERROR, models.ReferenceDataState.COMPLETE
+    }
+
+
+def test_refdata_state_is_terminal():
+    expected = {s: False for s in list(models.ReferenceDataState)}
+    expected[models.ReferenceDataState.COMPLETE] = True
+    expected[models.ReferenceDataState.ERROR] = True
+    
+    for s, term in expected.items():
+        assert s.is_terminal() is term


### PR DESCRIPTION
Needed to alter refdata saving / adding a refdata site so that the cleaned field is persisted per cluster and the nersc task ID field is not initialized as null, which prevents $push operations