### PR TITLE
Use container stats vs. htcondor stats

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -5,6 +5,7 @@ Task Service.
 
 import asyncio
 from classad2 import ClassAd, ExprTree
+from dataclasses import dataclass
 import enum
 import htcondor2
 import os
@@ -149,29 +150,37 @@ def condor_jobs_all_held(job_classads_as_dict: list[dict[str, Any]]) -> bool:
     _not_falsy(job_classads_as_dict, "job_classads_as_dict")
     return not {ad[_AD_JOB_STATUS] for ad in job_classads_as_dict} - {_JOB_STATUS_HELD}
 
-def condor_job_stats(job_classads_as_dict: list[dict[str, Any]], requested_cpus: int
-) -> tuple[float, float, int]:
+
+@dataclass
+class CondorJobStats:
+    """Stats derived from HTCondor ClassAds for a job."""
+    cpu_hours: float | None
+    max_memory: int | None
+    runtime_seconds: float | None
+
+
+def condor_job_stats(job_classads_as_dict: list[dict[str, Any]]) -> CondorJobStats:
     """
     Given HTCondor job ClassAds converted to dictionaries for a job, compute stats for the job.
-    Returns a tuple of
-    
-    * total cpu hours (RemoteSysCpu + RemoteUserCpu) / 3600
-    * cpu usage factor (cpu time / (CommittedTime * requested_cpus))
-    * maximum memory use in B over each container (e.g. max(list[max_container_mem_usage])
+
+    cpu_hours - total (RemoteSysCpu + RemoteUserCpu) / 3600
+    max_memory - maximum MemoryUsage in bytes across all containers (MemoryUsage is in MiB)
+    runtime_seconds - total CommittedTime in seconds across all containers
     """
     _not_falsy(job_classads_as_dict, "job_classads_as_dict")
-    _check_num(requested_cpus, "requested_cpus")
     # Seems like condor uses MiB, although docs aren't great
     # https://htcondor.readthedocs.io/en/24.x/man-pages/condor_submit.html?utm_source=chatgpt.com#request_memory
     mems = [c[_AD_MEM] for c in job_classads_as_dict if _AD_MEM in c]
-    max_mem = max(mems) * 1024 * 1024 if mems else None
     cpu_sec = 0
-    committed_time = 0
+    runtime_sec = 0
     for c in job_classads_as_dict:
         cpu_sec += (c.get(_AD_CPU_USER) or 0) + (c.get(_AD_CPU_SYS) or 0)
-        committed_time += (c.get(_AD_COMMITTED_TIME) or 0)
-    cpufactor = cpu_sec / (committed_time * requested_cpus) if committed_time else None
-    return cpu_sec / 3600.0 if cpu_sec else None, cpufactor, max_mem
+        runtime_sec += (c.get(_AD_COMMITTED_TIME) or 0)
+    return CondorJobStats(
+        cpu_hours=cpu_sec / 3600.0 if cpu_sec else None,
+        max_memory=max(mems) * 1024 * 1024 if mems else None,
+        runtime_seconds=float(runtime_sec) if runtime_sec else None,
+    )
 
 
 class CondorClient:

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -19,7 +19,7 @@ from cdmtaskservice.arg_checkers import (
     require_string as _require_string,
 )
 from cdmtaskservice.condor.client import (
-    CondorClient, ProcState, condor_job_stats, condor_jobs_all_held
+    CondorClient, CondorJobStats, ProcState, condor_job_stats, condor_jobs_all_held
 )
 from cdmtaskservice.condor.config import CondorClientConfig
 from cdmtaskservice.config_s3 import S3Config
@@ -124,12 +124,13 @@ class KBaseRunner(JobFlow):
             models.JobState.JOB_SUBMITTED: lambda job, t: self._updates.update_job_state(
                 job.id, update_state.submitted_job(), update_time=t
             ),
-            models.JobState.UPLOAD_SUBMITTING: self._submitting_upload_handler,
+            models.JobState.UPLOAD_SUBMITTING: lambda job, t:
+                self._submitting_stats_handler(job, t, update_state.submitting_upload),
             models.JobState.UPLOAD_SUBMITTED: lambda job, t: self._updates.update_job_state(
                 job.id, update_state.submitted_upload(), update_time=t
             ),
-            models.JobState.ERROR_PROCESSING_SUBMITTING:
-                self._submitting_error_processing_handler,
+            models.JobState.ERROR_PROCESSING_SUBMITTING: lambda job, t:
+                self._submitting_stats_handler(job, t, update_state.submitting_error_processing),
             models.JobState.ERROR_PROCESSING_SUBMITTED: lambda job, t:
                 self._updates.update_job_state(
                     job.id, update_state.submitted_error_processing(), update_time=t
@@ -287,7 +288,6 @@ class KBaseRunner(JobFlow):
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
 
-    
     async def update_container_state(
         self,
         job: models.AdminJobDetails,
@@ -337,38 +337,32 @@ class KBaseRunner(JobFlow):
         except Exception as e:
             await self._updates.handle_exception(e, job.id, "updating job state")
 
-    async def _submitting_upload_handler(
-        self, job: models.AdminJobDetails, update_time: datetime.datetime
-    ):
+    async def _submitting_stats_handler(self, job, update_time, update_fn):
+        cpu_hours, max_memory, cpu_factor = await self._get_subjob_stats(job)
         await self._updates.update_job_state(
-            job.id, update_state.submitting_upload(), update_time=update_time
-        )
-
-    async def _submitting_error_processing_handler(
-        self, job: models.AdminJobDetails, update_time: datetime.datetime
-    ):
-        await self._updates.update_job_state(
-            job.id, update_state.submitting_error_processing(), update_time=update_time
+            job.id,
+            update_fn(cpu_hours=cpu_hours, cpu_factor=cpu_factor, max_memory=max_memory),
+            update_time=update_time,
         )
 
     async def _error_job(self, job: models.AdminJobDetails):
-        cpu_hours, cpu_factor, max_mem = await self._get_condor_stats(job)
+        condor_stats = await self._fetch_condor_classad_stats(job)
         exit_codes = await self._mongo.get_exit_codes_for_subjobs(job.id)
         # if any exit codes are present and > 0, a container failed. Exit codes can be None
         # if the container never ran
         err_exit = set(exit_codes) - {0, None}
         if err_exit:
-            err = (f"At least one container exited with a non-zero "
+            err = ("At least one container exited with a non-zero "
                    + "error code. Please examine the logs for details.")
         else:
             err = "An unexpected error occurred."
         await self._updates.update_job_state(job.id, update_state.error(
-            "Check subjobs / containers for admin errors",  # maybe improve later,
+            "Check subjobs / containers for admin errors",  # maybe improve later
             user_error=err,
             log_files_path=str(Path(self._s3logdir) / job.id) if err_exit else None,
-            cpu_hours=cpu_hours,
-            cpu_factor=cpu_factor,
-            max_memory=max_mem,
+            htcondor_cpu_hours=condor_stats.cpu_hours,
+            htcondor_max_memory=condor_stats.max_memory,
+            htcondor_runtime_seconds=condor_stats.runtime_seconds,
         ))
         
     async def _complete_job(
@@ -380,7 +374,12 @@ class KBaseRunner(JobFlow):
         # to propagate so the caller can retry without killing the job.
         # update_time, if provided, is the subjob-derived completion timestamp. Error paths
         # intentionally ignore it — they represent newly discovered failures.
-        cpu_hours, cpu_factor, max_mem = await self._get_condor_stats(job)
+        condor_stats = await self._fetch_condor_classad_stats(job)
+        htcondor_kwargs = dict(
+            htcondor_cpu_hours=condor_stats.cpu_hours,
+            htcondor_max_memory=condor_stats.max_memory,
+            htcondor_runtime_seconds=condor_stats.runtime_seconds,
+        )
         subjobs = await self.get_subjobs(job.id)
         filechecksums = {}
         for sj in subjobs:
@@ -394,7 +393,9 @@ class KBaseRunner(JobFlow):
                 filechecksums[f.file] = f.crc64nvme
         if not filechecksums:
             err = "The job produced no output files"
-            await self._updates.update_job_state(job.id, update_state.error(err, user_error=err))
+            await self._updates.update_job_state(
+                job.id, update_state.error(err, user_error=err, **htcondor_kwargs)
+            )
             return
         s3objs = await self._s3.get_object_meta(S3Paths(filechecksums.keys()))
         outfiles = []
@@ -406,15 +407,14 @@ class KBaseRunner(JobFlow):
                 )
                 await self._updates.update_job_state(
                     # no way the user can fix this, something went very wrong
-                    job.id, update_state.error(err, user_error="An unexpected error occurred")
+                    job.id, update_state.error(
+                        err, user_error="An unexpected error occurred", **htcondor_kwargs
+                    )
                 )
                 return
             outfiles.append(models.S3File(file=o.path, crc64nvme=o.crc64nvme))
-        await self._updates.update_job_state(job.id, update_state.complete(
-            outfiles,
-            cpu_hours=cpu_hours,
-            cpu_factor=cpu_factor,
-            max_memory=max_mem
+        await self._updates.update_job_state(
+            job.id, update_state.complete(outfiles, **htcondor_kwargs
         ), update_time=update_time)
         
     async def cancel_job(self, job: models.AdminJobDetails):
@@ -429,18 +429,24 @@ class KBaseRunner(JobFlow):
         # Refresh: in the normal path this coroutine is spawned asynchronously and state
         # may have changed; in the recovery path the job is up-to-date but re-fetching is harmless.
         job = await self._mongo.get_job(job.id, as_admin=True)
-        cpu_hours = cpu_factor = max_mem = None
+        condor_stats = None
         if job.htcondor_details and job.htcondor_details.cluster_id:
             # assume there's only one job in the list for now
             await self._condor.cancel_job(job.htcondor_details.cluster_id[-1])
-            cpu_hours, cpu_factor, max_mem = await self._get_condor_stats(job)
+            condor_stats = await self._fetch_condor_classad_stats(job)
+        cpu_hours, max_mem, cpu_factor = await self._get_subjob_stats(job)
         await self._updates.update_job_state(job.id, update_state.canceled(
             cpu_hours=cpu_hours,
             cpu_factor=cpu_factor,
-            max_memory=max_mem
+            max_memory=max_mem,
+            htcondor_cpu_hours=condor_stats.cpu_hours if condor_stats else None,
+            htcondor_max_memory=condor_stats.max_memory if condor_stats else None,
+            htcondor_runtime_seconds=condor_stats.runtime_seconds if condor_stats else None,
         ))
 
-    async def _get_condor_stats(self, job: models.AdminJobDetails) -> tuple[float, float, int]:
+    async def _fetch_condor_classad_stats(
+        self, job: models.AdminJobDetails
+    ) -> CondorJobStats:
         attempts = 0
         # if cluster_id exists, there's a cluster ID in it
         cluster_id = job.htcondor_details.cluster_id[-1]
@@ -451,9 +457,29 @@ class KBaseRunner(JobFlow):
             # If the condor job errors, it's held with the current setup
             # Means the client and this code is coupled, might need to rethink
             if not running or condor_jobs_all_held(running):
-                return condor_job_stats(running + complete, job.job_input.cpus)
+                return condor_job_stats(running + complete)
             attempts += 1
         raise IOError("Condor jobs didn't complete for 60s after all executors sent termination")
+
+    async def _get_subjob_stats(
+        self, job: models.AdminJobDetails
+    ) -> tuple[float | None, int | None, float | None]:
+        """
+        Fetch subjobs and compute job-level stats.
+        Returns (total_cpu_hours, max_memory_bytes, cpu_factor).
+        """
+        subjobs = await self._mongo.get_subjobs(job.id)
+        cpu_hours_vals = [s.cpu_hours for s in subjobs if s.cpu_hours is not None]
+        memory_vals = [s.max_memory for s in subjobs if s.max_memory is not None]
+        runtime_vals = [s.runtime_seconds for s in subjobs if s.runtime_seconds is not None]
+        total_cpu_hours = sum(cpu_hours_vals) if cpu_hours_vals else None
+        max_memory = max(memory_vals) if memory_vals else None
+        cpu_factor = None
+        if total_cpu_hours is not None:
+            total_runtime_s = sum(runtime_vals)
+            if total_runtime_s:
+                cpu_factor = (total_cpu_hours * 3600) / (total_runtime_s * job.job_input.cpus)
+        return total_cpu_hours, max_memory, cpu_factor
     
     async def clean_job(self, job: models.AdminJobDetails, force: bool = False):
         """

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -56,6 +56,9 @@ FLD_JOB_JAWS_DETAILS = "jaws_details"
 FLD_JAWS_DETAILS_RUN_ID = "run_id"
 FLD_JOB_HTC_DETAILS = "htcondor_details"
 FLD_HTC_DETAILS_CLUSTER_ID = "cluster_id"
+FLD_HTC_DETAILS_CPU_HOURS = "cpu_hours"
+FLD_HTC_DETAILS_MAX_MEM = "max_memory"
+FLD_HTC_DETAILS_RUNTIME = "runtime_seconds"
 FLD_JOB_CPU_HOURS = "cpu_hours"
 FLD_JOB_CPU_FACTOR = "cpu_factor"
 FLD_JOB_MAX_MEM = "max_memory"
@@ -1063,6 +1066,20 @@ class HTCondorDetails(BaseModel):
         description="Cluster IDs for a HTCondor job. Multiple cluster IDs indicate job "
             + "retries after failures."
     )]
+    cpu_hours: Annotated[float | None, Field(
+        examples=[1.5],
+        description="Total CPU hours used by the job as reported by HTCondor, if available."
+    )] = None
+    max_memory: Annotated[int | None, Field(
+        examples=[536870912],
+        description="Peak memory in bytes used by any single container as reported by HTCondor, "
+            + "if available."
+    )] = None
+    runtime_seconds: Annotated[float | None, Field(
+        examples=[1800.0],
+        description="Total wall-clock runtime in seconds across all containers as reported by "
+            + "HTCondor, if available."
+    )] = None
 
 
 class AdminJobStateTransition(JobStateTransition):

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -573,6 +573,9 @@ class MongoDAO:
     _FLD_NERSC_DL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_DL_TASK_ID}"
     _FLD_JAWS_RUN_ID = f"{models.FLD_JOB_JAWS_DETAILS}.{models.FLD_JAWS_DETAILS_RUN_ID}"
     _FLD_HTC_CLUSTER_ID = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_CLUSTER_ID}"
+    _FLD_HTC_CPU_HOURS = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_CPU_HOURS}"
+    _FLD_HTC_MAX_MEM = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_MAX_MEM}"
+    _FLD_HTC_RUNTIME = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_RUNTIME}"
     _FLD_NERSC_UL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_UL_TASK_ID}"
     _FLD_NERSC_LOG_UL_TASK = (
         f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_LOG_UL_TASK_ID}"
@@ -582,6 +585,9 @@ class MongoDAO:
             UpdateField.NERSC_DOWNLOAD_TASK_ID: (self._FLD_NERSC_DL_TASK, True),
             UpdateField.JAWS_RUN_ID: (self._FLD_JAWS_RUN_ID, True),
             UpdateField.HTCONDOR_CLUSTER_ID: (self._FLD_HTC_CLUSTER_ID, True),
+            UpdateField.HTCONDOR_CPU_HOURS: (self._FLD_HTC_CPU_HOURS, False),
+            UpdateField.HTCONDOR_MAX_MEM: (self._FLD_HTC_MAX_MEM, False),
+            UpdateField.HTCONDOR_RUNTIME: (self._FLD_HTC_RUNTIME, False),
             UpdateField.CPU_HOURS: (models.FLD_JOB_CPU_HOURS, False),
             UpdateField.CPU_FACTOR: (models.FLD_JOB_CPU_FACTOR, False),
             UpdateField.MAX_MEMORY: (models.FLD_JOB_MAX_MEM, False),

--- a/cdmtaskservice/update_state.py
+++ b/cdmtaskservice/update_state.py
@@ -55,6 +55,15 @@ class UpdateField(StrEnum):
 
     RUNTIME = auto()
     """ The wall-clock runtime of a container in seconds. """
+
+    HTCONDOR_CPU_HOURS = auto()
+    """ The total CPU hours for a job as reported by HTCondor. """
+
+    HTCONDOR_MAX_MEM = auto()
+    """ The peak memory in bytes for a job as reported by HTCondor. """
+
+    HTCONDOR_RUNTIME = auto()
+    """ The total wall-clock runtime in seconds for a job as reported by HTCondor. """
     
     USER_ERROR = auto()
     """ Error information about a process targeted at a user. """
@@ -224,17 +233,21 @@ def submitted_jaws_job(jaws_run_id: str) -> JobUpdate:
     )
 
 
-def submitting_upload(cpu_hours: float = None) -> JobUpdate:
+def submitting_upload(
+    *,
+    cpu_hours: float = None,
+    cpu_factor: float = None,
+    max_memory: int = None,
+) -> JobUpdate:
     """
-    Update a job's state from job submitted to upload submitting and add cpu hours, if available.
+    Update a job's state from job submitted to upload submitting, with optional job-level stats.
     """
+    flds = {}
+    _set_job_stats(flds, cpu_hours, max_memory, cpu_factor)
     return JobUpdate(
         )._set_current_state(models.JobState.JOB_SUBMITTED
         )._set_new_state(models.JobState.UPLOAD_SUBMITTING
-        )._set_fields(
-            {
-                UpdateField.CPU_HOURS: _check_num(cpu_hours, "cpu_hours", minimum=0)
-            } if cpu_hours is not None else {}
+        )._set_fields(flds
     )
 
 
@@ -250,12 +263,7 @@ def submitting_upload_with_exit_code(
     and optionally cpu hours, max memory, and runtime.
     """
     flds = {UpdateField.EXIT_CODE: _check_num(exit_code, "exit_code", minimum=0)}
-    if cpu_hours is not None:
-        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
-    if max_memory is not None:
-        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
-    if runtime_seconds is not None:
-        flds[UpdateField.RUNTIME] = _check_num(runtime_seconds, "runtime_seconds", minimum=0)
+    _set_container_stats(flds, cpu_hours, max_memory, runtime_seconds)
     return JobUpdate(
         )._set_current_state(models.JobState.JOB_SUBMITTED
         )._set_new_state(models.JobState.UPLOAD_SUBMITTING
@@ -285,19 +293,67 @@ def submitted_nersc_upload(task_id: str) -> JobUpdate:
     )
 
 
+def _set_job_stats(
+    flds: dict,
+    cpu_hours: float | None,
+    max_memory: int | None,
+    cpu_factor: float | None,
+):
+    if cpu_hours is not None:
+        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
+    if max_memory is not None:
+        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
+    if cpu_factor is not None:
+        flds[UpdateField.CPU_FACTOR] = _check_num(cpu_factor, "cpu_factor", minimum=0)
+
+
+def _set_container_stats(
+    flds: dict,
+    cpu_hours: float | None,
+    max_memory: int | None,
+    runtime_seconds: float | None,
+):
+    if cpu_hours is not None:
+        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
+    if max_memory is not None:
+        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
+    if runtime_seconds is not None:
+        flds[UpdateField.RUNTIME] = _check_num(runtime_seconds, "runtime_seconds", minimum=0)
+
+
+def _set_htcondor_stats(
+    flds: dict,
+    htcondor_cpu_hours: float | None,
+    htcondor_max_memory: int | None,
+    htcondor_runtime_seconds: float | None,
+):
+    if htcondor_cpu_hours is not None:
+        flds[UpdateField.HTCONDOR_CPU_HOURS] = _check_num(
+            htcondor_cpu_hours, "htcondor_cpu_hours", minimum=0
+        )
+    if htcondor_max_memory is not None:
+        flds[UpdateField.HTCONDOR_MAX_MEM] = _check_num(
+            htcondor_max_memory, "htcondor_max_memory", minimum=0
+        )
+    if htcondor_runtime_seconds is not None:
+        flds[UpdateField.HTCONDOR_RUNTIME] = _check_num(
+            htcondor_runtime_seconds, "htcondor_runtime_seconds", minimum=0
+        )
+
+
 def complete(
     output_file_paths: list[models.S3File],
-    cpu_hours: float = None,
-    cpu_factor: float = None,
-    max_memory: int = None,
+    *,
+    htcondor_cpu_hours: float | None = None,
+    htcondor_max_memory: int | None = None,
+    htcondor_runtime_seconds: float | None = None,
 ) -> JobUpdate:
     """
     Update a job's state from upload submitted to complete.
-    
+
     output_file_paths - the output file paths.
-    cpu_hours - the job cpu hours, if available.
-    cpu_factor - the job's cpu usage factor, if available.
-    max_memory - the maximum memory used by the job in bytes, if available.
+    htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
+        htcondor_details, if available.
     """
     output_file_paths = output_file_paths or []
     out = [o.model_dump() for o in output_file_paths]
@@ -305,12 +361,7 @@ def complete(
         UpdateField.OUTPUT_FILE_PATHS: out,
         UpdateField.OUTPUT_FILE_COUNT: len(out),
     }
-    if cpu_hours is not None:  # Don't potentially clobber cpu hours if there's nothing to write
-        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
-    if cpu_factor is not None:
-        flds[UpdateField.CPU_FACTOR] = _check_num(cpu_factor, "cpu_factor", minimum=0)
-    if max_memory is not None:
-        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
+    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
     return JobUpdate(
         )._set_current_state(models.JobState.UPLOAD_SUBMITTED
         )._set_new_state(models.JobState.COMPLETE
@@ -357,25 +408,26 @@ def canceling() -> JobUpdate:
 
 
 def canceled(
+    *,
     cpu_hours: float = None,
     cpu_factor: float = None,
     max_memory: int = None,
+    htcondor_cpu_hours: float | None = None,
+    htcondor_max_memory: int | None = None,
+    htcondor_runtime_seconds: float | None = None,
 ) -> JobUpdate:
     """
     Set a job to the canceled state.
-    
+
     cpu_hours - the job cpu hours, if available.
     cpu_factor - the job's cpu usage factor, if available.
     max_memory - the maximum memory used by the job in bytes, if available.
+    htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
+        htcondor_details, if available.
     """
-    # There are 3 repetitions of this that are pretty similar. Make a dataclass maybe?
     flds = {}
-    if cpu_hours is not None:  # Don't potentially clobber cpu hours if there's nothing to write
-        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
-    if cpu_factor is not None:
-        flds[UpdateField.CPU_FACTOR] = _check_num(cpu_factor, "cpu_factor", minimum=0)
-    if max_memory is not None:
-        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
+    _set_job_stats(flds, cpu_hours, max_memory, cpu_factor)
+    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
     return JobUpdate(
         )._set_current_state(models.JobState.CANCELING
         )._set_new_state(models.JobState.CANCELED
@@ -388,18 +440,22 @@ def canceled(
 ####################
 
 
-def submitting_error_processing(cpu_hours: float | None = None) -> JobUpdate:
+def submitting_error_processing(
+    *,
+    cpu_hours: float | None = None,
+    cpu_factor: float | None = None,
+    max_memory: int | None = None,
+) -> JobUpdate:
     """
-    Update a job's state from job submitted to error processing submitting and add cpu hours,
-    if available.
+    Update a job's state from job submitted to error processing submitting, with optional
+    job-level stats.
     """
+    flds = {}
+    _set_job_stats(flds, cpu_hours, max_memory, cpu_factor)
     return JobUpdate(
         )._set_current_state(models.JobState.JOB_SUBMITTED
         )._set_new_state(models.JobState.ERROR_PROCESSING_SUBMITTING
-        )._set_fields(
-            {
-                UpdateField.CPU_HOURS: _check_num(cpu_hours, "cpu_hours", minimum=0)
-            } if cpu_hours is not None else {}
+        )._set_fields(flds
     )
 
 
@@ -415,12 +471,7 @@ def submitting_error_processing_with_exit_code(
     exit code, and optionally cpu hours, max memory, and runtime.
     """
     flds = {UpdateField.EXIT_CODE: _check_num(exit_code, "exit_code", minimum=0)}
-    if cpu_hours is not None:
-        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
-    if max_memory is not None:
-        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
-    if runtime_seconds is not None:
-        flds[UpdateField.RUNTIME] = _check_num(runtime_seconds, "runtime_seconds", minimum=0)
+    _set_container_stats(flds, cpu_hours, max_memory, runtime_seconds)
     return JobUpdate(
         )._set_current_state(models.JobState.JOB_SUBMITTED
         )._set_new_state(models.JobState.ERROR_PROCESSING_SUBMITTING
@@ -454,25 +505,25 @@ def submitted_nersc_error_processing(task_id: str) -> JobUpdate:
 
 def error(
     admin_error: str,
+    *,
     user_error: str = None,
     traceback: str = None,
     log_files_path: str = None,
-    cpu_hours: float = None,
-    cpu_factor: float = None,
-    max_memory: int = None,
+    htcondor_cpu_hours: float | None = None,
+    htcondor_max_memory: int | None = None,
+    htcondor_runtime_seconds: float | None = None,
 ) -> JobUpdate:
     """
     Update a job's state to error.
-    
+
     admin_error - an error message targeted towards a service admin.
     user_error - an error message targeted towards a service user. Leave as null to indicate there
         is no error message available appropriate for a user.
     traceback - the error traceback.
     log_files_path - the path to any logs for the job.
-    cpu_hours - the job cpu hours, if available.
-    cpu_factor - the job's cpu usage factor, if available.
-    max_memory - the maximum memory used by the job in bytes, if available.
-    """ 
+    htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
+        htcondor_details, if available.
+    """
     flds = {
         UpdateField.ADMIN_ERROR: _require_string(admin_error, "admin_error"),
         UpdateField.TRACEBACK: traceback,
@@ -480,12 +531,7 @@ def error(
     }
     if user_error is not None:
         flds[UpdateField.USER_ERROR] = user_error
-    if cpu_hours is not None:  # Don't potentially clobber cpu hours if there's nothing to write
-        flds[UpdateField.CPU_HOURS] = _check_num(cpu_hours, "cpu_hours", minimum=0)
-    if cpu_factor is not None:
-        flds[UpdateField.CPU_FACTOR] = _check_num(cpu_factor, "cpu_factor", minimum=0)
-    if max_memory is not None:
-        flds[UpdateField.MAX_MEMORY] = _check_num(max_memory, "max_memory", minimum=0)
+    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
     return JobUpdate(
         )._set_new_state(models.JobState.ERROR
         )._set_disallowed_current_states(
@@ -536,6 +582,7 @@ def refdata_complete() -> RefdataUpdate:
 def refdata_error(
     user_error: str,
     admin_error: str,
+    *,
     traceback: str = None,
 ) -> RefdataUpdate:
     """

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -22,18 +22,28 @@ from cdmtaskservice.timestamp import utcdatetime
 _T = utcdatetime()
 _TRANS_ID = "test-trans-id"
 
-# A realistic HTCondor job ClassAd used to exercise cpu_hours / cpu_factor / max_memory paths.
-# RemoteUserCpu=3600s, CommittedTime=1800s, cpus=1 → cpu_hours=1.0, cpu_factor=2.0.
-# MemoryUsage=512 MiB → max_memory=512*1024*1024 bytes.
+# HTCondor ClassAd — RemoteUserCpu=3500s+RemoteSysCpu=100s → cpu_hours=1.0,
+# CommittedTime=1200s → runtime_seconds=1200 (distinct from cpu_hours in seconds and
+# all subjob totals below), MemoryUsage=512 MiB.
 _CONDOR_AD = {
-    "RemoteUserCpu": 3600.0,
-    "RemoteSysCpu": 0.0,
-    "CommittedTime": 1800,
+    "RemoteUserCpu": 3500.0,
+    "RemoteSysCpu": 100.0,
+    "CommittedTime": 1200,
     "MemoryUsage": 512,
 }
-_CPU_HOURS = 1.0
-_CPU_FACTOR = 2.0
-_MAX_MEM = 512 * 1024 * 1024
+_HTC_CPU_HOURS = 1.0
+_HTC_MAX_MEM = 512 * 1024 * 1024
+_HTC_RUNTIME = 1200.0
+
+def _make_subjob(*, cpu_hours=None, max_memory=None, runtime_seconds=None,
+                 exit_code=None, outputs=None):
+    return models.SubJob.model_construct(
+        exit_code=exit_code,
+        cpu_hours=cpu_hours,
+        max_memory=max_memory,
+        runtime_seconds=runtime_seconds,
+        outputs=outputs or [],
+    )
 
 
 class _FakeCoroutineWrangler:
@@ -171,47 +181,104 @@ async def test_update_container_state_job_submitted():
 
 
 async def test_update_container_state_upload_submitting():
-    """All subjobs at UPLOAD_SUBMITTING - subjob carries exit code, parent job does not."""
+    """All subjobs at UPLOAD_SUBMITTING - subjob carries per-container stats, parent job gets
+    aggregated stats from subjobs."""
     runner, mongo, _, updates, _ = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(
         models.JobState.UPLOAD_SUBMITTING, _T
     )
-
-    await runner.update_container_state(
-        _JOB, 0, models.JobState.UPLOAD_SUBMITTING, _update(exit_code=0)
-    )
-
-    mongo.update_subjob_state.assert_called_once_with(
-        "jid", 0, update_state.submitting_upload_with_exit_code(0), _T
-    )
-    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.UPLOAD_SUBMITTING)
-    updates.update_job_state.assert_called_once_with(
-        "jid", update_state.submitting_upload(), update_time=_T
-    )
-
-
-async def test_update_container_state_upload_submitting_with_stats():
-    """UPLOAD_SUBMITTING with stats - all written to subjob."""
-    runner, mongo, _, updates, _ = _make_runner()
-    updates.get_parent_job_update.return_value = ParentJobUpdate(
-        models.JobState.UPLOAD_SUBMITTING, _T
-    )
+    # Container 0 reports its stats; container 1 is already stored. get_subjobs returns both.
+    # cpu_hours 0.6+0.4=1.0; max_memory max(400MB,300MB)=400MB; runtime 1200+600=1800s → factor=2.0
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=1200, exit_code=0),
+        _make_subjob(cpu_hours=0.4, max_memory=300*1024*1024, runtime_seconds=600,  exit_code=0),
+    ]
 
     await runner.update_container_state(
         _JOB, 0, models.JobState.UPLOAD_SUBMITTING,
-        _update(exit_code=0, cpu_hours=1.5, max_memory_bytes=1024, runtime_seconds=42.3),
+        _update(exit_code=0, cpu_hours=0.6, max_memory_bytes=400*1024*1024, runtime_seconds=1200),
     )
 
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.submitting_upload_with_exit_code(
-            0, cpu_hours=1.5, max_memory=1024, runtime_seconds=42.3
+            0, cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=1200
         ),
         _T,
     )
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.UPLOAD_SUBMITTING)
+    mongo.get_subjobs.assert_called_once_with("jid")
     updates.update_job_state.assert_called_once_with(
-        "jid", update_state.submitting_upload(), update_time=_T
+        "jid",
+        update_state.submitting_upload(cpu_hours=1.0, max_memory=400*1024*1024, cpu_factor=2.0),
+        update_time=_T,
+    )
+
+
+async def test_update_container_state_upload_submitting_partial_stats():
+    """UPLOAD_SUBMITTING: subjobs with None stats are excluded — only non-None values aggregate."""
+    runner, mongo, _, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(
+        models.JobState.UPLOAD_SUBMITTING, _T
+    )
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=1200, exit_code=0),
+        _make_subjob(exit_code=0),
+    ]
+
+    await runner.update_container_state(
+        _JOB, 0, models.JobState.UPLOAD_SUBMITTING,
+        _update(exit_code=0, cpu_hours=0.6, max_memory_bytes=400*1024*1024, runtime_seconds=1200),
+    )
+
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        # Only subjob 0's stats contribute: cpu_factor=(0.6*3600)/(1200*1)=1.8
+        update_state.submitting_upload(cpu_hours=0.6, max_memory=400*1024*1024, cpu_factor=1.8),
+        update_time=_T,
+    )
+
+
+async def test_update_container_state_upload_submitting_no_stats():
+    """UPLOAD_SUBMITTING: no subjobs have stats — job update carries no stats."""
+    runner, mongo, _, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(
+        models.JobState.UPLOAD_SUBMITTING, _T
+    )
+    mongo.get_subjobs.return_value = [
+        _make_subjob(exit_code=0),
+        _make_subjob(exit_code=0),
+    ]
+
+    await runner.update_container_state(
+        _JOB, 0, models.JobState.UPLOAD_SUBMITTING, _update(exit_code=0),
+    )
+
+    updates.update_job_state.assert_called_once_with(
+        "jid", update_state.submitting_upload(), update_time=_T,
+    )
+
+
+async def test_update_container_state_upload_submitting_no_runtime():
+    """UPLOAD_SUBMITTING: cpu_hours and max_memory present but no runtime → cpu_factor is None."""
+    runner, mongo, _, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(
+        models.JobState.UPLOAD_SUBMITTING, _T
+    )
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=None, exit_code=0),
+        _make_subjob(cpu_hours=0.4, max_memory=300*1024*1024, runtime_seconds=None, exit_code=0),
+    ]
+
+    await runner.update_container_state(
+        _JOB, 0, models.JobState.UPLOAD_SUBMITTING,
+        _update(exit_code=0, cpu_hours=0.6, max_memory_bytes=400*1024*1024),
+    )
+
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.submitting_upload(cpu_hours=1.0, max_memory=400*1024*1024),
+        update_time=_T,
     )
 
 
@@ -234,51 +301,41 @@ async def test_update_container_state_upload_submitted():
 
 
 async def test_update_container_state_error_processing_submitting():
-    """All subjobs at ERROR_PROCESSING_SUBMITTING - subjob carries exit code, parent does not."""
+    """All subjobs at ERROR_PROCESSING_SUBMITTING - subjob carries per-container stats, parent
+    gets aggregated stats from subjobs."""
     runner, mongo, _, updates, _ = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(
         models.JobState.ERROR_PROCESSING_SUBMITTING, _T
     )
-
-    await runner.update_container_state(
-        _JOB, 0, models.JobState.ERROR_PROCESSING_SUBMITTING, _update(exit_code=1)
-    )
-
-    mongo.update_subjob_state.assert_called_once_with(
-        "jid", 0, update_state.submitting_error_processing_with_exit_code(1), _T
-    )
-    updates.get_parent_job_update.assert_called_once_with(
-        _JOB, models.JobState.ERROR_PROCESSING_SUBMITTING
-    )
-    updates.update_job_state.assert_called_once_with(
-        "jid", update_state.submitting_error_processing(), update_time=_T
-    )
-
-
-async def test_update_container_state_error_processing_submitting_with_stats():
-    """ERROR_PROCESSING_SUBMITTING with stats - all written to subjob."""
-    runner, mongo, _, updates, _ = _make_runner()
-    updates.get_parent_job_update.return_value = ParentJobUpdate(
-        models.JobState.ERROR_PROCESSING_SUBMITTING, _T
-    )
+    # Container 0 reports its stats; container 1 is already stored. get_subjobs returns both.
+    # cpu_hours 0.6+0.4=1.0; max_memory max(400MB,300MB)=400MB; runtime 1800+1200=3000s → factor=1.2
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=1800, exit_code=1),
+        _make_subjob(cpu_hours=0.4, max_memory=300*1024*1024, runtime_seconds=1200, exit_code=0),
+    ]
 
     await runner.update_container_state(
         _JOB, 0, models.JobState.ERROR_PROCESSING_SUBMITTING,
-        _update(exit_code=1, cpu_hours=1.5, max_memory_bytes=1024, runtime_seconds=42.3),
+        _update(exit_code=1, cpu_hours=0.6, max_memory_bytes=400*1024*1024, runtime_seconds=1800),
     )
 
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.submitting_error_processing_with_exit_code(
-            1, cpu_hours=1.5, max_memory=1024, runtime_seconds=42.3
+            1, cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=1800
         ),
         _T,
     )
     updates.get_parent_job_update.assert_called_once_with(
         _JOB, models.JobState.ERROR_PROCESSING_SUBMITTING
     )
+    mongo.get_subjobs.assert_called_once_with("jid")
     updates.update_job_state.assert_called_once_with(
-        "jid", update_state.submitting_error_processing(), update_time=_T
+        "jid",
+        update_state.submitting_error_processing(
+            cpu_hours=1.0, max_memory=400*1024*1024, cpu_factor=1.2
+        ),
+        update_time=_T,
     )
 
 
@@ -313,7 +370,7 @@ async def test_update_container_state_terminal_error():
     mongo.get_exit_codes_for_subjobs.return_value = [1, 0]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
 
-    # asyncio.sleep is patched to make the _get_condor_stats polling loop instant
+    # asyncio.sleep is patched to make the _fetch_condor_classad_stats polling loop instant
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.update_container_state(
             _JOB, 1, models.JobState.ERROR,
@@ -327,6 +384,7 @@ async def test_update_container_state_terminal_error():
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    mongo.get_subjobs.assert_not_called()
     updates.update_job_state.assert_called_once_with(
         "jid",
         update_state.error(
@@ -336,9 +394,9 @@ async def test_update_container_state_terminal_error():
                 "error code. Please examine the logs for details."
             ),
             log_files_path="logs/jid",
-            cpu_hours=_CPU_HOURS,
-            cpu_factor=_CPU_FACTOR,
-            max_memory=_MAX_MEM,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
@@ -348,13 +406,13 @@ async def test_update_container_state_terminal_complete():
     runner, mongo, condor, updates, s3 = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.COMPLETE, _T)
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
-    sj = models.SubJob.model_construct(outputs=outputs)
+    sj = _make_subjob(exit_code=0, outputs=outputs)
     mongo.get_subjobs.return_value = [sj]
     s3obj = S3ObjectMeta("bucket/f.txt", "etag", 0, "aaaabbbbcccc")
     s3.get_object_meta.return_value = [s3obj]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
 
-    # asyncio.sleep is patched to make the _get_condor_stats polling loop instant
+    # asyncio.sleep is patched to make the _fetch_condor_classad_stats polling loop instant
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.update_container_state(
             _JOB, 0, models.JobState.COMPLETE, _update(outputs=outputs)
@@ -371,9 +429,9 @@ async def test_update_container_state_terminal_complete():
         "jid",
         update_state.complete(
             [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")],
-            cpu_hours=_CPU_HOURS,
-            cpu_factor=_CPU_FACTOR,
-            max_memory=_MAX_MEM,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
         update_time=_T,
     )
@@ -417,7 +475,7 @@ async def test_update_container_state_error_job_no_nonzero_exit_codes():
     mongo.get_exit_codes_for_subjobs.return_value = [0, None]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
 
-    # asyncio.sleep is patched to make the _get_condor_stats polling loop instant
+    # asyncio.sleep is patched to make the _fetch_condor_classad_stats polling loop instant
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.update_container_state(
             _JOB, 0, models.JobState.ERROR,
@@ -433,27 +491,28 @@ async def test_update_container_state_error_job_no_nonzero_exit_codes():
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    mongo.get_subjobs.assert_not_called()
     updates.update_job_state.assert_called_once_with(
         "jid",
         update_state.error(
             "Check subjobs / containers for admin errors",
             user_error="An unexpected error occurred.",
-            cpu_hours=_CPU_HOURS,
-            cpu_factor=_CPU_FACTOR,
-            max_memory=_MAX_MEM,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
 
 async def test_update_container_state_error_job_held_running_containers():
-    """_get_condor_stats exits on first iteration when all running containers are held."""
+    """_fetch_condor_classad_stats exits on first iteration when all running containers are held."""
     runner, mongo, condor, updates, _ = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
     mongo.get_exit_codes_for_subjobs.return_value = [1]
     # running=[held job] triggers an immediate exit via condor_jobs_all_held
     condor.get_cluster_classads.return_value = ([{"JobStatus": 5}], [_CONDOR_AD])
 
-    # asyncio.sleep is patched to make the _get_condor_stats polling loop instant;
+    # asyncio.sleep is patched to make the _fetch_condor_classad_stats polling loop instant
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.update_container_state(
             _JOB, 0, models.JobState.ERROR,
@@ -462,6 +521,7 @@ async def test_update_container_state_error_job_held_running_containers():
 
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    mongo.get_subjobs.assert_not_called()
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.error("container failed", traceback="Traceback: container failed"), _T,
@@ -476,15 +536,15 @@ async def test_update_container_state_error_job_held_running_containers():
                 "error code. Please examine the logs for details."
             ),
             log_files_path="logs/jid",
-            cpu_hours=_CPU_HOURS,
-            cpu_factor=_CPU_FACTOR,
-            max_memory=_MAX_MEM,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
 
 async def test_update_container_state_condor_stats_timeout():
-    """_get_condor_stats raises IOError after 12 attempts; handle_exception is called."""
+    """_fetch_condor_classad_stats raises IOError after 12 attempts; handle_exception is called."""
     runner, mongo, condor, updates, _ = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
     # JobStatus=2 (running, not held) keeps the loop going until the 12-attempt limit
@@ -503,6 +563,8 @@ async def test_update_container_state_condor_stats_timeout():
     )
     assert condor.get_cluster_classads.call_count == 12
     condor.get_cluster_classads.assert_called_with(123)
+    # IOError raised before get_subjobs is reached
+    mongo.get_subjobs.assert_not_called()
     mongo.get_exit_codes_for_subjobs.assert_not_called()
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
     exc = updates.handle_exception.call_args.args[0]
@@ -529,12 +591,14 @@ async def test_update_container_state_complete_job_no_outputs():
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.COMPLETE)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_subjobs.assert_called_once_with("jid")
-    # stats are computed but not forwarded on this error path
     updates.update_job_state.assert_called_once_with(
         "jid",
         update_state.error(
             "The job produced no output files",
             user_error="The job produced no output files",
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
@@ -567,6 +631,9 @@ async def test_update_container_state_complete_job_checksum_mismatch():
             "Expected CRC64/NVME checksum aaaaaaaaaaaa but got bbbbbbbbbbbb "
             "for uploaded file bucket/f.txt",
             user_error="An unexpected error occurred",
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
@@ -664,11 +731,15 @@ async def test_recover_job_standard_canceled_state():
 
 
 async def test_recover_job_standard_canceling_with_cluster_id():
-    """CANCELING: refreshed job has a cluster ID → full cancel flow runs."""
+    """CANCELING: refreshed job has a cluster ID → full cancel flow with condor and subjob stats."""
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.CANCELING)
     refreshed_job = _recovery_job(state=models.JobState.CANCELING)
     mongo.get_job.return_value = refreshed_job
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=600, exit_code=0),
+        _make_subjob(cpu_hours=0.4, max_memory=300*1024*1024, runtime_seconds=300, exit_code=0),
+    ]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
 
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
@@ -677,9 +748,15 @@ async def test_recover_job_standard_canceling_with_cluster_id():
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
     condor.cancel_job.assert_called_once_with(123)
     condor.get_cluster_classads.assert_called_once_with(123)
+    mongo.get_subjobs.assert_called_once_with("jid")
     updates.update_job_state.assert_called_once_with(
         "jid",
-        update_state.canceled(cpu_hours=_CPU_HOURS, cpu_factor=_CPU_FACTOR, max_memory=_MAX_MEM),
+        update_state.canceled(
+            cpu_hours=1.0, max_memory=400*1024*1024, cpu_factor=4.0,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
+        ),
     )
 
 
@@ -689,22 +766,26 @@ async def test_recover_job_standard_canceling_with_cluster_id():
 ])
 async def test_recover_job_standard_canceling_no_cluster_id(cluster_ids):
     """
-    CANCELING: refreshed job has no cluster ID (either no htcondor_details or empty cluster_id
-    list) → condor skipped, CANCELED written with no stats.
+    CANCELING: refreshed job has no cluster ID → condor skipped, CANCELED written with subjob stats.
     """
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.CANCELING)
     refreshed_job = _recovery_job(state=models.JobState.CANCELING, cluster_ids=cluster_ids)
     mongo.get_job.return_value = refreshed_job
+    mongo.get_subjobs.return_value = [
+        _make_subjob(cpu_hours=0.6, max_memory=400*1024*1024, runtime_seconds=600, exit_code=0),
+        _make_subjob(cpu_hours=0.4, max_memory=300*1024*1024, runtime_seconds=300, exit_code=0),
+    ]
 
     await runner.recover_job(job)
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
     condor.cancel_job.assert_not_called()
     condor.get_cluster_classads.assert_not_called()
+    mongo.get_subjobs.assert_called_once_with("jid")
     updates.update_job_state.assert_called_once_with(
         "jid",
-        update_state.canceled(cpu_hours=None, cpu_factor=None, max_memory=None),
+        update_state.canceled(cpu_hours=1.0, max_memory=400*1024*1024, cpu_factor=4.0),
     )
 
 
@@ -726,6 +807,14 @@ async def test_recover_job_standard_canceling_error_propagates():
     )
 
 
+# Expected parent-job update when all subjobs reach UPLOAD_SUBMITTING in recovery.
+# Matches the 1-subjob stats used in recovery tests: cpu_hours=0.5, max_memory=500MB,
+# runtime=720s → cpu_factor=(0.5*3600)/(720*1)=2.5.
+_UPLOAD_SUBMITTING_JOB_UPDATE = update_state.submitting_upload(
+    cpu_hours=0.5, max_memory=500*1024*1024, cpu_factor=2.5
+)
+
+
 async def test_recover_job_error_state_advance_to_complete():
     """
     Job in ERROR, no held/running containers → RECOVERING lock acquired, job reset via
@@ -745,7 +834,9 @@ async def test_recover_job_error_state_advance_to_complete():
     condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
 
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
-    sj = models.SubJob.model_construct(outputs=outputs)
+    # cpu_factor = (0.5*3600) / (720*1) = 2.5
+    sj = _make_subjob(cpu_hours=0.5, max_memory=500*1024*1024, runtime_seconds=720,
+                      exit_code=0, outputs=outputs)
     mongo.get_subjobs.return_value = [sj]
     s3.get_object_meta.return_value = [S3ObjectMeta("bucket/f.txt", "etag", 0, "aaaabbbbcccc")]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
@@ -756,7 +847,9 @@ async def test_recover_job_error_state_advance_to_complete():
     condor.get_cluster_proc_states.assert_called_once_with(123)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
-    mongo.get_subjobs.assert_called_once_with("jid")
+    # Called twice: once for UPLOAD_SUBMITTING stats, once in _complete_job for outputs
+    mongo.get_subjobs.assert_called_with("jid")
+    assert mongo.get_subjobs.call_count == 2
     s3.get_object_meta.assert_called_once_with(S3Paths(["bucket/f.txt"]))
     updates.get_parent_job_update.assert_not_called()
 
@@ -767,13 +860,15 @@ async def test_recover_job_error_state_advance_to_complete():
         ),
         call("jid", update_state.submitting_job(), update_time=advance_times[0]),
         call("jid", update_state.submitted_job(), update_time=advance_times[1]),
-        call("jid", update_state.submitting_upload(), update_time=advance_times[2]),
+        call("jid", _UPLOAD_SUBMITTING_JOB_UPDATE, update_time=advance_times[2]),
         call("jid", update_state.submitted_upload(), update_time=advance_times[3]),
         call(
             "jid",
             update_state.complete(
                 [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")],
-                cpu_hours=_CPU_HOURS, cpu_factor=_CPU_FACTOR, max_memory=_MAX_MEM,
+                htcondor_cpu_hours=_HTC_CPU_HOURS,
+                htcondor_max_memory=_HTC_MAX_MEM,
+                htcondor_runtime_seconds=_HTC_RUNTIME,
             ),
             update_time=advance_times[4],
         ),
@@ -844,16 +939,16 @@ async def test_recover_job_error_state_lock_fails():
     (models.JobState.DOWNLOAD_SUBMITTED, [
         (models.JobState.JOB_SUBMITTING, update_state.submitting_job()),
         (models.JobState.JOB_SUBMITTED, update_state.submitted_job()),
-        (models.JobState.UPLOAD_SUBMITTING, update_state.submitting_upload()),
+        (models.JobState.UPLOAD_SUBMITTING, _UPLOAD_SUBMITTING_JOB_UPDATE),
         (models.JobState.UPLOAD_SUBMITTED, update_state.submitted_upload()),
     ]),
     (models.JobState.JOB_SUBMITTING, [
         (models.JobState.JOB_SUBMITTED, update_state.submitted_job()),
-        (models.JobState.UPLOAD_SUBMITTING, update_state.submitting_upload()),
+        (models.JobState.UPLOAD_SUBMITTING, _UPLOAD_SUBMITTING_JOB_UPDATE),
         (models.JobState.UPLOAD_SUBMITTED, update_state.submitted_upload()),
     ]),
     (models.JobState.JOB_SUBMITTED, [
-        (models.JobState.UPLOAD_SUBMITTING, update_state.submitting_upload()),
+        (models.JobState.UPLOAD_SUBMITTING, _UPLOAD_SUBMITTING_JOB_UPDATE),
         (models.JobState.UPLOAD_SUBMITTED, update_state.submitted_upload()),
     ]),
     (models.JobState.UPLOAD_SUBMITTING, [
@@ -873,7 +968,9 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
     updates.get_parent_job_update.side_effect = parent_updates
 
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
-    sj = models.SubJob.model_construct(outputs=outputs)
+    # cpu_factor = (0.5*3600) / (720*1) = 2.5
+    sj = _make_subjob(cpu_hours=0.5, max_memory=500*1024*1024, runtime_seconds=720,
+                      exit_code=0, outputs=outputs)
     mongo.get_subjobs.return_value = [sj]
     s3obj = S3ObjectMeta("bucket/f.txt", "etag", 0, "aaaabbbbcccc")
     s3.get_object_meta.return_value = [s3obj]
@@ -884,7 +981,9 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
 
     condor.get_cluster_proc_states.assert_called_once_with(123)
     condor.get_cluster_classads.assert_called_once_with(123)
-    mongo.get_subjobs.assert_called_once_with("jid")
+    # get_subjobs called once per UPLOAD_SUBMITTING (stats) plus once in _complete_job (outputs)
+    mongo.get_subjobs.assert_called_with("jid")
+    assert mongo.get_subjobs.call_count == 2
     s3.get_object_meta.assert_called_once_with(S3Paths(["bucket/f.txt"]))
 
     expected_times = [_T + datetime.timedelta(seconds=i + 1) for i in range(len(state_updates))]
@@ -894,9 +993,9 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
         "jid",
         update_state.complete(
             [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")],
-            cpu_hours=_CPU_HOURS,
-            cpu_factor=_CPU_FACTOR,
-            max_memory=_MAX_MEM,
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
         update_time=complete_time,
     )]
@@ -931,6 +1030,9 @@ async def test_recover_job_complete_job_no_outputs():
         update_state.error(
             "The job produced no output files",
             user_error="The job produced no output files",
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
@@ -961,6 +1063,9 @@ async def test_recover_job_complete_job_checksum_mismatch():
             "Expected CRC64/NVME checksum aaaaaaaaaaaa but got bbbbbbbbbbbb "
             "for uploaded file bucket/f.txt",
             user_error="An unexpected error occurred",
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
     )
 
@@ -1161,7 +1266,9 @@ async def test_recover_job_force_all_complete():
     condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
 
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
-    sj = models.SubJob.model_construct(outputs=outputs)
+    # cpu_factor = (0.5*3600) / (720*1) = 2.5
+    sj = _make_subjob(cpu_hours=0.5, max_memory=500*1024*1024, runtime_seconds=720,
+                      exit_code=0, outputs=outputs)
     mongo.get_subjobs.return_value = [sj]
     s3.get_object_meta.return_value = [S3ObjectMeta("bucket/f.txt", "etag", 0, "aaaabbbbcccc")]
     condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
@@ -1172,7 +1279,9 @@ async def test_recover_job_force_all_complete():
     condor.get_cluster_proc_states.assert_called_once_with(123)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
-    mongo.get_subjobs.assert_called_once_with("jid")
+    # Called twice: once for UPLOAD_SUBMITTING stats, once in _complete_job for outputs
+    mongo.get_subjobs.assert_called_with("jid")
+    assert mongo.get_subjobs.call_count == 2
     s3.get_object_meta.assert_called_once_with(S3Paths(["bucket/f.txt"]))
     updates.get_parent_job_update.assert_not_called()
 
@@ -1183,13 +1292,15 @@ async def test_recover_job_force_all_complete():
         ),
         call("jid", update_state.submitting_job(), update_time=advance_times[0]),
         call("jid", update_state.submitted_job(), update_time=advance_times[1]),
-        call("jid", update_state.submitting_upload(), update_time=advance_times[2]),
+        call("jid", _UPLOAD_SUBMITTING_JOB_UPDATE, update_time=advance_times[2]),
         call("jid", update_state.submitted_upload(), update_time=advance_times[3]),
         call(
             "jid",
             update_state.complete(
                 [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")],
-                cpu_hours=_CPU_HOURS, cpu_factor=_CPU_FACTOR, max_memory=_MAX_MEM,
+                htcondor_cpu_hours=_HTC_CPU_HOURS,
+                htcondor_max_memory=_HTC_MAX_MEM,
+                htcondor_runtime_seconds=_HTC_RUNTIME,
             ),
             update_time=advance_times[4],
         ),

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -983,7 +983,7 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
     condor.get_cluster_classads.assert_called_once_with(123)
     # get_subjobs called once per UPLOAD_SUBMITTING (stats) plus once in _complete_job (outputs)
     mongo.get_subjobs.assert_called_with("jid")
-    assert mongo.get_subjobs.call_count == 2
+    assert mongo.get_subjobs.call_count == 2 if len(state_updates) > 1 else 1
     s3.get_object_meta.assert_called_once_with(S3Paths(["bucket/f.txt"]))
 
     expected_times = [_T + datetime.timedelta(seconds=i + 1) for i in range(len(state_updates))]

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -25,6 +25,7 @@ from cdmtaskservice.update_state import (
     submitted_nersc_refdata_download,
     submitting_job,
     submitting_upload,
+    submitting_upload_with_exit_code,
 )
 
 from conftest import (
@@ -337,7 +338,7 @@ async def test_update_job(mondb):
     dt2 = dt + datetime.timedelta(minutes=1)
     await mc.update_job_state("foo", submitting_job(), dt, "tid1")  # no fields
     await mc.update_job_state("foo", submitted_jaws_job("123"), dt, "tid2")  # array field
-    await mc.update_job_state("foo", submitting_upload(1.2), dt2, "tid3")  # std field
+    await mc.update_job_state("foo", submitting_upload(cpu_hours=1.2), dt2, "tid3")  # std field
     await mc.update_job_state("foo", error("adminerr", user_error="usererr"), dt2, "tid4")
     got = await mc.get_job("foo", as_admin=True)
     
@@ -375,6 +376,34 @@ async def test_update_job(mondb):
         ),
     ])
     assert got == expected
+
+
+async def test_update_job_htcondor_stats(mondb):
+    """HTCondor stats fields are written to htcondor_details subdocument and read back correctly."""
+    mc = await MongoDAO.create(mondb)
+    # HTCondorDetails.cluster_id is required, so initialise it before setting the stats fields
+    job = _BASEJOB.model_copy(deep=True)
+    job.htcondor_details = models.HTCondorDetails(cluster_id=[42])
+    await mc.save_job(job)
+
+    dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
+    await mc.update_job_state(
+        "foo",
+        error(
+            "admin err",
+            htcondor_cpu_hours=1.5,
+            htcondor_max_memory=536870912,
+            htcondor_runtime_seconds=1800.0,
+        ),
+        dt, "tid1",
+    )
+    got = await mc.get_job("foo", as_admin=True)
+    assert got.htcondor_details == models.HTCondorDetails(
+        cluster_id=[42],
+        cpu_hours=1.5,
+        max_memory=536870912,
+        runtime_seconds=1800.0,
+    )
 
 
 async def test_update_job_fail(mondb):
@@ -849,6 +878,36 @@ async def test_update_subjob(mondb):
         models.JobStateTransition(state=models.JobState.ERROR, time=dt2),
     ])
     assert got == expected
+
+
+async def test_update_subjob_container_stats(mondb):
+    """Container stats (exit_code, cpu_hours, max_memory, runtime_seconds) stored in subjob."""
+    mc = await MongoDAO.create(mondb)
+    dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
+    dt2 = dt + datetime.timedelta(minutes=1)
+    sj = models.SubJob(
+        id="bar",
+        sub_id=0,
+        state=models.JobState.JOB_SUBMITTED,
+        transition_times=[models.JobStateTransition(state=models.JobState.JOB_SUBMITTED, time=dt)],
+    )
+    await mc.initialize_subjobs([sj])
+    await mc.update_subjob_state(
+        "bar", 0,
+        submitting_upload_with_exit_code(0, cpu_hours=1.5, max_memory=536870912, runtime_seconds=1800.0),
+        dt2,
+    )
+
+    expected = sj.model_copy(deep=True)
+    expected.state = models.JobState.UPLOAD_SUBMITTING
+    expected.exit_code = 0
+    expected.cpu_hours = 1.5
+    expected.max_memory = 536870912
+    expected.runtime_seconds = 1800.0
+    expected.transition_times.append(
+        models.JobStateTransition(state=models.JobState.UPLOAD_SUBMITTING, time=dt2)
+    )
+    assert await mc.get_subjob("bar", 0) == expected
 
 
 async def test_update_subjob_fail(mondb):


### PR DESCRIPTION
If the container runs as a sibling to the htcondor container, htcondor can't detect cpu / memory usage. Use the data uploaded from the executor instead, but also record htcondor stats in admin job details for now.

Fixes #619 