### PR TITLE
Throw accurate errors when a constrained job state update fails

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -19,7 +19,7 @@ from cdmtaskservice.arg_checkers import (
     check_num as _check_num,
     verify_aware_datetime
 )
-from cdmtaskservice.exceptions import JobRecoveryError
+from cdmtaskservice.exceptions import InvalidJobStateError, JobRecoveryError
 from cdmtaskservice.update_state import JobUpdate, UpdateField, RefdataUpdate
 
 
@@ -463,7 +463,7 @@ class MongoDAO:
             ]
         return query
 
-    async def _update_job_state_err(
+    async def _update_job_state_diagnose_err(
         self,
         col: AsyncIOMotorCollection,
         job_id: str,
@@ -472,29 +472,59 @@ class MongoDAO:
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
     ):
-        if recovery_cooldown and recovery_cooldown > datetime.timedelta(0):
-            # Distinguish cooldown violation from state/existence mismatch: re-query without
-            # the cooldown constraint to check if the job exists and is in the right state
-            diag_query = self._update_job_state_query(job_id, time, update)
-            doc = await col.find_one(diag_query, {_FLD_MONGO_ID: 0, _FLD_LAST_RECOVER: 1})
-            if doc is not None:
-                remaining = (doc[_FLD_LAST_RECOVER] + recovery_cooldown) - time
-                raise JobRecoveryError(
-                    f"Job '{job_id}' was recovered too recently; "
-                    f"must wait {remaining} more before forcing recovery again"
-                )
-        statestr = ""
-        if update.current_state:
-            statestr = f"in state {update.current_state.value} "
-        if update.disallowed_current_states:
-            statestr = "not in states " + str(
-                sorted([s.value for s in update.disallowed_current_states])
-            ) + " "
+        if not recovery_cooldown or recovery_cooldown <= datetime.timedelta(0):
+            recovery_cooldown = None
+        id_query = {models.FLD_COMMON_ID: job_id}
         if subjob_id is not None:
-            raise NoSuchSubJobError(
-                f"No job with ID '{job_id}' and subjob ID {subjob_id} {statestr}exists"
+            id_query[models.FLD_SUBJOB_ID] = subjob_id
+        doc = await col.find_one(
+            id_query,
+            {
+                _FLD_MONGO_ID: 0,
+                models.FLD_COMMON_STATE: 1,
+                _FLD_LAST_RECOVER: 1,
+                _FLD_UPDATE_TIME: 1,
+            },
+        )
+        if doc is None:
+            if subjob_id is not None:
+                raise NoSuchSubJobError(
+                    f"No job with ID '{job_id}' and subjob ID {subjob_id} exists"
+                )
+            raise NoSuchJobError(f"No job with ID '{job_id}' exists")
+        entity = f"Job '{job_id}'"
+        if subjob_id is not None:
+            entity = f"Job '{job_id}' with subjob ID {subjob_id}"
+        actual_state = doc[models.FLD_COMMON_STATE]
+        if update.current_state and actual_state != update.current_state.value:
+            raise InvalidJobStateError(
+                f"{entity} is in state {actual_state!r}, "
+                f"expected {update.current_state.value!r}"
             )
-        raise NoSuchJobError(f"No job with ID '{job_id}' {statestr}exists")
+        if (
+            update.disallowed_current_states
+            and actual_state in {s.value for s in update.disallowed_current_states}
+        ):
+            raise InvalidJobStateError(f"{entity} is in disallowed state {actual_state!r}")
+        if doc[_FLD_UPDATE_TIME] > time:
+            raise ValueError(
+                f"{entity} last update time is after the provided time"
+            )
+        # State constraints and timestamp are satisfied; the cooldown is the only
+        # remaining cause. Both recovery_cooldown and _last_recover are guaranteed
+        # non-null — unless the document changed between the original query and this
+        # diagnostic read (race condition), in which case we can't diagnose further.
+        last_recover = doc.get(_FLD_LAST_RECOVER)
+        if not recovery_cooldown or last_recover is None:
+            raise ValueError(  # This is too painful to test
+                f"{entity}: could not diagnose update failure; "
+                "the document may have changed between queries"
+            )
+        remaining = (last_recover + recovery_cooldown) - time
+        raise JobRecoveryError(
+            f"Job '{job_id}' was recovered too recently; "
+            f"must wait {remaining} more before forcing recovery again"
+        )
 
     async def _update_job_state(
         self,
@@ -536,10 +566,7 @@ class MongoDAO:
             },
         )
         if not res.matched_count:
-            # This doesn't account for missing matches due to a too-early `time` argument,
-            # but that generally shouldn't happen unless someone is deliberately being a pain
-            # YAGNI for now, improve later if necessary
-            await self._update_job_state_err(
+            await self._update_job_state_diagnose_err(
                 col, job_id, update, time, subjob_id, recovery_cooldown
             )
 

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -1175,9 +1175,11 @@ async def test_recover_job_force_all_complete_lock_fails():
     runner, mongo, condor, updates, s3 = _make_runner()
     job = _recovery_job(state=models.JobState.RECOVERING)
     condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
-    updates.update_job_state.side_effect = InvalidJobStateError("not in RECOVERING state")
+    updates.update_job_state.side_effect = InvalidJobStateError(
+        "Job 'jid' is in state 'error', expected 'recovering'"
+    )
 
-    with pytest.raises(InvalidJobStateError, match="not in RECOVERING state"):
+    with pytest.raises(InvalidJobStateError, match="expected 'recovering'"):
         await runner.recover_job(job, force=True)
 
     condor.get_cluster_proc_states.assert_called_once_with(123)
@@ -1247,15 +1249,15 @@ async def test_recover_job_force_held_release_fails():
 
 async def test_recover_job_force_held_lock_fails():
     """
-    Force held: lock acquisition fails (job not in RECOVERING or cooldown not yet expired);
-    exception propagates; no subjob resets or HTC calls are made.
+    Force held: cooldown not yet expired → JobRecoveryError propagates; no subjob resets
+    or HTC calls are made.
     """
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.RECOVERING)
     condor.get_cluster_proc_states.return_value = [ProcState.HELD, ProcState.HELD]
-    updates.update_job_state.side_effect = InvalidJobStateError("cooldown not expired")
+    updates.update_job_state.side_effect = JobRecoveryError("cooldown not expired")
 
-    with pytest.raises(InvalidJobStateError, match="cooldown not expired"):
+    with pytest.raises(JobRecoveryError, match="cooldown not expired"):
         await runner.recover_job(job, force=True)
 
     condor.get_cluster_proc_states.assert_called_once_with(123)

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -8,7 +8,7 @@ from typing import Coroutine, Callable, Any
 
 from cdmtaskservice import models
 from cdmtaskservice import sites
-from cdmtaskservice.exceptions import JobRecoveryError
+from cdmtaskservice.exceptions import InvalidJobStateError, JobRecoveryError
 from cdmtaskservice.mongo import (
     MissingSubJobError,
     MongoDAO,
@@ -391,13 +391,13 @@ async def test_update_job_fail(mondb):
     await fail_update_job(mc, "foo", u, dt, None, ValueError("trans_id is required"))
     await fail_update_job(mc, "foo", u, dt, "   \t    ", ValueError("trans_id is required"))
     await fail_update_job(mc, "bar", u, dt, tid, NoSuchJobError(
-        "No job with ID 'bar' in state download_submitted exists"
+        "No job with ID 'bar' exists"
     ))
-    await fail_update_job(mc, "foo", submitting_upload(), dt, tid, NoSuchJobError(
-        "No job with ID 'foo' in state job_submitted exists"
+    await fail_update_job(mc, "foo", submitting_upload(), dt, tid, InvalidJobStateError(
+        "Job 'foo' is in state 'download_submitted', expected 'job_submitted'"
     ))
     await fail_update_job(mc, "foo", u, _SAFE_TIME + datetime.timedelta(milliseconds=-1), tid,
-        NoSuchJobError("No job with ID 'foo' in state download_submitted exists")
+        ValueError("Job 'foo' last update time is after the provided time")
     )
 
 
@@ -409,19 +409,18 @@ async def test_update_job_and_subjob_fail_update_to_error(mondb):
     dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
     tid = "1"
     
-    disallowed_str = "['canceled', 'canceling', 'complete', 'error', 'recovering']"
     for state in (
-        models.JobState.terminal_states() | 
+        models.JobState.terminal_states() |
         models.JobState.canceling_states() |
         {models.JobState.RECOVERING}
     ):
         await mondb.jobs.update_one({}, {"$set": {"state": state.value}})
         await mondb.subjobs.update_one({}, {"$set": {"state": state.value}})
-        await fail_update_job(mc, "foo", u, dt, tid, NoSuchJobError(
-            f"No job with ID 'foo' not in states {disallowed_str} exists"
+        await fail_update_job(mc, "foo", u, dt, tid, InvalidJobStateError(
+            f"Job 'foo' is in disallowed state {state.value!r}"
         ))
-        await fail_update_subjob(mc, "bar", 0, u, dt, NoSuchSubJobError(
-            f"No job with ID 'bar' and subjob ID 0 not in states {disallowed_str} exists"
+        await fail_update_subjob(mc, "bar", 0, u, dt, InvalidJobStateError(
+            f"Job 'bar' with subjob ID 0 is in disallowed state {state.value!r}"
         ))
 
 
@@ -543,15 +542,15 @@ async def test_update_job_force_recovery_no_prior_recover(mondb):
 
 
 async def test_update_job_recovery_cooldown_state_mismatch(mondb):
-    # A positive cooldown on a job in the wrong state should raise NoSuchJobError, not
-    # JobRecoveryError — the diagnostic query must correctly attribute the failure to state
+    # A positive cooldown on a job in the wrong state should raise InvalidJobStateError, not
+    # JobRecoveryError — the cooldown diagnostic query must not mask a state mismatch
     mc = await MongoDAO.create(mondb)
     await mc.save_job(_BASEJOB)  # state = DOWNLOAD_SUBMITTED
 
     dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
     # force_recovering requires current state = RECOVERING, but job is DOWNLOAD_SUBMITTED
-    with pytest.raises(NoSuchJobError, match=(
-        r"^No job with ID 'foo' in state recovering exists$"
+    with pytest.raises(InvalidJobStateError, match=(
+        r"^Job 'foo' is in state 'download_submitted', expected 'recovering'$"
     )):
         await mc.update_job_state(
             "foo", force_recovering(), dt, "tid1",
@@ -865,16 +864,16 @@ async def test_update_subjob_fail(mondb):
     await fail_update_subjob(mc, "bar", 0, None, dt, ValueError("update is required"))
     await fail_update_subjob(mc, "bar", 0, u, None, ValueError("time is required"))
     await fail_update_subjob(mc, "foo", 0, u, dt, NoSuchSubJobError(
-        "No job with ID 'foo' and subjob ID 0 in state created exists"
+        "No job with ID 'foo' and subjob ID 0 exists"
     ))
     await fail_update_subjob(mc, "bar", 1, u, dt, NoSuchSubJobError(
-        "No job with ID 'bar' and subjob ID 1 in state created exists"
+        "No job with ID 'bar' and subjob ID 1 exists"
     ))
-    await fail_update_subjob(mc, "bar", 0, submitting_upload(), dt, NoSuchSubJobError(
-        "No job with ID 'bar' and subjob ID 0 in state job_submitted exists"
+    await fail_update_subjob(mc, "bar", 0, submitting_upload(), dt, InvalidJobStateError(
+        "Job 'bar' with subjob ID 0 is in state 'created', expected 'job_submitted'"
     ))
     await fail_update_subjob(mc, "bar", 0, u, _SAFE_TIME + datetime.timedelta(milliseconds=-1),
-         NoSuchSubJobError("No job with ID 'bar' and subjob ID 0 in state created exists")
+        ValueError("Job 'bar' with subjob ID 0 last update time is after the provided time")
     )
 
 


### PR DESCRIPTION
  Previously _update_job_state_err always raised NoSuchJobError (404), even when the job existed but was in the wrong state, the provided timestamp was stale, or the recovery cooldown had not yet elapsed.

  The method is rewritten (_update_job_state_diagnose_err) to do a single diagnostic find_one by ID after any failed update and derive the actual cause:

  - Job not found → NoSuchJobError / NoSuchSubJobError (unchanged)
  - State constraint mismatch → InvalidJobStateError with the actual and expected states; container number included for subjob errors
  - Stale timestamp → ValueError (programming error in the caller)
  - Recovery cooldown not expired → JobRecoveryError with remaining wait

  Tests updated throughout to assert the correct exception types and
  messages.