### PR TITLE
Add endpoint for users to check external runner status

### DIFF
--- a/cdmtaskservice/jaws/client.py
+++ b/cdmtaskservice/jaws/client.py
@@ -17,6 +17,70 @@ from cdmtaskservice.arg_checkers import require_string as _require_string, not_f
 from cdmtaskservice.jaws.config import JAWSConfig
 
 
+class JAWSStatus(Enum):
+    """
+    Represents the status of the JAWS job. The many JAWS states are condensed to a small
+    number of states.
+    """
+    CREATED = 1
+    QUEUED = 2
+    RUNNING = 3
+    COMPLETE = 4
+    UNKNOWN = 100
+
+
+_JAWS_DONE = "done"
+
+
+# Maps condensed status enums to the raw JAWS states they cover.
+# States like "succeeded", "failed", and "cancelled" map to RUNNING rather than
+# a terminal status because JAWS always continues post-execution processing (output downloads,
+# permission fixes, notifications) before reaching "done" — nothing before "done" is truly final.
+# Also, most of these states are rare / very quick. In most cases the job is in queued, running,
+# or done.
+_ENUM_TO_STATUS = {
+    JAWSStatus.CREATED: ["created"],
+    JAWSStatus.QUEUED: [
+        "upload queued",
+        "uploading",
+        "upload failed",
+        "upload inactive",
+        "upload complete",
+        "ready",
+        "submitted",
+        "submission failed",
+        "queued",
+    ],
+    JAWSStatus.RUNNING: [
+        "running",
+        "succeeded",
+        "failed",
+        "complete",
+        "finished",
+        "cancel",
+        "cancelled",
+        "download queued",
+        "downloading",
+        "download failed",
+        "download inactive",
+        "download complete",
+        "download skipped",
+        "fix perms queued",
+        "fix perms complete",
+        "fix perms failed",
+        "sync complete",
+        "slack succeeded",
+        "slack failed",
+        "post succeeded",
+        "post failed",
+    ],
+    JAWSStatus.COMPLETE: [_JAWS_DONE],
+}
+
+
+_STATUS_TO_ENUM = {s: e for e, statuses in _ENUM_TO_STATUS.items() for s in statuses}
+
+
 class JAWSResult(Enum):
     """
     An enum of the possible JAWS result states.
@@ -37,6 +101,16 @@ class JAWSResult(Enum):
     """
     A JAWS system error prevented the job from running. Likely no output files are available.
     """
+
+
+_JAWS_RES_TO_ENUM = {
+    "succeeded": JAWSResult.SUCCESS,
+    "failed": JAWSResult.FAILED,
+    "cancelled": JAWSResult.CANCELED,
+    None: JAWSResult.SYSTEM_ERROR,
+}
+# TODO RELIABILITY cancelled is a possible result, but can be cancelled and still be null.
+#                  if null, check the jaws logs for a cancelled state
 
 
 class JAWSClient:
@@ -172,17 +246,15 @@ def is_done(job: dict[str, Any]) -> bool:
     """
     Given a JAWS status dictionary, determine if the job is done.
     """
-    return job["status"] == "done"
+    return job["status"] == _JAWS_DONE
 
 
-_JAWS_RES_TO_ENUM = {
-    "succeeded": JAWSResult.SUCCESS,
-    "failed": JAWSResult.FAILED,
-    "cancelled": JAWSResult.CANCELED,
-    None: JAWSResult.SYSTEM_ERROR,
-}
-# TODO RELIABILITY cancelled is a possible result, but can be cancelled and still be null.
-#                  if null, check the jaws logs for a cancelled state
+def status(job: dict[str, Any]) -> JAWSStatus:
+    """
+    Given a JAWS status dictionary, return the condensed status. Returns JAWSStatus.UNKNOWN
+    if the JAWS state is not recognized.
+    """
+    return _STATUS_TO_ENUM.get(job["status"], JAWSStatus.UNKNOWN)
 
 
 def result(job: dict[str, Any]) -> JAWSResult:

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -45,6 +45,15 @@ from cdmtaskservice.user import CTSUser
 from cdmtaskservice.timestamp import utcdatetime
 
 
+_PROC_STATE_TO_EXTERNAL = {
+    ProcState.QUEUED:    models.ExternalRunnerState.QUEUED,
+    ProcState.RUNNING:   models.ExternalRunnerState.RUNNING,
+    ProcState.HELD:      models.ExternalRunnerState.ERROR,
+    ProcState.COMPLETE:  models.ExternalRunnerState.COMPLETE,
+    ProcState.CANCELED:  models.ExternalRunnerState.CANCELED,
+    ProcState.OTHER:     models.ExternalRunnerState.UNKNOWN,
+}
+
 _RETRY_DELAY_SEC = 5 * 60  # configurable?
 _RECOVERY_COOLDOWN = datetime.timedelta(minutes=10)
 _STANDARD_PATH_STATES = frozenset(update_state.JOB_COMPLETED_PATH[1:-1])
@@ -204,14 +213,14 @@ class KBaseRunner(JobFlow):
             return await self._mongo.get_subjob(job_id, container_num)
         return await self._mongo.get_subjobs(job_id)
 
-    async def get_job_external_runner_status(
+    async def get_job_external_runner_details(
         self,
         job: models.AdminJobDetails,
         container_number: int = 0
     ) -> dict[str, Any]:
         """
         Get details from the external job runner (HTCondor in this case) about the job.
-        
+
         Returns the HTC ClassAd dict as returned from HTC. If the job has not yet been submitted
         to HTC, an empty dict is returned.
         """
@@ -229,6 +238,32 @@ class KBaseRunner(JobFlow):
         # if cluster_id exists, there's a cluster ID in it
         cluster_id = job.htcondor_details.cluster_id[-1]
         return await self._condor.get_container_classad(cluster_id, container_number)
+
+    async def get_job_external_runner_status(
+        self,
+        job: models.AdminJobDetails,
+    ) -> models.ExternalRunnerStatus:
+        """
+        Get the abstracted status of the job on HTCondor.
+
+        Returns one ExternalRunnerState per container. If the job has not yet been submitted
+        to HTCondor, all containers are reported as NONE.
+        """
+        _not_falsy(job, "job")
+        if job.job_input.cluster != self.CLUSTER:
+            raise ValueError(f"Job cluster must match {self.CLUSTER}")
+        if not job.htcondor_details or not job.htcondor_details.cluster_id:
+            n = job.job_input.num_containers
+            return models.ExternalRunnerStatus(
+                manages_containers=False,
+                states=[models.ExternalRunnerState.NONE] * n,
+            )
+        cluster_id = job.htcondor_details.cluster_id[-1]
+        proc_states = await self._condor.get_cluster_proc_states(cluster_id)
+        return models.ExternalRunnerStatus(
+            manages_containers=False,
+            states=[_PROC_STATE_TO_EXTERNAL[s] for s in proc_states],
+        )
 
     async def start_job(self, job: models.Job, objmeta: list[S3ObjectMeta]):
         """

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -52,6 +52,23 @@ from cdmtaskservice.update_state import (
 )
 from cdmtaskservice.user import CTSUser
 
+
+_JAWS_STATUS_TO_EXTERNAL = {
+    jaws_client.JAWSStatus.CREATED:  models.ExternalRunnerState.CREATED,
+    jaws_client.JAWSStatus.QUEUED:   models.ExternalRunnerState.QUEUED,
+    jaws_client.JAWSStatus.RUNNING:  models.ExternalRunnerState.RUNNING,
+    jaws_client.JAWSStatus.COMPLETE: models.ExternalRunnerState.COMPLETE,
+    jaws_client.JAWSStatus.UNKNOWN:  models.ExternalRunnerState.UNKNOWN,
+}
+
+_JAWS_RESULT_TO_EXTERNAL = {
+    jaws_client.JAWSResult.SUCCESS:      models.ExternalRunnerState.COMPLETE,
+    jaws_client.JAWSResult.FAILED:       models.ExternalRunnerState.ERROR,
+    jaws_client.JAWSResult.CANCELED:     models.ExternalRunnerState.CANCELED,
+    jaws_client.JAWSResult.SYSTEM_ERROR: models.ExternalRunnerState.ERROR,
+}
+
+
 # Not sure how other flows would work and how much code they might share. For now just make
 # this work and pull it apart / refactor later.
 
@@ -169,17 +186,17 @@ class NERSCJAWSRunner(JobFlow):
             f"This method is not supported for the {self.CLUSTER.value} job flow"
         )
 
-    async def get_job_external_runner_status(
+    async def get_job_external_runner_details(
         self,
         job: models.AdminJobDetails,
         container_number: int = None
     ) -> dict[str, Any]:
         """
         Get details from the external job runner (JAWS in this case) about the job.
-        
+
         Returns the JAWS status dict as returned from JAWS. If the job has not yet been submitted
         to JAWS, an empty dict is returned.
-        
+
         Since the containers are managed by JAWS, the container number is ignored.
         """
         # Could get the jaws logs and return container specific info in the future
@@ -190,6 +207,36 @@ class NERSCJAWSRunner(JobFlow):
             return {}  # job not submitted yet
         jaws_id = job.jaws_details.run_id[-1]  # if run_id exists, there's a job ID in it
         return await self._jaws.status(jaws_id)
+
+    async def get_job_external_runner_status(
+        self,
+        job: models.AdminJobDetails,
+    ) -> models.ExternalRunnerStatus:
+        """
+        Get the abstracted status of the job on JAWS.
+
+        Since JAWS manages all containers as a unit, the result is always a single-element list.
+        If the job has not yet been submitted to JAWS, returns NONE. If the job is done, the
+        state is derived from the JAWS result; otherwise it is derived from the JAWS status.
+        """
+        _not_falsy(job, "job")
+        if job.job_input.cluster != self.CLUSTER:
+            raise ValueError(f"Job cluster must match {self.CLUSTER}")
+        if not job.jaws_details or not job.jaws_details.run_id:
+            return models.ExternalRunnerStatus(
+                manages_containers=True,
+                states=[models.ExternalRunnerState.NONE],
+            )
+        jaws_id = job.jaws_details.run_id[-1]
+        jaws_job = await self._jaws.status(jaws_id)
+        if jaws_client.is_done(jaws_job):
+            state = _JAWS_RESULT_TO_EXTERNAL[jaws_client.result(jaws_job)]
+        else:
+            state = _JAWS_STATUS_TO_EXTERNAL[jaws_client.status(jaws_job)]
+        return models.ExternalRunnerStatus(
+            manages_containers=True,
+            states=[state],
+        )
 
     async def start_job(self, job: models.Job, objmeta: list[S3ObjectMeta]):
         """

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -860,6 +860,41 @@ class JobState(str, Enum):
         return self in self.canceling_states()
 
 
+class ExternalRunnerState(str, Enum):
+    """ The state of a job or container on an external compute resource. """
+    NONE = "none"
+    """ The job has not yet been submitted to the external runner. """
+    CREATED = "created"
+    """ The job has been created in the external runner but not yet queued. """
+    QUEUED = "queued"
+    """ The job is queued and waiting for resources. """
+    RUNNING = "running"
+    """ The job is actively running. """
+    COMPLETE = "complete"
+    """ The job completed successfully. """
+    ERROR = "error"
+    """ The job completed with an error. """
+    CANCELED = "canceled"
+    """ The job was canceled. """
+    UNKNOWN = "unknown"
+    """ The external runner reported a state this service does not recognize. """
+
+
+class ExternalRunnerStatus(BaseModel):
+    """ The status of a job as reported by an external compute resource. """
+    manages_containers: Annotated[bool, Field(
+        description="True if the external runner manages all containers as a unit, "
+            + "in which case `states` contains a single entry for the whole job. "
+            + "False if each entry in `states` corresponds to one container."
+    )]
+    states: Annotated[list[ExternalRunnerState], Field(
+        examples=[[ExternalRunnerState.RUNNING]],
+        description="The state of the job or its containers on the external runner. "
+            + "When `manages_containers` is true this list has a single entry for the whole job. "
+            + "When false, each entry corresponds to one container, indexed by container number.",
+    )]
+
+
 class JobStateTransition(BaseModel):
     """
     Denotes the new state and the entry time when a state change occurs.

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -481,6 +481,26 @@ async def cancel_job(
     await flow.cancel_job(job)
 
 
+@ROUTER_JOBS.get(
+    "/{job_id}/runner_status",
+    response_model=models.ExternalRunnerStatus,
+    summary="Get a job's external runner status",
+    description="Get the status of the job as reported by the external job runner, "
+        + "rather than the service's own state tracking.\n\n"
+        + "**This endpoint is rarely needed.** The standard job state endpoint is faster, "
+        + "cheaper, and sufficient for normal polling. Call this endpoint only when you suspect "
+        + "the service's job state has desynced from the external runner — for example, "
+        + "if a job appears stuck in the service but you want to verify what the runner reports."
+)
+async def get_job_runner_status(
+    r: Request,
+    job_id: _ANN_JOB_ID,
+    user: CTSUser=Depends(_AUTH),
+) -> models.ExternalRunnerStatus:
+    job, flow = await _get_job_and_flow(r, job_id, user)
+    return await flow.get_job_external_runner_status(job)
+
+
 _ANN_IMAGE_ID = Annotated[str, FastPath(
     openapi_examples={"image with digest": {
         "value": "ghcr.io/kbase/collections:checkm2_0.1.6"
@@ -839,7 +859,7 @@ async def _get_containers(
         + "If the job has not yet been submitted to an external runner, "
         + "an empty dictionary is returned."
 )
-async def get_job_runner_status(
+async def get_job_runner_details_admin(
     r: Request,
     job_id: _ANN_JOB_ID,
     container_number: Annotated[int, Query(
@@ -851,7 +871,7 @@ async def get_job_runner_status(
     user: CTSUser=Depends(_AUTH),
 ) -> dict[str, Any]:
     job, flow = await _admin_get_job_and_flow(r, job_id, user, "get job runner status.")
-    return await flow.get_job_external_runner_status(job, container_number=container_number)
+    return await flow.get_job_external_runner_details(job, container_number=container_number)
 
 
 @ROUTER_ADMIN.put(

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -62,7 +62,8 @@ services:
       - KBCTS_VERIFY_S3_EXTERNAL_URL=false
       - KBCTS_S3_ACCESS_KEY=miniouser
       - KBCTS_S3_ACCESS_SECRET=miniopassword
-      - KBCTS_S3_ALLOW_INSECURE=true
+      - KBCTS_S3_ALLOW_INSECURE=false
+      - KBCTS_S3_ALLOW_INSECURE_EXTERNAL=true
       - KBCTS_MONGO_HOST=mongodb://mongodb:27017
       - KBCTS_MONGO_DB=cdmtaskservice
       # TODO MONGOAUTH need to add a user to the cmdtaskservice db before this works out

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -3,6 +3,7 @@ import pytest
 from unittest.mock import call, create_autospec, patch, PropertyMock
 
 from cdmtaskservice.condor.client import CondorClient, ProcState
+from cdmtaskservice import sites
 from cdmtaskservice.config_s3 import S3Config
 from cdmtaskservice.exceptions import InvalidJobStateError, JobRecoveryError, UnsupportedOperationError
 from cdmtaskservice.jobflows.kbase import KBaseRunner
@@ -108,6 +109,71 @@ def _make_runner(_timestamp_fn=None):
         _trans_id_fn=lambda: _TRANS_ID,
     )
     return runner, mongo, condor, updates, s3
+
+
+######
+# get_job_external_runner_status tests
+######
+
+
+async def test_get_job_external_runner_status_null_job():
+    runner, _, _, _, _ = _make_runner()
+    with pytest.raises(ValueError, match="^job is required$"):
+        await runner.get_job_external_runner_status(None)
+
+
+async def test_get_job_external_runner_status_wrong_cluster():
+    runner, _, _, _, _ = _make_runner()
+    job = models.AdminJobDetails.model_construct(
+        job_input=models.JobInput.model_construct(cluster=sites.Cluster.PERLMUTTER_JAWS),
+    )
+    with pytest.raises(ValueError, match="Job cluster must match"):
+        await runner.get_job_external_runner_status(job)
+
+
+@pytest.mark.parametrize("htcondor_details", [None, models.HTCondorDetails(cluster_id=[])])
+async def test_get_job_external_runner_status_not_submitted(htcondor_details):
+    runner, _, _, _, _ = _make_runner()
+    job = models.AdminJobDetails.model_construct(
+        job_input=models.JobInput.model_construct(num_containers=3, cluster=sites.Cluster.KBASE),
+        htcondor_details=htcondor_details,
+    )
+    result = await runner.get_job_external_runner_status(job)
+    assert result == models.ExternalRunnerStatus(
+        manages_containers=False,
+        states=[models.ExternalRunnerState.NONE] * 3,
+    )
+
+
+async def test_get_job_external_runner_status_submitted():
+    """All ProcState values map to the correct ExternalRunnerState."""
+    runner, _, condor, _, _ = _make_runner()
+    job = models.AdminJobDetails.model_construct(
+        id="jid",
+        job_input=models.JobInput.model_construct(num_containers=6, cluster=sites.Cluster.KBASE),
+        htcondor_details=models.HTCondorDetails(cluster_id=[123]),
+    )
+    condor.get_cluster_proc_states.return_value = [
+        ProcState.QUEUED,
+        ProcState.RUNNING,
+        ProcState.HELD,
+        ProcState.COMPLETE,
+        ProcState.CANCELED,
+        ProcState.OTHER,
+    ]
+    result = await runner.get_job_external_runner_status(job)
+    assert result == models.ExternalRunnerStatus(
+        manages_containers=False,
+        states=[
+            models.ExternalRunnerState.QUEUED,
+            models.ExternalRunnerState.RUNNING,
+            models.ExternalRunnerState.ERROR,
+            models.ExternalRunnerState.COMPLETE,
+            models.ExternalRunnerState.CANCELED,
+            models.ExternalRunnerState.UNKNOWN,
+        ],
+    )
+    condor.get_cluster_proc_states.assert_called_once_with(123)
 
 
 ######


### PR DESCRIPTION
Provides an abstract, more understandable view than the similar admin endpoint which exposes way too much and leaks implementation details