### PR TITLE
Drop container root user capabilities and fix permissions bug

### DIFF
--- a/cdmtaskservice/externalexecution/container_runner.py
+++ b/cdmtaskservice/externalexecution/container_runner.py
@@ -87,6 +87,8 @@ async def run_container(
         detach=True,
         tty=False,
         remove=False,  # Don't remove immediately to ensure logs are written
+        cap_drop=["ALL"],
+        security_opt=["no-new-privileges:true"],
     )
     
     def cleanup(signum, frame):

--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -232,7 +232,8 @@ Local relative path: {loc}
         if job.job_input.params.declobber:
             output = output / str(self._cfg.container_number)
         # Needs to be global write since the job container user is unknown
-        output.mkdir(0x777, parents=True, exist_ok=True)
+        output.mkdir(0o777, parents=True, exist_ok=True)
+        output.chmod(0o777)  # bypass process umask
         if self._cfg.mount_prefix_override:
             prefix, replace = [Path(x) for x in self._cfg.mount_prefix_override.split(":")]
             relative_in = input_.relative_to(prefix)


### PR DESCRIPTION
* Drop all capabilities for root users (cap_drop=["ALL"])
* Prevent setuid files from gaining privs ("no-new-privileges:true")
* Fix a output directory permissions bug (octal, not hex, dummy)
    * Also add an explicit chmod since directory creation is affected by the process umask

not really sure how to test the first two, but they don't break anything