### PR TITLE
Add get_cluster_proc_details to HTCondor client

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -11,7 +11,7 @@ import htcondor2
 import os
 from pathlib import Path
 import posixpath
-from typing import Any, Collection
+from typing import Any, Callable, Collection, TypeVar
 from yarl import URL
 
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy, check_num as _check_num
@@ -23,6 +23,8 @@ from cdmtaskservice import models
 # Some of this stuff is pretty specific to KBase but the likelihood we'll ever be submitting
 # to some other condor instance is pretty low, so don't worry about it 
 
+
+_V = TypeVar("_V")
 
 _JOB_TIMEOUT_MIN = 7 * 24 * 60
 _JOB_TIMEOUT_FUDGE_FACTOR_MIN = 6 * 60
@@ -37,6 +39,8 @@ _AD_CPU_USER = "RemoteUserCpu"
 _AD_MEM = "MemoryUsage"
 _AD_COMMITTED_TIME = "CommittedTime"
 _AD_JOB_STATUS = "JobStatus"
+_AD_HOLD_REASON = "HoldReason"
+_AD_HOLD_REASON_CODE = "HoldReasonCode"
 _JOB_STATUS_HELD = 5
 
 
@@ -72,6 +76,7 @@ def _status_to_proc_state(status: int) -> ProcState:
 
 
 _STATUS_ONLY = [_AD_PROC_ID, _AD_JOB_STATUS]
+_STATUS_AND_HOLD = [_AD_PROC_ID, _AD_JOB_STATUS, _AD_HOLD_REASON, _AD_HOLD_REASON_CODE]
 
 _LOCATIONS = ["Iwd", "Err", "Out", "UserLog"]
 _IDS = [_AD_CLUSTER_ID, _AD_PROC_ID, _AD_JOB_ID, _AD_CONTAINER_NUMBER]
@@ -106,8 +111,8 @@ _JOB_STATE = [
     "JobRunCount",
     "NumRestarts",
     "NumJobStarts",
-    "HoldReason",
-    "HoldReasonCode",
+    _AD_HOLD_REASON,
+    _AD_HOLD_REASON_CODE,
     "PeriodicHold",
     "VacateReason",
     "VacateReasonCode",
@@ -158,6 +163,14 @@ def condor_jobs_all_held(job_classads_as_dict: list[dict[str, Any]]) -> bool:
     """
     _not_falsy(job_classads_as_dict, "job_classads_as_dict")
     return not {ad[_AD_JOB_STATUS] for ad in job_classads_as_dict} - {_JOB_STATUS_HELD}
+
+
+@dataclass
+class ProcDetails:
+    """State and hold information for an HTCondor process."""
+    state: ProcState
+    hold_reason: str | None = None
+    hold_reason_code: int | None = None
 
 
 @dataclass
@@ -386,11 +399,10 @@ class CondorClient:
         running_job_ads, complete_job_ads = await self._fetch_cluster_ads(
             cluster_id, _RETURNED_JOB_ADS
         )
-        id2ad = {(ad[_AD_CLUSTER_ID], ad[_AD_PROC_ID]): ad for ad in running_job_ads}
+        id2ad = {ad[_AD_PROC_ID]: ad for ad in running_job_ads}
         for ad in complete_job_ads:
-            job_key = (ad[_AD_CLUSTER_ID], ad[_AD_PROC_ID])
             # remove jobs that have transitioned to complete between the queries
-            id2ad.pop(job_key, None)
+            id2ad.pop(ad[_AD_PROC_ID], None)
         running = [self._classad_to_dict(ad) for ad in id2ad.values()]
         complete = [self._classad_to_dict(ad) for ad in complete_job_ads]
         return running, complete
@@ -417,6 +429,25 @@ class CondorClient:
             raise ValueError(f"No records found for cluster ID {cluster_id}")
         return active_ads, complete_ads
 
+    async def _fetch_proc_map(
+        self,
+        cluster_id: int,
+        projection: list[str],
+        proc_ids: Collection[int] | None,
+        transform: Callable[[Any], _V],
+    ) -> dict[int, _V]:
+        _check_num(cluster_id, "cluster_id")
+        if proc_ids is not None and not proc_ids:
+            return {}
+        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, projection, proc_ids)
+        result: dict[int, _V] = {}
+        for ad in active_ads:
+            result[ad[_AD_PROC_ID]] = transform(ad)
+        for ad in complete_ads:
+            # override active entry if a proc raced from query to history between calls
+            result[ad[_AD_PROC_ID]] = transform(ad)
+        return result
+
     async def get_cluster_proc_states(
         self,
         cluster_id: int,
@@ -433,17 +464,35 @@ class CondorClient:
             an empty result is returned (rather than an error) if none are found.
             An empty list returns an empty dict without querying HTCondor.
         """
-        _check_num(cluster_id, "cluster_id")
-        if proc_ids is not None and not proc_ids:
-            return {}
-        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, _STATUS_ONLY, proc_ids)
-        states: dict[int, ProcState] = {}
-        for ad in active_ads:
-            states[ad[_AD_PROC_ID]] = _status_to_proc_state(ad[_AD_JOB_STATUS])
-        for ad in complete_ads:
-            # override active entry if a proc raced from query to history between calls
-            states[ad[_AD_PROC_ID]] = _status_to_proc_state(ad[_AD_JOB_STATUS])
-        return states
+        return await self._fetch_proc_map(
+            cluster_id, _STATUS_ONLY, proc_ids,
+            lambda ad: _status_to_proc_state(ad[_AD_JOB_STATUS]),
+        )
+
+    async def get_cluster_proc_details(
+        self,
+        cluster_id: int,
+        proc_ids: Collection[int] | None = None,
+    ) -> dict[int, ProcDetails]:
+        """
+        Get the state and hold details of each process in an HTC cluster.
+
+        Returns a dict mapping proc ID (== container number) to ProcDetails.
+        Raises ValueError if no records are found for cluster_id and proc_ids is None.
+
+        cluster_id - the HTCondor cluster ID.
+        proc_ids - if provided, the HTCondor constraint is restricted to these proc IDs and
+            an empty result is returned (rather than an error) if none are found.
+            An empty list returns an empty dict without querying HTCondor.
+        """
+        return await self._fetch_proc_map(
+            cluster_id, _STATUS_AND_HOLD, proc_ids,
+            lambda ad: ProcDetails(
+                state=_status_to_proc_state(ad[_AD_JOB_STATUS]),
+                hold_reason=ad.get(_AD_HOLD_REASON),
+                hold_reason_code=ad.get(_AD_HOLD_REASON_CODE),
+            ),
+        )
 
     async def release_job(self, cluster_id: int):
         """

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -5,12 +5,15 @@ import htcondor2
 
 from classad2 import ClassAd, ExprTree
 
-from cdmtaskservice.condor.client import CondorClient, ProcState, _RETURNED_JOB_ADS
+from cdmtaskservice.condor.client import CondorClient, ProcDetails, ProcState, _RETURNED_JOB_ADS
 from cdmtaskservice.condor.config import CondorClientConfig
 from cdmtaskservice.config_s3 import S3Config
 
 
 # TODO TEST add more tests
+
+
+_HOLD_PROJ = ["ProcId", "JobStatus", "HoldReason", "HoldReasonCode"]
 
 
 def _make_dependencies():
@@ -332,12 +335,11 @@ async def test_get_cluster_proc_states_mixed():
 async def test_get_cluster_proc_states_unknown_status():
     """An unrecognised JobStatus value (outside 1-7) raises ValueError."""
     client, schedd = _make_client()
+    schedd.history.return_value = []
     for status in (0, 8, 99):
         schedd.query.return_value = [{"ProcId": 0, "JobStatus": status}]
-        schedd.history.return_value = []
         with pytest.raises(ValueError, match=f"^Unknown HTCondor job status: {status}$"):
             await client.get_cluster_proc_states(123)
-        schedd.reset_mock()
 
 
 async def test_get_cluster_proc_states_empty_proc_ids():
@@ -361,8 +363,9 @@ async def test_get_cluster_proc_states_proc_ids_filter():
 
     assert states == {1: ProcState.HELD, 3: ProcState.COMPLETE}
     constraint = "ClusterId == 123 && (ProcId == 1 || ProcId == 3)"
-    schedd.query.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
-    schedd.history.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
+    proj = ["ProcId", "JobStatus"]
+    schedd.query.assert_called_once_with(constraint=constraint, projection=proj)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=proj)
 
 
 async def test_get_cluster_proc_states_proc_ids_not_found():
@@ -375,8 +378,114 @@ async def test_get_cluster_proc_states_proc_ids_not_found():
 
     assert states == {}
     constraint = "ClusterId == 123 && (ProcId == 0 || ProcId == 1)"
-    schedd.query.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
-    schedd.history.assert_called_once_with(constraint=constraint, projection=["ProcId", "JobStatus"])
+    proj = ["ProcId", "JobStatus"]
+    schedd.query.assert_called_once_with(constraint=constraint, projection=proj)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=proj)
+
+
+async def test_get_cluster_proc_details_bad_args():
+    client, _ = _make_client()
+    with pytest.raises(ValueError, match="^cluster_id is required$"):
+        await client.get_cluster_proc_details(None)
+    with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
+        await client.get_cluster_proc_details(0)
+    with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
+        await client.get_cluster_proc_details(-1)
+
+
+async def test_get_cluster_proc_details_no_records():
+    client, schedd = _make_client()
+    schedd.query.return_value = []
+    schedd.history.return_value = []
+
+    with pytest.raises(ValueError, match="^No records found for cluster ID 123$"):
+        await client.get_cluster_proc_details(123)
+
+    constraint = "ClusterId == 123"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+
+
+async def test_get_cluster_proc_details_mixed():
+    """Held proc carries hold fields; history overrides active; no-detail held is fine."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [
+        {"ProcId": 0, "JobStatus": 2},                                          # Running
+        {"ProcId": 1, "JobStatus": 5, "HoldReason": "timeout", "HoldReasonCode": 3},  # Held
+        {"ProcId": 2, "JobStatus": 5},                                          # Held, no details
+        {"ProcId": 3, "JobStatus": 2},                                     # will be overridden
+    ]
+    schedd.history.return_value = [
+        {"ProcId": 3, "JobStatus": 4},   # Completed — overrides active
+        {"ProcId": 4, "JobStatus": 3},   # Removed
+    ]
+
+    details = await client.get_cluster_proc_details(123)
+
+    assert details == {
+        0: ProcDetails(state=ProcState.RUNNING),
+        1: ProcDetails(state=ProcState.HELD, hold_reason="timeout", hold_reason_code=3),
+        2: ProcDetails(state=ProcState.HELD),
+        3: ProcDetails(state=ProcState.COMPLETE),
+        4: ProcDetails(state=ProcState.CANCELED),
+    }
+    constraint = "ClusterId == 123"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+
+
+async def test_get_cluster_proc_details_empty_proc_ids():
+    """Empty proc_ids list returns empty dict without querying condor."""
+    client, schedd = _make_client()
+
+    details = await client.get_cluster_proc_details(123, proc_ids=[])
+
+    assert details == {}
+    schedd.query.assert_not_called()
+    schedd.history.assert_not_called()
+
+
+async def test_get_cluster_proc_details_proc_ids_filter():
+    """The proc_ids list is pushed into the HTCondor constraint, not filtered in Python."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [
+        {"ProcId": 1, "JobStatus": 5, "HoldReason": "oom", "HoldReasonCode": 7}
+    ]
+    schedd.history.return_value = [{"ProcId": 3, "JobStatus": 4}]
+
+    details = await client.get_cluster_proc_details(123, proc_ids=[1, 3])
+
+    assert details == {
+        1: ProcDetails(state=ProcState.HELD, hold_reason="oom", hold_reason_code=7),
+        3: ProcDetails(state=ProcState.COMPLETE),
+    }
+    constraint = "ClusterId == 123 && (ProcId == 1 || ProcId == 3)"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+
+
+async def test_get_cluster_proc_details_unknown_status():
+    """An unrecognised JobStatus value raises ValueError."""
+    client, schedd = _make_client()
+    schedd.history.return_value = []
+    for status in (0, 8, 99):
+        schedd.query.return_value = [{"ProcId": 0, "JobStatus": status}]
+        with pytest.raises(ValueError, match=f"^Unknown HTCondor job status: {status}$"):
+            await client.get_cluster_proc_details(123)
+
+
+async def test_get_cluster_proc_details_proc_ids_not_found():
+    """Requested proc IDs absent from both queues returns empty dict, not an error."""
+    client, schedd = _make_client()
+    schedd.query.return_value = []
+    schedd.history.return_value = []
+
+    details = await client.get_cluster_proc_details(123, proc_ids=[0, 1])
+
+    assert details == {}
+    constraint = "ClusterId == 123 && (ProcId == 0 || ProcId == 1)"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
 
 
 async def test_release_job_bad_args():


### PR DESCRIPTION
...for dead-subjob error messages with HTCondor hold details

get_cluster_proc_details returns a ProcDetails dataclass (state + optional
HoldReason/HoldReasonCode) for each proc in a cluster, using a _fetch_proc_map
helper that both it and get_cluster_proc_states now delegate to. The _AD_HOLD_REASON / _AD_HOLD_REASON_CODE field-name constants are used everywhere
the strings appear.

Minor cleanup: simplify get_cluster_classads' dedup map key from (ClusterId,
ProcId) to just ProcId since all results share the same cluster.