### PR TITLE
Refactor container runner for eventual timeout handling

### DIFF
--- a/cdmtaskservice/externalexecution/container_runner.py
+++ b/cdmtaskservice/externalexecution/container_runner.py
@@ -6,12 +6,9 @@ import asyncio
 from dataclasses import dataclass
 import datetime
 import docker
-from functools import lru_cache
 import logging
 from pathlib import Path
-import signal
 import threading
-from typing import Awaitable, Callable
 
 from cdmtaskservice.arg_checkers import require_string as _require_string, not_falsy as _not_falsy
 
@@ -25,18 +22,14 @@ class ContainerResult:
     max_memory_bytes: int | None
 
 
-@lru_cache
-def _get_client():
-    # don't create the client on module load
-    return docker.from_env()
-
-
 def _make_log_thread(
     container: docker.models.containers.Container, path: Path, stdout: bool
 ) -> threading.Thread:
     def stream():
         with path.open("wb") as f:
-            for chunk in container.logs(stdout=stdout, stderr=not stdout, stream=True, follow=True):
+            for chunk in container.logs(
+                stdout=stdout, stderr=not stdout, stream=True, follow=True
+            ):
                 f.write(chunk)
                 f.flush()
     return threading.Thread(target=stream, daemon=True)
@@ -85,127 +78,157 @@ def _make_stats_thread(
     return threading.Thread(target=stream, daemon=True), result
 
 
-def _stream_data(
-    container: docker.models.containers.Container, stdout_path: Path, stderr_path: Path
-) -> dict:
+class RunningContainer:
     """
-    Stream container logs and stats in background threads, blocking until all complete.
-    Returns the stats result dict from _make_stats_thread.
+    A handle to a running Docker container. Not concurrency-safe.
+
+    Obtain instances via ContainerCreator.start_container().
     """
-    stop_stats = threading.Event()
-    stats_thread, stats = _make_stats_thread(container, stop_stats)
-    log_threads = [
-        _make_log_thread(container, stdout_path, stdout=True),
-        _make_log_thread(container, stderr_path, stdout=False),
-    ]
-    for t in [*log_threads, stats_thread]:
-        t.start()
-    for t in log_threads:
-        t.join()
-    stop_stats.set()
-    stats_thread.join()
-    return stats
 
+    def __init__(
+        self,
+        container: docker.models.containers.Container,
+        stdout_path: Path,
+        stderr_path: Path,
+    ):
+        self._container = container
+        self._logr = logging.getLogger(__name__)
+        self._stop_stats = threading.Event()
+        self._stats_thread, self._stats_result = _make_stats_thread(container, self._stop_stats)
+        self._log_threads = [
+            _make_log_thread(container, stdout_path, stdout=True),
+            _make_log_thread(container, stderr_path, stdout=False),
+        ]
+        for t in [*self._log_threads, self._stats_thread]:
+            t.start()
+        self._result: ContainerResult | None = None
 
-async def run_container(
-    image: str,
-    stdout_path: Path,
-    stderr_path: Path,
-    *,
-    command: list[str] | None = None,
-    env: dict[str, str] | None = None,
-    mounts: dict[str, tuple[str, bool]] | None = None,
-    post_start_callback: Awaitable[None] | None = None,
-    sigterm_callback: Callable[[int], None] | None = None,
-) -> ContainerResult:
-    """
-    Run a container and wait for it to complete.
+    async def __aenter__(self):
+        return self
 
-    image - the image to run.
-    stdout_path - a file where stdout logs should be streamed.
-    stderr_path - a file where stderr logs should be streamed.
-    command - a command to provide to the container.
-    env - a map from environment variable to environment value to provide to the container
-    mounts - mounting directives for the container. A map from the host mount path to a tuple of
-        * the container mount path
-        * A boolean denoting whether the mounts should be read write (True) or just read (False)
-    post_start_callback - an awaitable that will be awaited when the container has started but
-        before streaming logs.
-    sigterm_callback - a callable that will be called if a SIGTERM or SIGINT is sent to the
-        process, after a stop signal is sent to the docker container. The argument is the signal
-        number.
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        await self.cancel()
 
-    Returns a ContainerResult with the exit code, wall-clock runtime in seconds from the Docker
-    daemon's StartedAt/FinishedAt timestamps, and optionally peak memory usage in bytes and total
-    CPU usage in hours collected by streaming stats during container execution.
-    """
-    _require_string(image, "image")
-    _not_falsy(stdout_path, "stdout_path")
-    _not_falsy(stderr_path, "stderr_path")
-    logr = logging.getLogger(__name__)
+    def _join_threads(self, timeout: float | None = None):
+        for t in self._log_threads:
+            t.join(timeout=timeout)
+        self._stop_stats.set()
+        self._stats_thread.join(timeout=timeout)
 
-    client = _get_client()
-    mounts = mounts or {}
-    volumes = {
-        host: {"bind": container, "mode": "rw" if rw else "ro"}
-        for host, (container, rw) in mounts.items()
-    }
+    async def _finish(self, *, cancel: bool = False) -> ContainerResult:
+        if self._result:
+            return self._result
+        try:
+            if cancel:
+                await asyncio.to_thread(self._stop_container)
+            # Run in a thread so the event loop stays free dur-ing container execution
+            await asyncio.to_thread(self._join_threads, 30 if cancel else None)
+            # Saved so subsequent calls return the cached result without querying
+            # the removed container if there's a race, since _collect_result is synchronous
+            self._result = self._result or self._collect_result()
+            return self._result
+        finally:
+            self._remove_container()
 
-    container = client.containers.run(
-        image=image,
-        entrypoint=command,
-        environment=env,
-        volumes=volumes,
-        detach=True,
-        tty=False,
-        remove=False,  # Don't remove immediately to ensure logs are written
-        cap_drop=["ALL"],
-        security_opt=["no-new-privileges:true"],
-    )
+    def _stop_container(self):
+        self._logr.info(f"Stopping container {self._container.short_id}")
+        try:
+            self._container.stop(timeout=10)
+            self._logr.info(f"Stopped container {self._container.short_id}")
+        except docker.errors.NotFound:
+            pass
+        except Exception as e:
+            self._logr.exception(f"Failed to stop container: {e}")
 
-    def cleanup(signum, frame):
-        logr.info(f"Got signum {signum}")
-        if container:
-            logr.info(f"Stopping container {container.short_id}")
-            try:
-                container.stop(timeout=10)
-                logr.info(f"Stopped container {container.short_id}")
-            except Exception as e:
-                logr.exception(f"Failed to stop container: {e}")
-        # Probably the right way to do this is to turn this into a class and add a stop()
-        # method or something, but this is internal only code for now and this way is faster.
-        # If needed move the signal catching out of here and make the class.
-        sigterm_callback(signum)
+    async def wait(self) -> ContainerResult:
+        """
+        Wait for the container to complete.
 
-    try:
-        signal.signal(signal.SIGTERM, cleanup)
-        signal.signal(signal.SIGINT, cleanup)
-        logr.info(f"Container started: {container.short_id}")
-        if post_start_callback:
-            await post_start_callback
+        Returns a ContainerResult with the exit code, wall-clock runtime, and optionally
+        peak memory and CPU hours. Idempotent — subsequent calls return the cached result.
+        """
+        return await self._finish()
 
-        # Run in a thread so the event loop stays free during container execution
-        stats = await asyncio.to_thread(_stream_data, container, stdout_path, stderr_path)
+    async def cancel(self) -> ContainerResult:
+        """
+        Stop the container and wait for all log and stats threads to exit.
 
-        result = container.wait()
-        exit_code = result["StatusCode"]
+        Returns a ContainerResult with the exit code, wall-clock runtime, and optionally
+        peak memory and CPU hours. Idempotent — subsequent calls return the cached result.
+        """
+        return await self._finish(cancel=True)
 
-        container.reload()
-        started_at = datetime.datetime.fromisoformat(container.attrs["State"]["StartedAt"])
-        finished_at = datetime.datetime.fromisoformat(container.attrs["State"]["FinishedAt"])
+    def _collect_result(self) -> ContainerResult:
+        exit_code = self._container.wait()["StatusCode"]
+        self._container.reload()
+        started_at = datetime.datetime.fromisoformat(
+            self._container.attrs["State"]["StartedAt"]
+        )
+        finished_at = datetime.datetime.fromisoformat(
+            self._container.attrs["State"]["FinishedAt"]
+        )
         runtime_seconds = (finished_at - started_at).total_seconds()
-
-        cpu_total_ns = stats.get("cpu_total_ns")
-        cpu_hours = cpu_total_ns / (1e9 * 3600) if cpu_total_ns is not None else None
-
+        cpu_total_ns = self._stats_result.get("cpu_total_ns")
         return ContainerResult(
             exit_code=exit_code,
             runtime_seconds=runtime_seconds,
-            cpu_hours=cpu_hours,
-            max_memory_bytes=stats.get("max_memory_bytes"),
+            cpu_hours=cpu_total_ns / (1e9 * 3600) if cpu_total_ns is not None else None,
+            max_memory_bytes=self._stats_result.get("max_memory_bytes"),
         )
-    finally:
+
+    def _remove_container(self):
         try:
-            container.remove(force=True)
+            self._container.remove(force=True)
+        except docker.errors.NotFound:
+            pass
         except docker.errors.APIError as e:
-            logr.exception(f"Cleanup failed: {e}")
+            self._logr.exception(f"Cleanup failed: {e}")
+
+
+
+class ContainerCreator:
+    """Creates and starts Docker containers. Inject this to enable mocking in tests."""
+
+    async def start_container(
+        self,
+        image: str,
+        stdout_path: Path,
+        stderr_path: Path,
+        *,
+        command: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        mounts: dict[str, tuple[str, bool]] | None = None,
+    ) -> RunningContainer:
+        """
+        Start a container and return a handle to it.
+
+        image - the image to run.
+        stdout_path - a file where stdout logs should be streamed.
+        stderr_path - a file where stderr logs should be streamed.
+        command - a command to provide to the container.
+        env - a map from environment variable name to value for the container.
+        mounts - mounting directives. A map from host path to a tuple of:
+            * the container mount path
+            * a boolean: True for read-write, False for read-only.
+        """
+        _require_string(image, "image")
+        _not_falsy(stdout_path, "stdout_path")
+        _not_falsy(stderr_path, "stderr_path")
+        client = docker.from_env()
+        volumes = {
+            host: {"bind": container_path, "mode": "rw" if rw else "ro"}
+            for host, (container_path, rw) in (mounts or {}).items()
+        }
+        container = client.containers.run(
+            image=image,
+            entrypoint=command,
+            environment=env,
+            volumes=volumes,
+            detach=True,
+            tty=False,
+            remove=False,  # Don't remove immediately to ensure logs are written
+            cap_drop=["ALL"],
+            security_opt=["no-new-privileges:true"],
+        )
+        logging.getLogger(__name__).info(f"Container started: {container.short_id}")
+        return RunningContainer(container, stdout_path, stderr_path)

--- a/cdmtaskservice/externalexecution/executor.py
+++ b/cdmtaskservice/externalexecution/executor.py
@@ -7,6 +7,7 @@ import asyncio
 import json
 import logging
 from pathlib import Path
+import signal
 import sys
 import time
 import traceback
@@ -16,7 +17,11 @@ from typing import TextIO, Any
 from cdmtaskservice.argument_generator import ArgumentGenerator
 from cdmtaskservice.exceptions import ChecksumMismatchError
 from cdmtaskservice.externalexecution.config import Config
-from cdmtaskservice.externalexecution import container_runner
+from cdmtaskservice.externalexecution.container_runner import (
+    ContainerCreator,
+    ContainerResult,
+    RunningContainer,
+)
 from cdmtaskservice.git_commit import GIT_COMMIT
 from cdmtaskservice.jobflows.container_filenames import get_filenames_for_container
 from cdmtaskservice import models
@@ -35,10 +40,11 @@ _OUTPUT = "__output__"
 
 class Executor:
     """ The executor. Note that the executor is not concurrency safe. """
-    
-    def __init__(self, cfg: Config):
+
+    def __init__(self, cfg: Config, container_creator: ContainerCreator):
         """ Create the executor from the configuration. """
         self._cfg = cfg
+        self._creator = container_creator
         self._url = self._cfg.cts_url.rstrip("/")
         self._sess = aiohttp.ClientSession(
             headers={"Authorization": f"Bearer {cfg.get_cts_token()}"}
@@ -46,19 +52,20 @@ class Executor:
         self._logr = logging.getLogger(__name__)
         self._args = None
         self._s3cli = None  # created lazily
-    
+        self._runner: RunningContainer | None = None
+
     async def __aenter__(self):
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
-        
+
     async def close(self):
         """ Close any resources associated with the executor. """
         await self._sess.close()
         if self._s3cli:
             await self._s3cli.close()
-    
+
     async def _heartbeat_loop(self, job_id: uuid.UUID):
         url = (
             f"{self._url}/external_exec/jobs/{job_id}"
@@ -72,6 +79,28 @@ class Executor:
                 self._logr.warning("Heartbeat failed, will retry next interval: %s", e)
             await asyncio.sleep(self._cfg.heartbeat_interval_min * 60)
 
+    def _setup_signal_handlers(self):
+        async def on_signal(signum: int):
+            self._logr.info(f"Received signal {signum}, stopping")
+            if self._runner:
+                await self._runner.cancel()
+            sys.exit(128 + signum)
+
+        def _retrieve_exc(task):
+            # Calling exception() marks it as retrieved, suppressing asyncio's
+            # "Task exception was never retrieved" warning for the SystemExit we raise.
+            if not task.cancelled():
+                task.exception()
+
+        loop = asyncio.get_running_loop()
+        for sig in (signal.SIGTERM, signal.SIGINT):
+            loop.add_signal_handler(
+                sig,
+                lambda s=sig: asyncio.create_task(on_signal(s)).add_done_callback(
+                    _retrieve_exc
+                ),
+            )
+
     async def execute(self) -> int:
         """
         Run the executor.
@@ -79,6 +108,7 @@ class Executor:
         occurred other than a container error.
         """
         await self._log_service_ver()
+        self._setup_signal_handlers()
         heartbeat_task = asyncio.create_task(self._heartbeat_loop(self._cfg.job_id))
         try:
             # If we can't get the job, we presumably can't update the job either,
@@ -90,8 +120,7 @@ class Executor:
                     self._cfg.container_number
                 )
                 await self._download_files(job)
-                await self._update_job_state_loop(job, models.JobState.JOB_SUBMITTING)
-                result = await self._run_container(job)  # updates to JOB_SUBMITTED
+                result = await self._run_container(job)
                 if result.exit_code > 0:
                     await self._process_error_state(job, result)
                 else:
@@ -104,7 +133,7 @@ class Executor:
         finally:
             heartbeat_task.cancel()
             await asyncio.gather(heartbeat_task, return_exceptions=True)
-    
+
     async def _check_resp(self, resp: aiohttp.ClientResponse, action: str
     ) -> dict[str, Any] | None:
         if resp.status == 204:  # no content
@@ -127,12 +156,12 @@ class Executor:
             # TODO ERRORHANDLING we'll need to see what other errors are possible here
             raise RetryableExecutorError(msg)
         return resjson
-    
+
     async def _log_service_ver(self):
         async with self._sess.get(self._url) as resp:
             root = await self._check_resp(resp, "Failed to contact CDM Task Service")
         self._logr.info(f"CTS version: {root['version']} githash: {root['git_hash']}")
-    
+
     async def _get_job(self) -> models.AdminJobDetails:
         # TODO RELIABILITY retries. Tenatcity might be useful
         url = f"{self._url}/admin/jobs/{self._cfg.job_id}"
@@ -270,7 +299,8 @@ Local relative path: {loc}
 
     async def _run_container(
         self, job: models.AdminJobDetails
-    ) -> container_runner.ContainerResult:
+    ) -> ContainerResult:
+        await self._update_job_state_loop(job, models.JobState.JOB_SUBMITTING)
         mount = Path.cwd().expanduser().absolute()
         input_ = mount / _INPUT
         output = mount / _OUTPUT
@@ -284,7 +314,7 @@ Local relative path: {loc}
             relative_in = input_.relative_to(prefix)
             relative_out = output.relative_to(prefix)
             input_ = replace / relative_in
-            output = replace / relative_out 
+            output = replace / relative_out
         mounts = {
             # if people want to write to their input directory, ok
             str(input_): (job.job_input.params.input_mount_point, True),
@@ -301,16 +331,17 @@ Local relative path: {loc}
         self._logr.info(
             f"Starting image {job.image.name_with_digest} with command:\n{self._args.args}"
         )
-        result = await container_runner.run_container(
+        self._runner = await self._creator.start_container(
             job.image.name_with_digest,
             Path(".") / (self._get_log_prefix(job) + ".out"),
             Path(".") / (self._get_log_prefix(job) + ".err"),
             mounts=mounts,
             command=self._args.args,
             env=self._args.env,
-            post_start_callback=self._update_job_state_loop(job, models.JobState.JOB_SUBMITTED),
-            sigterm_callback=lambda signum: sys.exit(128 + signum)
         )
+        async with self._runner:
+            await self._update_job_state_loop(job, models.JobState.JOB_SUBMITTED)
+            result = await self._runner.wait()
         self._logr.info(
             f"Container exited with code {result.exit_code}, "
             f"max memory: {result.max_memory_bytes} bytes, "
@@ -319,7 +350,7 @@ Local relative path: {loc}
         return result
 
     async def _process_error_state(
-        self, job: models.AdminJobDetails, result: container_runner.ContainerResult
+        self, job: models.AdminJobDetails, result: ContainerResult
     ):
         await self._update_job_state_loop(
             job, models.JobState.ERROR_PROCESSING_SUBMITTING,
@@ -349,7 +380,7 @@ Local relative path: {loc}
         )
 
     async def _process_complete_state(
-        self, job: models.AdminJobDetails, result: container_runner.ContainerResult
+        self, job: models.AdminJobDetails, result: ContainerResult
     ):
         await self._update_job_state_loop(
             job, models.JobState.UPLOAD_SUBMITTING,
@@ -375,12 +406,13 @@ Local relative path: {loc}
         )
 
 
-async def run_executor(stderr: TextIO) -> int:
+async def run_executor(stderr: TextIO, container_creator: ContainerCreator) -> int:
     """
-    Run the job executor. 
-    
+    Run the job executor.
+
     stderr - a stderr stream.
-    
+    container_creator - factory for starting Docker containers.
+
     Returns 0 for success, a positive integer for the container exit code, or -1 if an error
     occurred other than a container error.
     """
@@ -390,8 +422,8 @@ async def run_executor(stderr: TextIO) -> int:
     for k, v in cfg.safe_dump().items():
         stderr.write(f"{k}: {v}\n")
     stderr.write("\n")
-    async with Executor(cfg) as exe:
-        return await exe.execute();
+    async with Executor(cfg, container_creator) as exe:
+        return await exe.execute()
 
 
 class RetryableExecutorError(Exception):

--- a/cdmtaskservice/externalexecution/main.py
+++ b/cdmtaskservice/externalexecution/main.py
@@ -4,6 +4,7 @@ import asyncio
 import os
 import sys
 
+from cdmtaskservice.externalexecution.container_runner import ContainerCreator
 from cdmtaskservice.externalexecution.executor import run_executor
 import logging
 
@@ -18,7 +19,7 @@ if __name__ == "__main__":
             f"Invalid CTS_LOG_LEVEL '{cts_log_level}': must be a standard log level "
             + "e.g. DEBUG, INFO, WARNING, ERROR, CRITICAL"
         ) from e
-    exit_code = asyncio.run(run_executor(sys.stderr))  # allow testing via replacing streams
+    exit_code = asyncio.run(run_executor(sys.stderr, ContainerCreator()))  # allow testing via replacing streams
     # pick any old number that's less likely to collide with with container exit codes
     exit_code = 119 if exit_code < 0 else exit_code
     sys.exit(exit_code)

--- a/test_manual/externalexecution/container_runner_manual_executor.py
+++ b/test_manual/externalexecution/container_runner_manual_executor.py
@@ -1,6 +1,6 @@
 from pathlib import Path
 
-from cdmtaskservice.externalexecution.container_runner import run_container
+from cdmtaskservice.externalexecution.container_runner import ContainerCreator
 import asyncio
 import logging
 
@@ -18,20 +18,17 @@ MOUNTS = {
 
 logging.basicConfig(level=logging.INFO)
 
-async def start_cb():
-    print("started container")
-
-
 async def main():
-    res = await run_container(
+    creator = ContainerCreator()
+    runner = await creator.start_container(
         IMAGE,
         STDOUT,
         STDERR,
         command=ARGS,
         mounts=MOUNTS,
-        post_start_callback=start_cb(),
-        sigterm_callback=lambda signum: print(f"exited: {signum}")
     )
+    print("started container")
+    res = await runner.wait()
     print(res)
 
 if __name__ == "__main__":

--- a/test_manual/externalexecution/run_executor_manual.py
+++ b/test_manual/externalexecution/run_executor_manual.py
@@ -1,0 +1,207 @@
+"""
+Sets up test data in Minio + MongoDB and runs the CTS external executor locally.
+Assumes docker-compose-local.yaml is up (CTS at :5000, Minio at :9000, Mongo at :27017).
+
+Usage:
+    PYTHONPATH=. python test_manual/externalexecution/run_executor_manual.py --token MY_TOKEN
+
+The container image will sleep for --sleep seconds. While it is running, send SIGTERM or
+Ctrl-C to test that signal handling stops the container and exits cleanly.
+"""
+
+import argparse
+import asyncio
+import datetime
+import logging
+import os
+import sys
+import tempfile
+import uuid
+from pathlib import Path
+
+import boto3
+from botocore.config import Config as BotoConfig
+import motor.motor_asyncio
+
+from cdmtaskservice import models, sites
+from cdmtaskservice.externalexecution.container_runner import ContainerCreator
+from cdmtaskservice.externalexecution.executor import run_executor
+from cdmtaskservice.mongo import MongoDAO
+from cdmtaskservice.timestamp import utcdatetime
+
+_IMAGE = "ghcr.io/kbasetest/cts_test_image"
+_IMAGE_TAG = "0.1.10-nonroot"
+_IMAGE_DIGEST = "sha256:4c65668b647f50dfac587f957d2fe7e6cc717a0491aab34fc10296dd00de0eb2"
+_IMAGE_ENTRYPOINT = ["python", "/opt/tester.py"]
+_TEST_FILE_CONTENT = b"CTS executor signal-handling test input file\n"
+_TEST_FILE_CRC = "cZWeeOsnTSo="  # CRC64NVME of _TEST_FILE_CONTENT
+_INPUT_BUCKET = "cts-test-input"
+_OUTPUT_BUCKET = "cts-test-output"
+_ERROR_LOG_PATH = "cts-test-errors/container_logs"
+
+
+def _parse_args():
+    p = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    p.add_argument("--token", default=os.environ.get("KBASE_AUTH_TOKEN"),
+                   help="KBase CI token with the external executor role "
+                        "(default: $KBASE_AUTH_TOKEN)")
+    p.add_argument("--sleep", type=int, default=30,
+                   help="Seconds for the container to sleep (default: 30)")
+    p.add_argument("--s3-url", default="http://localhost:9000", help="Minio URL")
+    p.add_argument("--s3-key", default="miniouser", help="S3 access key")
+    p.add_argument("--s3-secret", default="miniopassword", help="S3 access secret")
+    p.add_argument("--mongo-url", default="mongodb://localhost:27017")
+    p.add_argument("--mongo-db", default="cdmtaskservice")
+    p.add_argument("--cts-url", default="http://localhost:5000", help="CTS service URL")
+    return p.parse_args()
+
+
+def _setup_s3(args) -> str:
+    """Create buckets and upload the test input file. Returns the s3_path."""
+    s3 = boto3.client(
+        "s3",
+        endpoint_url=args.s3_url,
+        aws_access_key_id=args.s3_key,
+        aws_secret_access_key=args.s3_secret,
+        config=BotoConfig(signature_version="s3v4"),
+    )
+
+    for bucket in [_INPUT_BUCKET, _OUTPUT_BUCKET, _ERROR_LOG_PATH.split("/")[0]]:
+        try:
+            s3.create_bucket(Bucket=bucket)
+            print(f"  created bucket: {bucket}")
+        except Exception as e:
+            if "BucketAlreadyOwnedByYou" in str(e) or "BucketAlreadyExists" in str(e):
+                print(f"  bucket exists: {bucket}")
+            else:
+                raise
+
+    s3_key = "test-input/test_file.txt"
+    s3.put_object(Bucket=_INPUT_BUCKET, Key=s3_key, Body=_TEST_FILE_CONTENT)
+    s3_path = f"{_INPUT_BUCKET}/{s3_key}"
+    print(f"  uploaded test file -> {s3_path}")
+    return s3_path
+
+
+async def _setup_mongo(args, s3_path: str, sleep_secs: int) -> str:
+    """Insert a job + subjob into MongoDB. Returns the job_id."""
+    client = motor.motor_asyncio.AsyncIOMotorClient(args.mongo_url)
+    db = client[args.mongo_db]
+    dao = await MongoDAO.create(db)
+
+    job_id = str(uuid.uuid4())
+    now = utcdatetime()
+
+    job = models.AdminJobDetails.model_construct(
+        id=job_id,
+        state=models.JobState.DOWNLOAD_SUBMITTED,
+        user="testuser",
+        admin_meta={},
+        cleaned=False,
+        input_file_count=1,
+        transition_times=[
+            models.AdminJobStateTransition.model_construct(
+                state=models.JobState.CREATED,
+                time=now,
+                trans_id=str(uuid.uuid4()),
+                notif_sent=False,
+            ),
+            models.AdminJobStateTransition.model_construct(
+                state=models.JobState.DOWNLOAD_SUBMITTED,
+                time=now,
+                trans_id=str(uuid.uuid4()),
+                notif_sent=False,
+            ),
+        ],
+        image=models.JobImage.model_construct(
+            name=_IMAGE,
+            digest=_IMAGE_DIGEST,
+            tag=_IMAGE_TAG,
+            entrypoint=_IMAGE_ENTRYPOINT,
+            registered_by="testuser",
+            registered_on=now,
+        ),
+        job_input=models.JobInput.model_construct(
+            cluster=sites.Cluster.KBASE,
+            image=f"{_IMAGE}@{_IMAGE_DIGEST}",
+            params=models.Parameters.model_construct(
+                input_mount_point="/input_files",
+                output_mount_point="/output_files",
+                declobber=False,
+                args=["-s", str(sleep_secs)],
+                environment=None,
+                refdata_mount_point=None,
+            ),
+            num_containers=1,
+            cpus=1,
+            memory=10_000_000,
+            runtime=datetime.timedelta(seconds=3600),
+            output_dir=f"{_OUTPUT_BUCKET}/output/",
+            input_files=[
+                models.S3FileWithDataID.model_construct(file=s3_path, crc64nvme=_TEST_FILE_CRC)
+            ],
+            input_roots=None,
+        ),
+    )
+
+    subjob = models.SubJob.model_construct(
+        id=job_id,
+        sub_id=0,
+        state=models.JobState.DOWNLOAD_SUBMITTED,
+        transition_times=[
+            models.JobStateTransition.model_construct(
+                state=models.JobState.DOWNLOAD_SUBMITTED,
+                time=now,
+            ),
+        ],
+    )
+
+    await dao.save_job(job)
+    await dao.initialize_subjobs([subjob])
+    client.close()
+    print(f"  job_id: {job_id}")
+    return job_id
+
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+    args = _parse_args()
+    if not args.token:
+        sys.exit("error: --token is required or set KBASE_AUTH_TOKEN")
+
+    print("Setting up S3...")
+    s3_path = _setup_s3(args)
+
+    print("Setting up MongoDB...")
+    job_id = await _setup_mongo(args, s3_path, args.sleep)
+
+    refdata_dir = Path(tempfile.gettempdir()) / "cts-test-refdata"
+    refdata_dir.mkdir(exist_ok=True)
+
+    os.environ.update({
+        "JOB_ID": job_id,
+        "CONTAINER_NUMBER": "0",
+        "SERVICE_ROOT_URL": args.cts_url,
+        "TOKEN": args.token,
+        "S3_URL": args.s3_url,
+        "S3_ACCESS_KEY": args.s3_key,
+        "S3_SECRET": args.s3_secret,
+        "S3_ERROR_LOG_PATH": _ERROR_LOG_PATH,
+        "S3_INSECURE": "true",
+        "REFDATA_HOST_PATH": str(refdata_dir),
+        "JOB_UPDATE_TIMEOUT_MIN": "5",
+        "HEARTBEAT_INTERVAL_MIN": "1",
+    })
+
+    print(f"\nRunning executor (container will sleep {args.sleep}s)...")
+    print("Send SIGTERM or Ctrl-C while sleeping to test signal handling.\n")
+
+    exit_code = await run_executor(sys.stderr, ContainerCreator())
+    print(f"\nExecutor exited with code {exit_code}")
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(main()))


### PR DESCRIPTION
Refactors the container runner to a class to an external caller can cancel the container. Moves signal handling outside the runner where it belongs.

Also adds an injected ContainerCreator for easy mocking in unit tests