### PR TITLE
Repoint to KBaseDataLakehouse org

### DIFF
--- a/.github/workflows/build_publish_scan_managed.yaml
+++ b/.github/workflows/build_publish_scan_managed.yaml
@@ -9,7 +9,7 @@ on:
     types: [published]
 jobs:
   build-publish-scan:
-    uses: BERDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
+    uses: KBaseDataLakehouse/.github/.github/workflows/build_publish_scan.yaml@main
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Repoint references to the renamed KBaseDataLakehouse org (GHCR namespace / reusable workflow / Codecov slug) after the GitHub org rename.