### PR TITLE
Hardcode subjob heartbeat interval

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -49,6 +49,10 @@ class ProcState(enum.Enum):
     CANCELED = "canceled"
     OTHER = "other"
 
+    def is_healthy(self) -> bool:
+        """ Return True if this state does not indicate a problem requiring intervention. """
+        return self in {ProcState.QUEUED, ProcState.RUNNING, ProcState.COMPLETE}
+
 
 _JOB_STATUS_TO_PROC_STATE = {
     1:                ProcState.QUEUED,    # Idle
@@ -193,16 +197,24 @@ class CondorClient:
     The condor client.
     """
 
-    def __init__(self, schedd: htcondor2.Schedd, config: CondorClientConfig, s3config: S3Config):
+    def __init__(
+        self,
+        schedd: htcondor2.Schedd,
+        config: CondorClientConfig,
+        s3config: S3Config,
+        heartbeat_interval_min: int,
+    ):
         """
         Create the client.
-        
+
         schedd: An htcondor Schedd instance, configured to submit jobs to the cluster.
         config - the configuration for the client.
         s3Config - the configuration for the S3 instance where files are stored.
+        heartbeat_interval_min - how often, in minutes, the executor sends a heartbeat.
         """
         self._schedd = _not_falsy(schedd, "schedd")
         self._config = _not_falsy(config, "config")
+        self._heartbeat_interval_min = _check_num(heartbeat_interval_min, "heartbeat_interval_min", minimum=1)
         # Why this has to exist locally is beyond me
         Path(self._config.initial_dir).mkdir(parents=True, exist_ok=True)
         self._exe_url = config.get_executable_url()
@@ -238,7 +250,7 @@ class CondorClient:
             "JOB_UPDATE_TIMEOUT_MIN": self._config.job_update_timeout_min,
             "JOB_TIMEOUT_MIN": _JOB_TIMEOUT_MIN,
             "REFDATA_HOST_PATH": self._config.refdata_host_path,
-            "HEARTBEAT_INTERVAL_MIN": self._config.heartbeat_interval_min,
+            "HEARTBEAT_INTERVAL_MIN": self._heartbeat_interval_min,
         }
         if self._config.mount_prefix_override:
             env["MOUNT_PREFIX_OVERRIDE"] = self._config.mount_prefix_override

--- a/cdmtaskservice/condor/config.py
+++ b/cdmtaskservice/condor/config.py
@@ -89,11 +89,6 @@ class CondorClientConfig(BaseModel):
     The root directory of the refdata storage location on the job container host.
     """
 
-    heartbeat_interval_min: Annotated[int, Field(ge=1)]
-    """
-    How often, in minutes, the external executor sends a liveness heartbeat to the service.
-    """
-    
     @field_validator("refdata_host_path", mode="after")
     @classmethod
     def _validate_refdata_host_path(cls, v: str) -> str:

--- a/cdmtaskservice/config.py
+++ b/cdmtaskservice/config.py
@@ -78,8 +78,6 @@ class CDMTaskServiceConfig:
         data is stored.
     external_executor_job_update_timeout_min: int - the number of minutes to wait when trying
         to update the job state in the service before failing.
-    external_executor_heartbeat_interval_min: int - how often, in minutes, the external executor
-        sends a liveness heartbeat to the service.
     external_executor_mount_prefix_override: str - a host container mount path prefix override
         in the form <prefix of path to replace>:<path to replace prefix with>
     code_archive_path: str - the local path to the tgz code archive.
@@ -204,9 +202,6 @@ class CDMTaskServiceConfig:
         self.external_executor_mount_prefix_override = _get_string_optional(
             config, _SEC_EXTERNAL_EXEC, "mount_prefix_override"
         )
-        self.external_executor_heartbeat_interval_min = _get_int_required(
-            config, _SEC_EXTERNAL_EXEC, "heartbeat_interval_min", minimum=1
-        )
         self.code_archive_path = _get_string_required(config, _SEC_EXTERNAL_EXEC, "archive_path")
         self.code_archive_url_override = _get_string_optional(
             config, _SEC_EXTERNAL_EXEC, "archive_url_override"
@@ -329,7 +324,6 @@ class CDMTaskServiceConfig:
             cache_dir=self.condor_cache_dir,
             use_S3_external_url=self.condor_use_s3_external_url,
             refdata_host_path=self.refdata_host_path,
-            heartbeat_interval_min=self.external_executor_heartbeat_interval_min,
         )
 
     def print_config(self, output: TextIO):
@@ -370,8 +364,6 @@ class CDMTaskServiceConfig:
                 + str(self.external_executor_job_update_timeout_min),
             "External executor mount prefix override: " +
                 f"{self.external_executor_mount_prefix_override}",  # f string in case it's None
-            "External executor heartbeat interval (min): "
-                + str(self.external_executor_heartbeat_interval_min),
             f"Code archive path: {self.code_archive_path}",
             f"Code archive url override: {self.code_archive_url_override}",
             f"S3 URL: {self.s3_url}",

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -348,7 +348,6 @@ class KBaseRunner(JobFlow):
         container_num - the container / subjob number.
         update - the new state for the container.
         """
-        # TODO UPDATE_SUBJOB add other states.
         _not_falsy(job, "job")
         _check_num(container_num, "container_num", minimum=0)
         _not_falsy(new_state, "new_state")
@@ -808,6 +807,8 @@ class KBaseFlowProvider:
     Manages KBase job flow initialization.
     """
     
+    _HEARTBEAT_INTERVAL_MIN = 5
+
     @classmethod
     async def create(
         cls,
@@ -821,7 +822,7 @@ class KBaseFlowProvider:
     ):
         """
         WARNING: this class is not thread safe.
-        
+
         Create the flow provider.
 
         condor_config - the configuration for the condor client.
@@ -832,7 +833,6 @@ class KBaseFlowProvider:
         refserver_url - the url for the refdata server.
         refserver_token - the token to use when communicating with the refdata server.
         """
-    
         kb = cls()
         kb._condor_config = _not_falsy(condor_config, "condor_config")
         kb._mongodao = _not_falsy(mongodao, "mongodao")
@@ -947,7 +947,9 @@ class KBaseFlowProvider:
             schedd_ad = collector.locate(htcondor2.DaemonTypes.Schedd)
             schedd = htcondor2.Schedd(schedd_ad)
             self._logr.info("Done")
-            condor = CondorClient(schedd, self._condor_config, self._s3config)
+            condor = CondorClient(
+                schedd, self._condor_config, self._s3config, self._HEARTBEAT_INTERVAL_MIN
+            )
             self._logr.info("Initializing refdata service client...")
             refcli = await RefdataServiceClient.create(self._refserv_url, self._refserv_token)
             state_updates = SubjobFlowStateUpdates(

--- a/cdmtaskservice/update_state.py
+++ b/cdmtaskservice/update_state.py
@@ -162,7 +162,8 @@ class RefdataUpdate(Update[models.ReferenceDataState]):
 
 # The ordered sequence of states a job passes through on the happy path, from creation to
 # completion. Used to replay state transitions during job recovery.
-JOB_COMPLETED_PATH = [
+# Stored here rather than in the JobState enum since this module defines the job state FSM
+JOB_COMPLETED_PATH = (
     models.JobState.CREATED,
     models.JobState.DOWNLOAD_SUBMITTED,
     models.JobState.JOB_SUBMITTING,
@@ -170,7 +171,7 @@ JOB_COMPLETED_PATH = [
     models.JobState.UPLOAD_SUBMITTING,
     models.JobState.UPLOAD_SUBMITTED,
     models.JobState.COMPLETE,
-]
+)
 
 
 def submitted_download() -> JobUpdate:

--- a/cdmtaskservice_config.toml.jinja
+++ b/cdmtaskservice_config.toml.jinja
@@ -148,10 +148,6 @@ refdata_host_path = "{{ KBCTS_REFDATA_HOST_PATH or "" }}"
 # The default is 6 hours and minimum 1 minute.
 job_update_timeout_min = {{ KBCTS_EXTERNAL_JOB_UPDATE_TIMEOUT_MIN or 360 }}
 
-# How often, in minutes, an external executor sends a liveness heartbeat to the service.
-# The default is 5 minutes; minimum is 1 minute.
-heartbeat_interval_min = {{ KBCTS_EXTERNAL_HEARTBEAT_INTERVAL_MIN or 5 }}
-
 # A prefix override for the input and output data mount path for the job container.
 # This is not a mount string, although it looks like one. By default, the external job
 # executor mounts subdirectories in the current working directory into the job container

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -13,7 +13,7 @@ from cdmtaskservice.config_s3 import S3Config
 # TODO TEST add more tests
 
 
-def _make_client():
+def _make_dependencies():
     schedd = create_autospec(htcondor2.Schedd, instance=True)
     config = CondorClientConfig(
         initial_dir=tempfile.mkdtemp(),
@@ -28,11 +28,32 @@ def _make_client():
         additional_path=None,
         cache_dir="/cache",
         refdata_host_path="/refdata",
-        heartbeat_interval_min=5,
     )
     s3config = create_autospec(S3Config, spec_set=True, instance=True)
-    client = CondorClient(schedd, config, s3config)
+    return schedd, config, s3config
+
+
+def _make_client():
+    schedd, config, s3config = _make_dependencies()
+    client = CondorClient(schedd, config, s3config, heartbeat_interval_min=5)
     return client, schedd
+
+
+def test_proc_state_is_healthy():
+    assert ProcState.QUEUED.is_healthy() is True
+    assert ProcState.RUNNING.is_healthy() is True
+    assert ProcState.COMPLETE.is_healthy() is True
+    assert ProcState.HELD.is_healthy() is False
+    assert ProcState.CANCELED.is_healthy() is False
+    assert ProcState.OTHER.is_healthy() is False
+
+
+def test_condor_client_bad_heartbeat_interval():
+    schedd, config, s3config = _make_dependencies()
+    with pytest.raises(ValueError, match="^heartbeat_interval_min is required$"):
+        CondorClient(schedd, config, s3config, heartbeat_interval_min=None)
+    with pytest.raises(ValueError, match="^heartbeat_interval_min must be >= 1$"):
+        CondorClient(schedd, config, s3config, heartbeat_interval_min=0)
 
 
 async def test_get_container_classad_bad_args():


### PR DESCRIPTION
The interval doesn't need to be user-configurable and setting it too low could cause load issues, setting it too high could cause UX issues as dead jobs are undetected for long periods of time. Removing it simplifies the TOML config and service configuration