### PR TITLE
CDM-540: Add separate insecure http flags for internal and external URLs

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -197,7 +197,7 @@ class CondorClient:
             env["MOUNT_PREFIX_OVERRIDE"] = self._config.mount_prefix_override
         if self._config.additional_path:
             env["ADDITIONAL_PATH"] = self._config.additional_path
-        if self._s3config.insecure:
+        if self._s3config.get_insecure(self._config.use_S3_external_url):
             env["S3_INSECURE"] = "TRUE"
         if log_level := os.environ.get("CTS_LOG_LEVEL"):
             env["CTS_LOG_LEVEL"] = log_level

--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -88,8 +88,10 @@ class CDMTaskServiceConfig:
         service startup.
     s3_access_key: str - the S3 access key.
     s3_access_secret: str - the S3 access secret.
-    s3_allow_insecure: bool - whether to skip SSL cert validation, leaving the service vulnerable
-        to MITM attacks.
+    s3_allow_insecure: bool - whether to skip SSL cert validation for the internal S3 URL,
+        leaving the service vulnerable to MITM attacks.
+    s3_allow_insecure_external: bool - whether to skip SSL cert validation for the external S3
+        URL, leaving the service vulnerable to MITM attacks.
     mongo_host: str - the MongoDB host.
     mongo_db: str - the MongoDB database.
     mongo_user: str | None - the MongoDB user name.
@@ -210,6 +212,9 @@ class CDMTaskServiceConfig:
         self.s3_access_key = _get_string_required(config, _SEC_S3, "access_key")
         self.s3_access_secret = _get_string_required(config, _SEC_S3, "access_secret")
         self.s3_allow_insecure = _get_string_optional(config, _SEC_S3, "allow_insecure") == "true"
+        self.s3_allow_insecure_external = (
+            _get_string_optional(config, _SEC_S3, "allow_insecure_external") == "true"
+        )
         # If needed, we could add an S3 region parameter. YAGNI
         # If needed we could add sub sections to support > 1 S3 instance per service. YAGNI
         self.mongo_host = _get_string_required(config, _SEC_MONGODB, "mongo_host")
@@ -278,7 +283,8 @@ class CDMTaskServiceConfig:
             access_key=self.s3_access_key,
             access_secret=self.s3_access_secret,
             error_log_path=self.container_s3_log_dir,
-            insecure=self.s3_allow_insecure,
+            insecure_internal=self.s3_allow_insecure,
+            insecure_external=self.s3_allow_insecure_external,
             verify_external_url=self.s3_verify_external_url,
         )
 
@@ -364,7 +370,8 @@ class CDMTaskServiceConfig:
             f"S3 verify external URL: {self.s3_verify_external_url}",
             f"S3 access key: {self.s3_access_key}",
             "S3 access secret: REDACTED FOR YOUR SAFETY AND COMFORT",
-            f"S3 allow insecure: {self.s3_allow_insecure}",
+            f"S3 allow insecure (internal): {self.s3_allow_insecure}",
+            f"S3 allow insecure (external): {self.s3_allow_insecure_external}",
             f"MongoDB host: {self.mongo_host}",
             f"MongoDB database: {self.mongo_db}",
             f"MongoDB user: {self.mongo_user}",

--- a/cdmtaskservice/config_s3.py
+++ b/cdmtaskservice/config_s3.py
@@ -33,9 +33,15 @@ class S3Config(BaseModel):
     May not be present if unavailable.
     """
     
-    insecure: bool = False
+    insecure_internal: bool = False
     """
-    Whether to skip checking the SSL certificate for the S3 instance,
+    Whether to skip checking the SSL certificate for the internal S3 URL,
+    leaving the service open to MITM attacks.
+    """
+
+    insecure_external: bool = False
+    """
+    Whether to skip checking the SSL certificate for the external S3 URL,
     leaving the service open to MITM attacks.
     """
     
@@ -50,6 +56,10 @@ class S3Config(BaseModel):
         """ Get the S3 internal url, or the external url if external is true. """
         return self.external_url if external else self.internal_url
 
+    def get_insecure(self, external: bool = False) -> bool:
+        """ Get the insecure SSL flag for the internal url, or the external url if external is true. """
+        return self.insecure_external if external else self.insecure_internal
+
     async def initialize_clients(self):
         """
         Initialize the S3 clients. NOTE: this method is not safe for concurrent access.
@@ -63,14 +73,14 @@ class S3Config(BaseModel):
                 self.internal_url,
                 self.access_key,
                 self.access_secret,
-                insecure_ssl=self.insecure
+                insecure_ssl=self.insecure_internal
             )
         if self._s3_external_client is None and self.external_url:
             self._s3_external_client = await S3Client.create(
                 self.external_url,
                 self.access_key,
                 self.access_secret,
-                insecure_ssl=self.insecure,
+                insecure_ssl=self.insecure_external,
                 skip_connection_check=not self.verify_external_url
             )
 

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -98,7 +98,7 @@ class NERSCJAWSRunner(JobFlow):
         self._mongo = _not_falsy(mongodao, "mongodao")
         self._s3 = _not_falsy(s3config, "s3config").get_internal_client()
         self._s3ext = s3config.get_external_client()
-        self._s3insecure = s3config.insecure
+        self._s3insecure = s3config.insecure_external
         self._s3logdir = s3config.error_log_path
         self._coman = _not_falsy(coro_manager, "coro_manager")
         self._callback_root = _require_string(service_root_url, "service_root_url")

--- a/cdmtaskservice/refserv/config.py
+++ b/cdmtaskservice/refserv/config.py
@@ -85,7 +85,7 @@ class CDMRefdataServiceConfig:
             internal_url=self.s3_url,
             access_key=self.s3_access_key,
             access_secret=self.s3_access_secret,
-            insecure=self.s3_allow_insecure,
+            insecure_internal=self.s3_allow_insecure,
         )
 
     def print_config(self, output: TextIO):

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -198,9 +198,13 @@ access_key = "{{ KBCTS_S3_ACCESS_KEY or "" }}"
 # The S3 secret key.
 access_secret = "{{ KBCTS_S3_ACCESS_SECRET or "" }}"
 # Setting allow_insecure = true (and only the exact string "true") skips checking the validity of
-# the SSL certificate for both the standard and external urls, leaving the service vulnerable
-# to Man in the Middle attacks.
+# the SSL certificate for the internal url, leaving the service vulnerable to Man in the Middle
+# attacks.
 allow_insecure = "{{ KBCTS_S3_ALLOW_INSECURE or "false"}}"
+# Setting allow_insecure_external = true (and only the exact string "true") skips checking the
+# validity of the SSL certificate for the external url, leaving the service vulnerable to Man in
+# the Middle attacks.
+allow_insecure_external = "{{ KBCTS_S3_ALLOW_INSECURE_EXTERNAL or "false"}}"
 
 [MongoDB]
 


### PR DESCRIPTION
It appears as though the internal url will use a self signed cert while the external url will have a proper cert