### PR TITLE
Hold HTC jobs with container exit codes > 0

### DIFF
--- a/cdmtaskservice/externalexecution/container_runner.py
+++ b/cdmtaskservice/externalexecution/container_runner.py
@@ -49,7 +49,7 @@ async def run_container(
     mounts: dict[str, tuple[str, bool]] | None = None,
     post_start_callback: Awaitable[None] | None = None,
     sigterm_callback: Callable[[int], None] | None = None,
-):
+) -> int:
     """
     Run a container and wait for it to complete.
     
@@ -66,6 +66,8 @@ async def run_container(
     sigterm_callback - a callable that will be called if a SIGTERM or SIGINT is sent to the
         process, after a stop signal is sent to the docker container. The argument is the signal
         number.
+
+    Returns the container exit code.
     """
     _require_string(image, "image")
     _not_falsy(stdout_path, "stdout_path")
@@ -115,7 +117,7 @@ async def run_container(
         _stream_logs(container, stdout_path, stderr_path)
 
         result = container.wait()
-        return result.get("StatusCode", -1)
+        return result["StatusCode"]
     finally:
         try:
             container.remove(force=True)

--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -58,8 +58,12 @@ class Executor:
         if self._s3cli:
             await self._s3cli.close()
     
-    async def execute(self):
-        """ Run the executor. Returns True for success, False for fail. """
+    async def execute(self) -> int:
+        """
+        Run the executor.
+        Returns 0 for success, a positive integer for the container exit code, or -1 if an error
+        occurred other than a container error.
+        """
         await self._log_service_ver()
         # If we can't get the job, we presumably can't update the job either, so we just throw any
         # exceptions.
@@ -74,11 +78,11 @@ class Executor:
                 await self._process_error_state(job, exit_code)
             else:
                 await self._process_complete_state(job)
+            return exit_code
         except Exception as e:
             self._logr.exception(f"Job failed: {e}")
             await self._update_job_state_loop(job, models.JobState.ERROR, exception=e)
-            return False
-        return True
+            return -1
     
     async def _check_resp(self, resp: aiohttp.ClientResponse, action: str
     ) -> dict[str, Any] | None:
@@ -317,13 +321,14 @@ Local relative path: {loc}
         )
 
 
-async def run_executor(stderr: TextIO):
+async def run_executor(stderr: TextIO) -> int:
     """
     Run the job executor. 
     
     stderr - a stderr stream.
     
-    Returns True for success, False for failure.
+    Returns 0 for success, a positive integer for the container exit code, or -1 if an error
+    occurred other than a container error.
     """
     stderr.write(f"Executor version: {VERSION} githash: {GIT_COMMIT}\n")
     cfg = Config()

--- a/cdmtaskservice/externalexecution/main.py
+++ b/cdmtaskservice/externalexecution/main.py
@@ -18,6 +18,7 @@ if __name__ == "__main__":
             f"Invalid CTS_LOG_LEVEL '{cts_log_level}': must be a standard log level "
             + "e.g. DEBUG, INFO, WARNING, ERROR, CRITICAL"
         ) from e
-    res = asyncio.run(run_executor(sys.stderr))  # allow testing via replacing streams
-    if not res:
-        sys.exit(1)
+    exit_code = asyncio.run(run_executor(sys.stderr))  # allow testing via replacing streams
+    # pick any old number that's less likely to collide with with container exit codes
+    exit_code = 119 if exit_code < 0 else exit_code
+    sys.exit(exit_code)


### PR DESCRIPTION
All other errors are held, a container error is an anomaly. This will enable requeuing the job for retries.

Also throw a KeyError if container.wait() doesn't return an exit code - that should never happen

https://docker-py.readthedocs.io/en/stable/containers.html#docker.models.containers.Container.wait