### PR TITLE
get_cluster_proc_states accepst optional proc_ids

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -11,7 +11,7 @@ import htcondor2
 import os
 from pathlib import Path
 import posixpath
-from typing import Any
+from typing import Any, Collection
 from yarl import URL
 
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy, check_num as _check_num
@@ -384,9 +384,13 @@ class CondorClient:
         return running, complete
 
     async def _fetch_cluster_ads(
-        self, cluster_id: int, projection: list[str]
+        self, cluster_id: int, projection: list[str],
+        proc_ids: Collection[int] | None = None,
     ) -> tuple[list, list]:
         constraint = f"{_AD_CLUSTER_ID} == {cluster_id}"
+        if proc_ids is not None:
+            proc_constraint = " || ".join(f"{_AD_PROC_ID} == {pid}" for pid in proc_ids)
+            constraint = f"{constraint} && ({proc_constraint})"
         active_ads = await asyncio.to_thread(  # Don't block the event loop
             self._schedd.query,
             constraint=constraint,
@@ -397,26 +401,37 @@ class CondorClient:
             constraint=constraint,
             projection=projection,
         )
-        if not active_ads and not complete_ads:
+        if not active_ads and not complete_ads and proc_ids is None:
             raise ValueError(f"No records found for cluster ID {cluster_id}")
         return active_ads, complete_ads
 
-    async def get_cluster_proc_states(self, cluster_id: int) -> list[ProcState]:
+    async def get_cluster_proc_states(
+        self,
+        cluster_id: int,
+        proc_ids: Collection[int] | None = None,
+    ) -> dict[int, ProcState]:
         """
         Get the state of each process in an HTC cluster using minimal data transfer.
 
-        Returns a list indexed by proc ID (which equals the container number), where each
-        element is a ProcState. Raises ValueError if no records are found for cluster_id.
+        Returns a dict mapping proc ID (== container number) to ProcState.
+        Raises ValueError if no records are found for cluster_id and proc_ids is None.
+
+        cluster_id - the HTCondor cluster ID.
+        proc_ids - if provided, the HTCondor constraint is restricted to these proc IDs and
+            an empty result is returned (rather than an error) if none are found.
+            An empty list returns an empty dict without querying HTCondor.
         """
         _check_num(cluster_id, "cluster_id")
-        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, _STATUS_ONLY)
-        states = {}
+        if proc_ids is not None and not proc_ids:
+            return {}
+        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, _STATUS_ONLY, proc_ids)
+        states: dict[int, ProcState] = {}
         for ad in active_ads:
             states[ad[_AD_PROC_ID]] = _status_to_proc_state(ad[_AD_JOB_STATUS])
         for ad in complete_ads:
             # override active entry if a proc raced from query to history between calls
             states[ad[_AD_PROC_ID]] = _status_to_proc_state(ad[_AD_JOB_STATUS])
-        return [states[i] for i in range(len(states))]
+        return states
 
     async def release_job(self, cluster_id: int):
         """

--- a/cdmtaskservice/externalexecution/container_runner.py
+++ b/cdmtaskservice/externalexecution/container_runner.py
@@ -121,7 +121,7 @@ class RunningContainer:
         try:
             if cancel:
                 await asyncio.to_thread(self._stop_container)
-            # Run in a thread so the event loop stays free dur-ing container execution
+            # Run in a thread so the event loop stays free during container execution
             await asyncio.to_thread(self._join_threads, 30 if cancel else None)
             # Saved so subsequent calls return the cached result without querying
             # the removed container if there's a race, since _collect_result is synchronous

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -259,9 +259,10 @@ class KBaseRunner(JobFlow):
             )
         cluster_id = job.htcondor_details.cluster_id[-1]
         proc_states = await self._condor.get_cluster_proc_states(cluster_id)
+        n = job.job_input.num_containers
         return models.ExternalRunnerStatus(
             manages_containers=False,
-            states=[_PROC_STATE_TO_EXTERNAL[s] for s in proc_states],
+            states=[_PROC_STATE_TO_EXTERNAL[proc_states[i]] for i in range(n)],
         )
 
     async def start_job(self, job: models.Job, objmeta: list[S3ObjectMeta]):
@@ -563,14 +564,14 @@ class KBaseRunner(JobFlow):
         proc_states = await self._condor.get_cluster_proc_states(
             job.htcondor_details.cluster_id[-1]
         )
-        if {ProcState.OTHER, ProcState.CANCELED} & set(proc_states):
+        if {ProcState.OTHER, ProcState.CANCELED} & set(proc_states.values()):
             raise InvalidJobStateError(
                 "External processor contains processes in an unexpected state. Unable to recover "
                 "job."
             )
-        held = [i for i, s in enumerate(proc_states) if s == ProcState.HELD]
+        held = [i for i, s in proc_states.items() if s == ProcState.HELD]
         running = [
-            i for i, s in enumerate(proc_states)
+            i for i, s in proc_states.items()
             if s in {ProcState.RUNNING, ProcState.QUEUED}
         ]
         return held, running

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -264,7 +264,7 @@ async def test_get_cluster_proc_states_all_complete():
 
     states = await client.get_cluster_proc_states(123)
 
-    assert states == [ProcState.COMPLETE, ProcState.COMPLETE]
+    assert states == {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     schedd.query.assert_called_once_with(
         constraint="ClusterId == 123", projection=["ProcId", "JobStatus"]
     )
@@ -291,15 +291,15 @@ async def test_get_cluster_proc_states_mixed():
 
     states = await client.get_cluster_proc_states(123)
 
-    assert states == [
-        ProcState.RUNNING,   # ProcId 0: Running
-        ProcState.HELD,      # ProcId 1: Held
-        ProcState.QUEUED,    # ProcId 2: Idle
-        ProcState.OTHER,     # ProcId 3: Suspended
-        ProcState.COMPLETE,  # ProcId 4: overridden by history
-        ProcState.CANCELED,  # ProcId 5: Removed (history only)
-        ProcState.RUNNING,   # ProcId 6: Transferring Output
-    ]
+    assert states == {
+        0: ProcState.RUNNING,   # Running
+        1: ProcState.HELD,      # Held
+        2: ProcState.QUEUED,    # Idle
+        3: ProcState.OTHER,     # Suspended
+        4: ProcState.COMPLETE,  # overridden by history
+        5: ProcState.CANCELED,  # Removed (history only)
+        6: ProcState.RUNNING,   # Transferring Output
+    }
     schedd.query.assert_called_once_with(
         constraint="ClusterId == 123", projection=["ProcId", "JobStatus"]
     )
@@ -317,6 +317,45 @@ async def test_get_cluster_proc_states_unknown_status():
         with pytest.raises(ValueError, match=f"^Unknown HTCondor job status: {status}$"):
             await client.get_cluster_proc_states(123)
         schedd.reset_mock()
+
+
+async def test_get_cluster_proc_states_empty_proc_ids():
+    """Empty proc_ids list returns empty dict without querying condor."""
+    client, schedd = _make_client()
+
+    states = await client.get_cluster_proc_states(123, proc_ids=[])
+
+    assert states == {}
+    schedd.query.assert_not_called()
+    schedd.history.assert_not_called()
+
+
+async def test_get_cluster_proc_states_proc_ids_filter():
+    """The proc_ids list is pushed into the HTCondor constraint, not filtered in Python."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [{"ProcId": 1, "JobStatus": 5}]   # Held
+    schedd.history.return_value = [{"ProcId": 3, "JobStatus": 4}]  # Complete
+
+    states = await client.get_cluster_proc_states(123, proc_ids=[1, 3])
+
+    assert states == {1: ProcState.HELD, 3: ProcState.COMPLETE}
+    constraint = "ClusterId == 123 && (ProcId == 1 || ProcId == 3)"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
+    schedd.history.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
+
+
+async def test_get_cluster_proc_states_proc_ids_not_found():
+    """Requested proc IDs absent from both queues returns empty dict, not an error."""
+    client, schedd = _make_client()
+    schedd.query.return_value = []
+    schedd.history.return_value = []
+
+    states = await client.get_cluster_proc_states(123, proc_ids=[0, 1])
+
+    assert states == {}
+    constraint = "ClusterId == 123 && (ProcId == 0 || ProcId == 1)"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
+    schedd.history.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
 
 
 async def test_release_job_bad_args():

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -153,14 +153,14 @@ async def test_get_job_external_runner_status_submitted():
         job_input=models.JobInput.model_construct(num_containers=6, cluster=sites.Cluster.KBASE),
         htcondor_details=models.HTCondorDetails(cluster_id=[123]),
     )
-    condor.get_cluster_proc_states.return_value = [
-        ProcState.QUEUED,
-        ProcState.RUNNING,
-        ProcState.HELD,
-        ProcState.COMPLETE,
-        ProcState.CANCELED,
-        ProcState.OTHER,
-    ]
+    condor.get_cluster_proc_states.return_value = {
+        0: ProcState.QUEUED,
+        1: ProcState.RUNNING,
+        2: ProcState.HELD,
+        3: ProcState.COMPLETE,
+        4: ProcState.CANCELED,
+        5: ProcState.OTHER,
+    }
     result = await runner.get_job_external_runner_status(job)
     assert result == models.ExternalRunnerStatus(
         manages_containers=False,
@@ -842,7 +842,7 @@ async def test_recover_job_no_cluster_id(force, cluster_ids):
 async def test_recover_job_unexpected_proc_state(force, bad_state):
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job()
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, bad_state]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: bad_state}
 
     with pytest.raises(
         InvalidJobStateError,
@@ -1004,7 +1004,7 @@ async def test_recover_job_error_state_advance_to_complete():
     ts = iter([lock_time, reset_time] + advance_times)
     runner, mongo, condor, updates, s3 = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.ERROR)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
 
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
     # cpu_factor = (0.5*3600) / (720*1) = 2.5
@@ -1061,7 +1061,7 @@ async def test_recover_job_error_state_advance_fails():
     ts = iter([lock_time, reset_time, advance_time])
     runner, mongo, condor, updates, s3 = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.ERROR)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     # First call (RECOVERING lock) succeeds; second (first state advance) raises.
     updates.update_job_state.side_effect = [None, IOError("mongo blew up")]
 
@@ -1091,7 +1091,7 @@ async def test_recover_job_error_state_lock_fails():
     """
     runner, mongo, condor, updates, s3 = _make_runner()
     job = _recovery_job(state=models.JobState.ERROR)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.update_job_state.side_effect = InvalidJobStateError("concurrent recovery won")
 
     with pytest.raises(InvalidJobStateError, match="concurrent recovery won"):
@@ -1132,7 +1132,7 @@ async def test_recover_job_error_state_lock_fails():
 async def test_recover_job_standard_advance_to_complete(start_state, state_updates):
     runner, mongo, condor, updates, s3 = _make_runner()
     job = _recovery_job(state=start_state)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     complete_time = _T + datetime.timedelta(seconds=len(state_updates) + 1)
     parent_updates = [
         ParentJobUpdate(state, _T + datetime.timedelta(seconds=i + 1))
@@ -1185,7 +1185,7 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
 async def test_recover_job_complete_job_no_outputs():
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.UPLOAD_SUBMITTED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.COMPLETE, _T)
     sj = models.SubJob.model_construct(outputs=[])
     mongo.get_subjobs.return_value = [sj]
@@ -1213,7 +1213,7 @@ async def test_recover_job_complete_job_no_outputs():
 async def test_recover_job_complete_job_checksum_mismatch():
     runner, mongo, condor, updates, s3 = _make_runner()
     job = _recovery_job(state=models.JobState.UPLOAD_SUBMITTED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.COMPLETE, _T)
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaaaaaaaaaa")]
     sj = models.SubJob.model_construct(outputs=outputs)
@@ -1247,7 +1247,7 @@ async def test_recover_job_complete_job_condor_stats_timeout():
     """Unlike update_container_state, the IOError propagates directly to the caller."""
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.UPLOAD_SUBMITTED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.COMPLETE, _T)
     condor.get_cluster_classads.return_value = ([{"JobStatus": 2}], [])
 
@@ -1265,7 +1265,7 @@ async def test_recover_job_complete_job_condor_stats_timeout():
 async def test_recover_job_standard_advance_invalid_state():
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.CREATED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
 
     with pytest.raises(RuntimeError, match="Unexpected job state"):
         await runner.recover_job(job)
@@ -1277,7 +1277,7 @@ async def test_recover_job_standard_advance_invalid_state():
 async def test_recover_job_standard_advance_update_raises():
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.DOWNLOAD_SUBMITTED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.get_parent_job_update.return_value = ParentJobUpdate(
         models.JobState.JOB_SUBMITTING, _T
     )
@@ -1300,7 +1300,7 @@ async def test_recover_job_standard_advance_parent_update_none():
     """
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.DOWNLOAD_SUBMITTED)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.get_parent_job_update.return_value = None
 
     with pytest.raises(RuntimeError, match="Not all subjobs have reached state"):
@@ -1314,8 +1314,8 @@ async def test_recover_job_standard_advance_parent_update_none():
 async def test_recover_job_standard_running_only():
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job()
-    condor.get_cluster_proc_states.return_value = [
-        ProcState.COMPLETE, ProcState.RUNNING, ProcState.QUEUED]
+    condor.get_cluster_proc_states.return_value = {
+        0: ProcState.COMPLETE, 1: ProcState.RUNNING, 2: ProcState.QUEUED}
 
     with pytest.raises(
         InvalidJobStateError,
@@ -1338,9 +1338,9 @@ async def test_recover_job_standard_held_containers():
     runner, mongo, condor, updates, _ = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.JOB_SUBMITTING)
     # Container 0 complete, containers 1 and 2 held.
-    condor.get_cluster_proc_states.return_value = [
-        ProcState.COMPLETE, ProcState.HELD, ProcState.HELD
-    ]
+    condor.get_cluster_proc_states.return_value = {
+        0: ProcState.COMPLETE, 1: ProcState.HELD, 2: ProcState.HELD
+    }
 
     await runner.recover_job(job)
 
@@ -1364,7 +1364,7 @@ async def test_recover_job_standard_held_release_fails():
     ts = iter([lock_time, reset_time])
     runner, mongo, condor, updates, _ = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.JOB_SUBMITTING)
-    condor.get_cluster_proc_states.return_value = [ProcState.HELD, ProcState.HELD]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.HELD, 1: ProcState.HELD}
     condor.release_job.side_effect = IOError("condor unavailable")
 
     with pytest.raises(
@@ -1390,7 +1390,7 @@ async def test_recover_job_standard_held_lock_fails():
     """
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job()
-    condor.get_cluster_proc_states.return_value = [ProcState.HELD, ProcState.HELD]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.HELD, 1: ProcState.HELD}
     updates.update_job_state.side_effect = InvalidJobStateError("concurrent recovery won")
 
     with pytest.raises(InvalidJobStateError, match="concurrent recovery won"):
@@ -1410,7 +1410,7 @@ async def test_recover_job_standard_held_lock_fails():
 async def test_recover_job_force_running_containers(running_state):
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.HELD, running_state]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.HELD, 1: running_state}
 
     with pytest.raises(
         InvalidJobStateError,
@@ -1438,7 +1438,7 @@ async def test_recover_job_force_all_complete():
     ts = iter([lock_time, reset_time] + advance_times)
     runner, mongo, condor, updates, s3 = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
 
     outputs = [models.S3File(file="bucket/f.txt", crc64nvme="aaaabbbbcccc")]
     # cpu_factor = (0.5*3600) / (720*1) = 2.5
@@ -1495,7 +1495,7 @@ async def test_recover_job_force_all_complete_advance_fails():
     ts = iter([lock_time, reset_time, advance_time])
     runner, mongo, condor, updates, s3 = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     # First call (force RECOVERING lock) succeeds; second (first state advance) raises.
     updates.update_job_state.side_effect = [None, IOError("mongo blew up")]
 
@@ -1525,7 +1525,7 @@ async def test_recover_job_force_all_complete_lock_fails():
     """
     runner, mongo, condor, updates, s3 = _make_runner()
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.COMPLETE, ProcState.COMPLETE]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     updates.update_job_state.side_effect = InvalidJobStateError(
         "Job 'jid' is in state 'error', expected 'recovering'"
     )
@@ -1556,9 +1556,9 @@ async def test_recover_job_force_held_containers():
     runner, mongo, condor, updates, _ = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.RECOVERING)
     # Container 0 complete, containers 1 and 2 held.
-    condor.get_cluster_proc_states.return_value = [
-        ProcState.COMPLETE, ProcState.HELD, ProcState.HELD
-    ]
+    condor.get_cluster_proc_states.return_value = {
+        0: ProcState.COMPLETE, 1: ProcState.HELD, 2: ProcState.HELD
+    }
 
     await runner.recover_job(job, force=True)
 
@@ -1582,7 +1582,7 @@ async def test_recover_job_force_held_release_fails():
     ts = iter([lock_time, reset_time])
     runner, mongo, condor, updates, _ = _make_runner(_timestamp_fn=lambda: next(ts))
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.HELD, ProcState.HELD]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.HELD, 1: ProcState.HELD}
     condor.release_job.side_effect = IOError("condor unavailable")
 
     with pytest.raises(
@@ -1608,7 +1608,7 @@ async def test_recover_job_force_held_lock_fails():
     """
     runner, mongo, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.RECOVERING)
-    condor.get_cluster_proc_states.return_value = [ProcState.HELD, ProcState.HELD]
+    condor.get_cluster_proc_states.return_value = {0: ProcState.HELD, 1: ProcState.HELD}
     updates.update_job_state.side_effect = JobRecoveryError("cooldown not expired")
 
     with pytest.raises(JobRecoveryError, match="cooldown not expired"):

--- a/test_manual/condor/helpers.py
+++ b/test_manual/condor/helpers.py
@@ -1,0 +1,33 @@
+"""
+Manual helpers for interacting with the CTS HTCondor client.
+
+Usage (from inside the cdm_task_service container, from /cts):
+
+```
+docker compose -f docker-compose-local.yaml exec -it cdm_task_service bash
+```
+
+Then, with the config already rendered by the entrypoint:
+
+```
+root@...:/cts# uv run ipython
+In [1]: from test_manual.condor.helpers import make_condor_client
+In [2]: import asyncio
+In [3]: client = make_condor_client()
+```
+"""
+
+import htcondor2
+
+from cdmtaskservice.config import CDMTaskServiceConfig
+from cdmtaskservice.condor.client import CondorClient
+
+
+def make_condor_client(config_path: str = "./cdmtaskservice_config.toml") -> CondorClient:
+    """Create a CondorClient using the rendered container config."""
+    with open(config_path, "rb") as f:
+        cfg = CDMTaskServiceConfig(f, "manual")
+    collector = htcondor2.Collector(htcondor2.param["COLLECTOR_HOST"])
+    schedd_ad = collector.locate(htcondor2.DaemonTypes.Schedd)
+    schedd = htcondor2.Schedd(schedd_ad)
+    return CondorClient(schedd, cfg.get_condor_client_config(), cfg.get_s3_config())


### PR DESCRIPTION
The return type changes from list (indexed by position) to dict (keyed by proc ID), making sparse results safe to handle. An optional proc_ids: Collection[int] parameter pushes per-proc filtering into the HTCondor ClassAd constraint rather than fetching all procs and discarding unwanted ones in Python.

Also adds test_manual/condor/helpers.py with make_condor_client() for manual condor inspection from inside the CTS container.