### PR TITLE
 Refactor _update_job_state to use find_one_and_update with conditional  pipeline

### DIFF
--- a/cdmtaskservice/error_mapping.py
+++ b/cdmtaskservice/error_mapping.py
@@ -23,6 +23,7 @@ from cdmtaskservice.images import NoEntrypointError
 from cdmtaskservice.image_remote_lookup import ImageNameParseError, ImageInfoFetchError
 from cdmtaskservice.jobflows.flowmanager import InactiveJobFlowError, UnavailableJobFlowError
 from cdmtaskservice.job_state import NoJobLogsError
+from cdmtaskservice.models import NoRefdataClusterStatusError
 from cdmtaskservice.mongo import (
     ImageTagExistsError,
     ImageDigestExistsError,
@@ -81,6 +82,7 @@ _ERR_MAP = {
     InvalidJobStateError: ErrorMapping(ErrorType.INVALID_JOB_STATE, _H400),
     JobRecoveryError: ErrorMapping(ErrorType.JOB_RECOVERY, _H400),
     InvalidReferenceDataStateError: ErrorMapping(ErrorType.INVALID_REFDATA_STATE, _H400),
+    NoRefdataClusterStatusError: ErrorMapping(ErrorType.NO_REFDATA_CLUSTER_STATUS, _H400),
     UnavailableResourceError: ErrorMapping(ErrorType.RESOURCE_UNAVAILABLE, _H400),
     InactiveJobFlowError: ErrorMapping(ErrorType.JOB_FLOW_INACTIVE, _H400),
     UnavailableJobFlowError: ErrorMapping(ErrorType.JOB_FLOW_UNAVAILABLE, _H400),

--- a/cdmtaskservice/errors.py
+++ b/cdmtaskservice/errors.py
@@ -72,6 +72,9 @@ class ErrorType(Enum):
     INVALID_REFDATA_STATE =      (30400, "Invalid reference data state")
     """ The reference data is not in the correct state for the requested operation. """
 
+    NO_REFDATA_CLUSTER_STATUS =  (30410, "No cluster status for reference data")
+    """ The reference data has no status entry for the requested cluster. """
+
     NOT_FOUND =                  (40000, "Not Found")
     """ The requested resource was not found. """
     

--- a/cdmtaskservice/exceptions.py
+++ b/cdmtaskservice/exceptions.py
@@ -1,6 +1,7 @@
 """
 General exceptions used by multiple modules.
 """
+from cdmtaskservice.models import JobState
 
 
 class ChecksumMismatchError(Exception):
@@ -13,6 +14,15 @@ class IllegalParameterError(Exception):
 
 class InvalidJobStateError(Exception):
     """ An exception thrown when a job is in an invalid state to perform an operation. """
+
+    def __init__(self, message: str, actual_state: JobState | None = None):
+        """
+        message - the error message.
+        actual_state - the actual state of the job at the time of the error, if known.
+            Callers can inspect this to decide how to handle the error, e.g. whether to retry.
+        """
+        super().__init__(message)
+        self.actual_state = actual_state
 
 
 class InvalidReferenceDataStateError(Exception):

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -23,7 +23,6 @@ from cdmtaskservice.arg_checkers import (
     contains_control_characters as _contains_control_characters,
     not_falsy as _not_falsy,
 )
-from cdmtaskservice.exceptions import InvalidReferenceDataStateError
 from cdmtaskservice.s3.paths import validate_path, validate_bucket_name, S3PathSyntaxError
 from cdmtaskservice import sites
 from cdmtaskservice.timestamp import utcdatetime
@@ -1324,7 +1323,7 @@ class _ReferenceDataRoot(S3File, RegistrationInfo):
         for s in self.statuses:
             if s.cluster == cluster:
                 return s
-        raise InvalidReferenceDataStateError(
+        raise NoRefdataClusterStatusError(
             f"No status for cluster {cluster.value} for reference data {self.id}"
         )
 
@@ -1365,3 +1364,7 @@ class RefdataUpdate(BaseModel):
     traceback: Annotated[str | None, Field(
         description="The error's traceback. Ignored if the new state isn't the error state."
     )] = None
+
+
+class NoRefdataClusterStatusError(Exception):
+    """ Raised when reference data has no status entry for a requested cluster. """

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -6,7 +6,7 @@ DAO for MongoDB.
 
 import datetime
 from motor.motor_asyncio import AsyncIOMotorDatabase, AsyncIOMotorCollection
-from pymongo import IndexModel, ASCENDING, DESCENDING
+from pymongo import IndexModel, ASCENDING, DESCENDING, ReturnDocument
 from pymongo.errors import DuplicateKeyError
 from pymongo.results import DeleteResult
 from typing import Any, Awaitable, Callable, Coroutine, Iterable
@@ -443,50 +443,39 @@ class MongoDAO:
         update: JobUpdate,
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
-    ) -> dict[str, Any]:
-        query = {
-            models.FLD_COMMON_ID: _require_string(job_id, "job_id"),
-            _FLD_UPDATE_TIME: {"$lte": _not_falsy(time, "time")},
-        }
-        if update.current_state:
-            query[models.FLD_COMMON_STATE] = update.current_state.value
-        if update.disallowed_current_states:
-            query[models.FLD_COMMON_STATE] = {"$nin": [
-                s.value for s in update.disallowed_current_states
-            ]}
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        """Returns (filter_, apply_cond) for use in a conditional aggregation pipeline."""
+        filter_ = {models.FLD_COMMON_ID: _require_string(job_id, "job_id")}
         if subjob_id is not None:
-            query[models.FLD_SUBJOB_ID] = _check_num(subjob_id, "subjob_id", minimum=0)
+            filter_[models.FLD_SUBJOB_ID] = _check_num(subjob_id, "subjob_id", minimum=0)
+        conditions = [{"$lte": [f"${_FLD_UPDATE_TIME}", _not_falsy(time, "time")]}]
+        if update.current_state:
+            conditions.append(
+                {"$eq": [f"${models.FLD_COMMON_STATE}", update.current_state.value]}
+            )
+        if update.disallowed_current_states:
+            conditions.append({"$not": [{"$in": [
+                f"${models.FLD_COMMON_STATE}",
+                [s.value for s in update.disallowed_current_states],
+            ]}]})
         if recovery_cooldown and recovery_cooldown > datetime.timedelta(0):
-            query["$or"] = [
-                {_FLD_LAST_RECOVER: {"$exists": False}},
-                {_FLD_LAST_RECOVER: {"$lte": time - recovery_cooldown}},
-            ]
-        return query
+            conditions.append({"$or": [
+                {"$eq": [f"${_FLD_LAST_RECOVER}", None]},
+                {"$lte": [f"${_FLD_LAST_RECOVER}", time - recovery_cooldown]},
+            ]})
+        apply_cond = {"$and": conditions} if len(conditions) > 1 else conditions[0]
+        return filter_, apply_cond
 
-    async def _update_job_state_diagnose_err(
+    def _update_job_state_check_result(
         self,
-        col: AsyncIOMotorCollection,
+        pre_doc: dict | None,
         job_id: str,
         update: JobUpdate,
         time: datetime.datetime,
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
     ):
-        if not recovery_cooldown or recovery_cooldown <= datetime.timedelta(0):
-            recovery_cooldown = None
-        id_query = {models.FLD_COMMON_ID: job_id}
-        if subjob_id is not None:
-            id_query[models.FLD_SUBJOB_ID] = subjob_id
-        doc = await col.find_one(
-            id_query,
-            {
-                _FLD_MONGO_ID: 0,
-                models.FLD_COMMON_STATE: 1,
-                _FLD_LAST_RECOVER: 1,
-                _FLD_UPDATE_TIME: 1,
-            },
-        )
-        if doc is None:
+        if pre_doc is None:
             if subjob_id is not None:
                 raise NoSuchSubJobError(
                     f"No job with ID '{job_id}' and subjob ID {subjob_id} exists"
@@ -495,36 +484,28 @@ class MongoDAO:
         entity = f"Job '{job_id}'"
         if subjob_id is not None:
             entity = f"Job '{job_id}' with subjob ID {subjob_id}"
-        actual_state = doc[models.FLD_COMMON_STATE]
-        if update.current_state and actual_state != update.current_state.value:
+        actual_state = models.JobState(pre_doc[models.FLD_COMMON_STATE])
+        if update.current_state and actual_state != update.current_state:
             raise InvalidJobStateError(
-                f"{entity} is in state {actual_state!r}, "
-                f"expected {update.current_state.value!r}"
+                f"{entity} is in state {actual_state.value!r}, "
+                f"expected {update.current_state.value!r}",
+                actual_state=actual_state,
             )
-        if (
-            update.disallowed_current_states
-            and actual_state in {s.value for s in update.disallowed_current_states}
-        ):
-            raise InvalidJobStateError(f"{entity} is in disallowed state {actual_state!r}")
-        if doc[_FLD_UPDATE_TIME] > time:
-            raise ValueError(
-                f"{entity} last update time is after the provided time"
+        if update.disallowed_current_states and actual_state in update.disallowed_current_states:
+            raise InvalidJobStateError(
+                f"{entity} is in disallowed state {actual_state.value!r}",
+                actual_state=actual_state,
             )
-        # State constraints and timestamp are satisfied; the cooldown is the only
-        # remaining cause. Both recovery_cooldown and _last_recover are guaranteed
-        # non-null — unless the document changed between the original query and this
-        # diagnostic read (race condition), in which case we can't diagnose further.
-        last_recover = doc.get(_FLD_LAST_RECOVER)
-        if not recovery_cooldown or last_recover is None:
-            raise ValueError(  # This is too painful to test
-                f"{entity}: could not diagnose update failure; "
-                "the document may have changed between queries"
-            )
-        remaining = (last_recover + recovery_cooldown) - time
-        raise JobRecoveryError(
-            f"Job '{job_id}' was recovered too recently; "
-            f"must wait {remaining} more before forcing recovery again"
-        )
+        if pre_doc[_FLD_UPDATE_TIME] > time:
+            raise ValueError(f"{entity} last update time is after the provided time")
+        if recovery_cooldown and recovery_cooldown > datetime.timedelta(0):
+            last_recover = pre_doc.get(_FLD_LAST_RECOVER)
+            if last_recover and last_recover + recovery_cooldown > time:
+                remaining = (last_recover + recovery_cooldown) - time
+                raise JobRecoveryError(
+                    f"Job '{job_id}' was recovered too recently; "
+                    f"must wait {remaining} more before forcing recovery again"
+                )
 
     async def _update_job_state(
         self,
@@ -536,15 +517,10 @@ class MongoDAO:
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
     ):
-        set_ = {}
-        push = {}
-        for fld, val in _not_falsy(update, "update").update_fields.items():
-            jbfld, ispush = self._FIELD_TO_KEY_AND_PUSH[fld]
-            target = push if ispush else set_
-            target[jbfld] = val
-        query = self._update_job_state_query(job_id, time, update, subjob_id, recovery_cooldown)
-        if recovery_cooldown is not None:
-            set_[_FLD_LAST_RECOVER] = time
+        _not_falsy(update, "update")
+        filter_, apply_cond = self._update_job_state_query(
+            job_id, time, update, subjob_id, recovery_cooldown
+        )
         transition = {
             models.FLD_COMMON_STATE_TRANSITION_STATE: update.new_state.value,
             models.FLD_COMMON_STATE_TRANSITION_TIME: time,
@@ -553,22 +529,41 @@ class MongoDAO:
         if trans_id:
             transition.update({
                 models.FLD_JOB_STATE_TRANSITION_ID: trans_id,
-                models.FLD_JOB_STATE_TRANSITION_NOTIFICATION_SENT: False
+                models.FLD_JOB_STATE_TRANSITION_NOTIFICATION_SENT: False,
             })
-        res = await col.update_one(
-            query,
-            {
-                "$push": push | {models.FLD_COMMON_TRANS_TIMES: transition},
-                "$set": set_ | {
-                    models.FLD_COMMON_STATE: update.new_state.value,
-                    _FLD_UPDATE_TIME: time,  # for indexing last state change time
-                }
+        apply_sets: dict[str, Any] = {
+            models.FLD_COMMON_STATE: update.new_state.value,
+            _FLD_UPDATE_TIME: time,  # for indexing last state change time
+            models.FLD_COMMON_TRANS_TIMES: {"$concatArrays": [
+                f"${models.FLD_COMMON_TRANS_TIMES}", [transition]
+            ]},
+        }
+        for fld, val in update.update_fields.items():
+            jbfld, ispush = self._FIELD_TO_KEY_AND_PUSH[fld]
+            if ispush:
+                apply_sets[jbfld] = {"$concatArrays": [{"$ifNull": [f"${jbfld}", []]}, [val]]}
+            else:
+                apply_sets[jbfld] = val
+        if recovery_cooldown is not None:
+            apply_sets[_FLD_LAST_RECOVER] = time
+        pipeline = [{"$set": {
+            key: {"$cond": [apply_cond, val, f"${key}"]}
+            for key, val in apply_sets.items()
+        }}]
+        pre_doc = await col.find_one_and_update(
+            filter_,
+            pipeline,
+            projection={
+                _FLD_MONGO_ID: 0,
+                models.FLD_COMMON_STATE: 1,
+                _FLD_UPDATE_TIME: 1,
+                _FLD_LAST_RECOVER: 1,
             },
+            return_document=ReturnDocument.BEFORE,
         )
-        if not res.matched_count:
-            await self._update_job_state_diagnose_err(
-                col, job_id, update, time, subjob_id, recovery_cooldown
-            )
+        self._update_job_state_check_result(
+            pre_doc, job_id, update, time, subjob_id, recovery_cooldown
+        )
 
     _FLD_NERSC_DL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_DL_TASK_ID}"
     _FLD_JAWS_RUN_ID = f"{models.FLD_JOB_JAWS_DETAILS}.{models.FLD_JAWS_DETAILS_RUN_ID}"

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -409,6 +409,7 @@ async def test_update_job_htcondor_stats(mondb):
 async def test_update_job_fail(mondb):
     mc = await MongoDAO.create(mondb)
     await mc.save_job(_BASEJOB)
+    initial_doc = await mondb.jobs.find_one({"id": "foo"})
     
     u = submitting_job()
     dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
@@ -424,10 +425,11 @@ async def test_update_job_fail(mondb):
     ))
     await fail_update_job(mc, "foo", submitting_upload(), dt, tid, InvalidJobStateError(
         "Job 'foo' is in state 'download_submitted', expected 'job_submitted'"
-    ))
+    ), expected_actual_state=models.JobState.DOWNLOAD_SUBMITTED)
     await fail_update_job(mc, "foo", u, _SAFE_TIME + datetime.timedelta(milliseconds=-1), tid,
         ValueError("Job 'foo' last update time is after the provided time")
     )
+    assert await mondb.jobs.find_one({"id": "foo"}) == initial_doc
 
 
 async def test_update_job_and_subjob_fail_update_to_error(mondb):
@@ -445,17 +447,27 @@ async def test_update_job_and_subjob_fail_update_to_error(mondb):
     ):
         await mondb.jobs.update_one({}, {"$set": {"state": state.value}})
         await mondb.subjobs.update_one({}, {"$set": {"state": state.value}})
+        expected_job_doc = await mondb.jobs.find_one({"id": "foo"})
+        expected_subjob_doc = await mondb.subjobs.find_one(
+            {"id": "bar", "sub_id": 0}
+        )
         await fail_update_job(mc, "foo", u, dt, tid, InvalidJobStateError(
             f"Job 'foo' is in disallowed state {state.value!r}"
-        ))
+        ), expected_actual_state=state)
+        assert await mondb.jobs.find_one({"id": "foo"}) == expected_job_doc
         await fail_update_subjob(mc, "bar", 0, u, dt, InvalidJobStateError(
             f"Job 'bar' with subjob ID 0 is in disallowed state {state.value!r}"
-        ))
+        ), expected_actual_state=state)
+        assert await mondb.subjobs.find_one(
+            {"id": "bar", "sub_id": 0}
+        ) == expected_subjob_doc
 
 
-async def fail_update_job(mc, job_id, update, dt, tid, expected):
-    with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$"):
+async def fail_update_job(mc, job_id, update, dt, tid, expected, expected_actual_state=None):
+    with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$") as exc_info:
         await mc.update_job_state(job_id, update, dt, tid)
+    if isinstance(expected, InvalidJobStateError):
+        assert exc_info.value.actual_state == expected_actual_state
 
 
 def check_job_retry_fields(jobdoc: dict[str, Any]):
@@ -577,14 +589,17 @@ async def test_update_job_recovery_cooldown_state_mismatch(mondb):
     await mc.save_job(_BASEJOB)  # state = DOWNLOAD_SUBMITTED
 
     dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
+    initial_doc = await mondb.jobs.find_one({"id": "foo"})
     # force_recovering requires current state = RECOVERING, but job is DOWNLOAD_SUBMITTED
     with pytest.raises(InvalidJobStateError, match=(
         r"^Job 'foo' is in state 'download_submitted', expected 'recovering'$"
-    )):
+    )) as exc_info:
         await mc.update_job_state(
             "foo", force_recovering(), dt, "tid1",
             recovery_cooldown=datetime.timedelta(minutes=10),
         )
+    assert exc_info.value.actual_state == models.JobState.DOWNLOAD_SUBMITTED
+    assert await mondb.jobs.find_one({"id": "foo"}) == initial_doc
 
 
 async def test_update_job_recovery_cooldown_fail(mondb):
@@ -599,6 +614,7 @@ async def test_update_job_recovery_cooldown_fail(mondb):
 
     # force recovery within the cooldown window should fail; remaining = 10min - 5min = 5min
     dt2 = dt + datetime.timedelta(minutes=4)
+    expected_doc = await mondb.jobs.find_one({"id": "foo"})
     with pytest.raises(JobRecoveryError, match=(
         r"^Job 'foo' was recovered too recently; "
         r"must wait 0:06:00 more before forcing recovery again$"
@@ -607,9 +623,7 @@ async def test_update_job_recovery_cooldown_fail(mondb):
             "foo", force_recovering(), dt2, "tid2",
             recovery_cooldown=datetime.timedelta(minutes=10),
         )
-    # job state should be unchanged
-    job = await mondb.jobs.find_one({"id": "foo"})
-    assert job["_last_recover"] == dt
+    assert await mondb.jobs.find_one({"id": "foo"}) == expected_doc
 
     # force recovery after the cooldown window should succeed
     dt3 = dt + datetime.timedelta(minutes=11)
@@ -913,6 +927,7 @@ async def test_update_subjob_container_stats(mondb):
 async def test_update_subjob_fail(mondb):
     mc = await MongoDAO.create(mondb)
     await mc.initialize_subjobs([_BASESUBJOB1])
+    initial_doc = await mondb.subjobs.find_one({"id": "bar", "sub_id": 0})
     
     u = submitted_download()
     dt = datetime.datetime(2025, 4, 2, 12, 0, 0, 345000, tzinfo=datetime.timezone.utc)
@@ -930,15 +945,18 @@ async def test_update_subjob_fail(mondb):
     ))
     await fail_update_subjob(mc, "bar", 0, submitting_upload(), dt, InvalidJobStateError(
         "Job 'bar' with subjob ID 0 is in state 'created', expected 'job_submitted'"
-    ))
+    ), expected_actual_state=models.JobState.CREATED)
     await fail_update_subjob(mc, "bar", 0, u, _SAFE_TIME + datetime.timedelta(milliseconds=-1),
         ValueError("Job 'bar' with subjob ID 0 last update time is after the provided time")
     )
+    assert await mondb.subjobs.find_one({"id": "bar", "sub_id": 0}) == initial_doc
 
 
-async def fail_update_subjob(mc, job_id, subjob_id, update, dt, expected):
-    with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$"):
+async def fail_update_subjob(mc, job_id, subjob_id, update, dt, expected, expected_actual_state=None):
+    with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$") as exc_info:
         await mc.update_subjob_state(job_id, subjob_id, update, dt)
+    if isinstance(expected, InvalidJobStateError):
+        assert exc_info.value.actual_state == expected_actual_state
 
 
 async def test_subjob_hidden_fields(mondb):


### PR DESCRIPTION
Replace the two-query pattern (update_one + diagnostic find_one) with a
single find_one_and_update using a conditional aggregation pipeline. The
pipeline uses $cond to make the update a structural no-op when
state/time/cooldown constraints fail, while always returning the
pre-update document for deterministic error diagnosis. This eliminates
the race-condition-induced "could not diagnose update  failure"
ValueError.

Add actual_state: JobState | None to InvalidJobStateError so callers can
inspect the job's state at the time of failure (e.g. to decide whether
to retry).

Break the circular import between models.py and exceptions.py by moving
NoRefdataClusterStatusError into models.py (where get_status_for_cluster
lives) and giving it a distinct appcode (30410) so it is distinguishable
from InvalidReferenceDataStateError in the API.

Update tests to assert actual_state on InvalidJobStateError and verify
raw MongoDB documents are unchanged after every failed update condition.