### PR TITLE
Fix ExprTree evaluation & make Environment ClassAd dynamic

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -181,7 +181,7 @@ class CondorClient:
     def _get_environment(self, job: models.Job) -> str:
         env = {
             "JOB_ID": job.id,
-            "CONTAINER_NUMBER": "$(container_number)",
+            "CONTAINER_NUMBER": f"$$([{_AD_CONTAINER_NUMBER}])",
             "CODE_ARCHIVE": self._code_archive_name,
             "GLOBAL_CACHE_DIR": self._config.cache_dir,
             "SERVICE_ROOT_URL": self._config.service_root_url,
@@ -268,7 +268,7 @@ class CondorClient:
             v = ca.get(k)
             if v is not None:
                 if k == _AD_MEM:
-                    v = v.eval()
+                    v = v.eval(scope=ca)
                 if isinstance(v, ExprTree):
                     v = str(v)  # eval()ing he ExprTree isn't helpful, want the expression
                 ret[k] = v


### PR DESCRIPTION
* ExprTree.eval() needs to have the parent ClassAd passed as the scope or it won't evaluate correctly. Oops. Seems like that should be required...
* Make the environment pull the container number from the classad vs hardcoding it. Currently this doesn't really matter but doing the same thing for the retry count will make it a lot easier to set, since the environment string won't need to be edited, just the CTSRetries (or whatever) ClassAd.