### PR TITLE
Fix flaky presigned upload tests

### DIFF
--- a/cdmtaskservice/s3/client.py
+++ b/cdmtaskservice/s3/client.py
@@ -235,7 +235,7 @@ class S3Client:
                     raise S3ClientConnectError(
                         "Access denied to list buckets on the s3 system"
                     ) from e
-            # BAdDigest = CEPH, ChecksumMismatch = Minio
+            # BadDigest = CEPH, ChecksumMismatch = Minio
             if code in ("XAmzContentChecksumMismatch", "BadDigest"):
                 raise S3ChecksumMismatchError(f"Checksum mismatch for upload to {path}")
             logger.exception(

--- a/test/controllers/minio.py
+++ b/test/controllers/minio.py
@@ -10,6 +10,7 @@ from typing import Any
 
 from utils import find_free_port
 
+
 class MinioController:
     # adapted from https://github.com/kbase/java_test_utilities/blob/develop/src/main/java/us/kbase/testutils/controllers/minio/MinioController.java
     
@@ -93,10 +94,6 @@ class MinioController:
     async def create_bucket(self, bucket):
         async with self.get_client() as client:
             await client.create_bucket(Bucket=bucket)
-
-    async def get_object(self, bucket, key) -> dict[str, Any]:
-        async with self.get_client() as client:
-            return await client.get_object(Bucket=bucket, Key=key, ChecksumMode="ENABLED")
 
     async def upload_file(
         self,

--- a/test/s3/s3_remote_test.py
+++ b/test/s3/s3_remote_test.py
@@ -229,10 +229,11 @@ async def test_upload_presigned_url(minio):
         await upload_presigned_url(sess, url.url, url.fields, TEST_RAND10KB, timeout_sec=5)
     with open(TEST_RAND10KB, "rb") as f:
         expectedfile = f.read()
-    objdata = await minio.get_object("test-bucket", "foo/myfile")
-    body = await objdata["Body"].read()
+    async with minio.get_client() as client:
+        obj = await client.get_object(Bucket="test-bucket", Key="foo/myfile")
+        body = await obj["Body"].read()
     assert body == expectedfile
-    assert objdata["ETag"] == '"3291fbb392f6fad06dbf331dfb74da81"'
+    assert obj["ETag"] == '"3291fbb392f6fad06dbf331dfb74da81"'
 
 
 @pytest.mark.asyncio
@@ -245,17 +246,19 @@ async def test_upload_presigned_url_with_crc_and_insecure_ssl(minio):
             S3Paths(["test-bucket/foo/myfile"]), ["4ekt2WB1KO4="]))[0]
     async with aiohttp.ClientSession() as sess:
         # There's not a lot to test with insecure ssl other than it doesn't break things
-        # Unless we want to get really crazy and set up Minio with a SSC in the tests. We don't
+        # Unless we want to get really crazy and set up S3 with a SSC in the tests. We don't
         await upload_presigned_url(
             sess, url.url, url.fields, TEST_RAND1KB, insecure_ssl=True, timeout_sec=5)
     with open(TEST_RAND1KB, "rb") as f:
         expectedfile = f.read()
-    objdata = await minio.get_object("test-bucket", "foo/myfile")
-    
-    body = await objdata["Body"].read()
+    async with minio.get_client() as client:
+        obj = await client.get_object(
+            Bucket="test-bucket", Key="foo/myfile", ChecksumMode="ENABLED"
+        )
+        body = await obj["Body"].read()
     assert body == expectedfile
-    assert objdata["ETag"] == '"b10278db14633f102103c5e9d75c0af0"'
-    assert objdata["ChecksumCRC64NVME"] == "4ekt2WB1KO4="
+    assert obj["ETag"] == '"b10278db14633f102103c5e9d75c0af0"'
+    assert obj["ChecksumCRC64NVME"] == "4ekt2WB1KO4="
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
minio.get_object() initiates a client close before returning the object data, which means obj["Body"].read() may or may not fail if the read occurs after the client is closed.

Get rid of get_object() and use the client directly in the tests