### PR TITLE
Remove LRC from API

### DIFF
--- a/cdmtaskservice/app_state.py
+++ b/cdmtaskservice/app_state.py
@@ -26,7 +26,8 @@ from cdmtaskservice.flow_cleaner import FlowCleaner
 from cdmtaskservice.jobflows.flowmanager import JobFlowManager
 from cdmtaskservice.jobflows.jaws_flows_provider import JAWSFlowProvider
 from cdmtaskservice.jobflows.kbase import KBaseFlowProvider, KBaseRunner
-from cdmtaskservice.jobflows.lawrencium_jaws import LawrenciumJAWSRunner
+# NOTE: Restore this import if Lawrencium is reactivated (see also sites.py and jaws_flows_provider.py).
+# from cdmtaskservice.jobflows.lawrencium_jaws import LawrenciumJAWSRunner
 from cdmtaskservice.jobflows.nersc_jaws import NERSCJAWSRunner
 from cdmtaskservice.job_state import JobState
 from cdmtaskservice.notifications.kafka_notifications import KafkaNotifier
@@ -335,7 +336,9 @@ async def _register_nersc_job_flows(
     )
     dest.register("JAWS flow provider", jaws_job_flows.close())
     flowman.register_flow(NERSCJAWSRunner.CLUSTER, jaws_job_flows.get_nersc_job_flow)
-    flowman.register_flow(LawrenciumJAWSRunner.CLUSTER, jaws_job_flows.get_lrc_job_flow)
+    # NOTE: LRC is offline. Restore this line (and see jaws_flows_provider.py and sites.py)
+    # if Lawrencium is reactivated.
+    # flowman.register_flow(LawrenciumJAWSRunner.CLUSTER, jaws_job_flows.get_lrc_job_flow)
     return jaws_job_flows
 
 

--- a/cdmtaskservice/jobflows/jaws_flows_provider.py
+++ b/cdmtaskservice/jobflows/jaws_flows_provider.py
@@ -309,15 +309,17 @@ class JAWSFlowProvider:
 
     def _build_flows(self, jaws_client: JAWSClient, nerscman: NERSCManager
     ) -> (NERSCJAWSRunner, LawrenciumJAWSRunner):
-        lrcjawsflow = LawrenciumJAWSRunner(
-            nerscman,
-            jaws_client,
-            self._mongodao,
-            self._s3config,
-            self._kafka,
-            self._coman,
-            self._service_root_url,
-        )
+        # NOTE: LRC is offline. Restore lrcjawsflow instantiation and on_refdata_complete
+        # coupling (and see app_state.py and sites.py) if Lawrencium is reactivated.
+        # lrcjawsflow = LawrenciumJAWSRunner(
+        #     nerscman,
+        #     jaws_client,
+        #     self._mongodao,
+        #     self._s3config,
+        #     self._kafka,
+        #     self._coman,
+        #     self._service_root_url,
+        # )
         nerscjawsflow = NERSCJAWSRunner(
             nerscman,
             jaws_client,
@@ -326,6 +328,6 @@ class JAWSFlowProvider:
             self._kafka,
             self._coman,
             self._service_root_url,
-            on_refdata_complete=lrcjawsflow.nersc_refdata_complete,
+            # on_refdata_complete=lrcjawsflow.nersc_refdata_complete,
         )
-        return nerscjawsflow, lrcjawsflow
+        return nerscjawsflow, None

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -157,10 +157,14 @@ async def whoami(r: Request, user: CTSUser=Depends(_AUTH)) -> WhoAmI:
 class Site(sites.ComputeSite):
     """
     Information about a remote compute site and its status.
-    
+
     For a site to be usable, it must be both active and available.
     """
-    
+
+    cluster: Annotated[sites.SubmittableCluster, Field(
+        examples=[sites.SubmittableCluster.PERLMUTTER_JAWS.value],
+        description="The site identifier",
+    )]
     active: Annotated[bool, Field(
         description="Whether the compute site has been set to active by a service admin."
     )]
@@ -258,6 +262,15 @@ class SubmitJobResponse(BaseModel):
     job_id: Annotated[str, Field(description="An opaque job ID.")]
 
 
+class JobInputCreate(models.JobInput):
+    """ Input to a Job. """
+
+    # restrict to clusters registered to the service
+    cluster: Annotated[sites.SubmittableCluster, Field(
+        examples=[sites.SubmittableCluster.PERLMUTTER_JAWS.value]
+    )]
+
+
 @ROUTER_JOBS.post(
     "",
     response_model=SubmitJobResponse,
@@ -267,7 +280,7 @@ class SubmitJobResponse(BaseModel):
 )
 async def submit_job(
     r: Request,
-    job_input: models.JobInput,
+    job_input: JobInputCreate,
     user: CTSUser=Depends(_AUTH),
 ) -> SubmitJobResponse:
     job_state = app_state.get_app_state(r).job_state

--- a/cdmtaskservice/sites.py
+++ b/cdmtaskservice/sites.py
@@ -9,15 +9,32 @@ from enum import Enum
 
 class Cluster(str, Enum):
     """
-    The location where a job should run.
-    
-    perlmutter-jaws: The Perlmutter cluster at NERSC run via JAWS.
-    lawrencium-jaws: The Lawrencium cluster at LBNL run via JAWS.
+    All clusters that have ever been registered in the system, including those that are no longer
+    registered but may have associated job records.
+
+    perlmutter-jaws: The Perlmutter cluster at NERSC run via JAWS.  
+    lawrencium-jaws: The Lawrencium cluster at LBNL run via JAWS.  
     kbase: KBase compute nodes.
     """
 
     PERLMUTTER_JAWS = "perlmutter-jaws"
     LAWRENCIUM_JAWS = "lawrencium-jaws"
+    KBASE = "kbase"
+
+
+class SubmittableCluster(str, Enum):
+    """
+    Clusters for job submission..
+
+    perlmutter-jaws: The Perlmutter cluster at NERSC run via JAWS.  
+    kbase: KBase compute nodes.
+    """
+    
+    # NOTE: If Lawrencium (lawrencium-jaws) is reactivated, add it back here and restore the
+    # LawrenciumJAWSRunner instantiation and flow registration — see jaws_flows_provider.py
+    # and app_state.py.
+
+    PERLMUTTER_JAWS = "perlmutter-jaws"
     KBASE = "kbase"
 
 


### PR DESCRIPTION
The presence of LRC in the sites endpoint and job submit documentation is confusing AI agents. Remove from the submission API and sites endpoint, but leave elsewhere to prevent errors when loading previously run jobs.