### PR TITLE
Add subjob heartbeat queries and optimistic lock to MongoDAO

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -35,6 +35,9 @@ _FLD_TRANS_TIME_SEND = (
 _FLD_RETRY_ATTEMPT = "_retry"  # not really used for now, but preparation for later
 _FLD_LAST_RECOVER = "_last_recover"
 
+# Sorted so the partial index definition is deterministic for tests
+_SUBJOB_ACTIVE_STATES = sorted(s.value for s in models.JobState.active_states())
+
 
 class MongoDAO:
     """
@@ -143,13 +146,25 @@ class MongoDAO:
             ),
             # Find subjobs in a specific state on a specific retry attempt
             # Could make it unique as there should only be one state per retry, but that would
-            # prevent sharding the collection - which seems unlikely but there's no need to 
+            # prevent sharding the collection - which seems unlikely but there's no need to
             # block the ability when a unique index isn't needed
             IndexModel([
                 (models.FLD_COMMON_ID, ASCENDING),
                 (statefield, ASCENDING),
                 (retryfield, ASCENDING)
             ]),
+            # Find active subjobs by heartbeat time for dead-executor detection.
+            # Partial filter restricts the index to non-terminal, non-canceling, non-recovering
+            # subjobs so it stays small and fast.
+            IndexModel(
+                [
+                    (models.FLD_COMMON_STATE, ASCENDING),
+                    (models.FLD_SUBJOB_HEARTBEAT, ASCENDING),
+                ],
+                partialFilterExpression={
+                    models.FLD_COMMON_STATE: {"$in": _SUBJOB_ACTIVE_STATES}
+                },
+            ),
         ])
         await self._col_exitcodes.create_indexes([
             # Ensure there's no duplicate exit code entries for a job
@@ -441,9 +456,12 @@ class MongoDAO:
         time: datetime.datetime,
         update: JobUpdate,
         recovery_cooldown: datetime.timedelta | None = None,
+        last_update_time: datetime.datetime | None = None,
     ) -> dict[str, Any]:
         """Returns the apply_cond expression for use in a conditional aggregation pipeline."""
         _not_falsy(update, "update")
+        if last_update_time is not None:
+            verify_aware_datetime(last_update_time, "last_update_time")
         conditions = [{"$lte": [f"${_FLD_UPDATE_TIME}", _not_falsy(time, "time")]}]
         if update.current_state:
             conditions.append(
@@ -459,6 +477,12 @@ class MongoDAO:
                 {"$eq": [f"${_FLD_LAST_RECOVER}", None]},
                 {"$lte": [f"${_FLD_LAST_RECOVER}", time - recovery_cooldown]},
             ]})
+        if last_update_time is not None:
+            # Optimistic lock: gate the write on the subjob's _update_time not having changed
+            # since the caller read it. If recovery (or any other write) has modified the
+            # subjob since the caller's read, the condition fails and the write is skipped.
+            # _update_job_state_check_result detects this and raises SubJobUpdateConflictError.
+            conditions.append({"$eq": [f"${_FLD_UPDATE_TIME}", last_update_time]})
         return {"$and": conditions} if len(conditions) > 1 else conditions[0]
 
     def _update_job_state_check_result(
@@ -469,6 +493,7 @@ class MongoDAO:
         time: datetime.datetime,
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
+        last_update_time: datetime.datetime | None = None,
     ):
         if pre_doc is None:
             if subjob_id is not None:
@@ -491,6 +516,20 @@ class MongoDAO:
                 f"{entity} is in disallowed state {actual_state.value!r}",
                 actual_state=actual_state,
             )
+        if last_update_time is not None:
+            # The aggregation write was gated on _update_time == last_update_time. If another
+            # write occurred between the caller's read and this write, the pipeline skipped the
+            # update but still returned pre_doc. Detect that by comparing _update_time in
+            # pre_doc against the expected value: if they differ, the lock was not held.
+            # Checked before the time check so that a concurrent write advancing _update_time
+            # past `time` raises SubJobUpdateConflictError rather than the misleading
+            # "last update time is after the provided time" ValueError.
+            actual_update_time = pre_doc[_FLD_UPDATE_TIME]
+            if actual_update_time != last_update_time:
+                raise SubJobUpdateConflictError(
+                    f"Job '{job_id}' subjob {subjob_id} _update_time {actual_update_time!r} "
+                    f"does not match expected {last_update_time!r}"
+                )
         if pre_doc[_FLD_UPDATE_TIME] > time:
             raise ValueError(f"{entity} last update time is after the provided time")
         if recovery_cooldown and recovery_cooldown > datetime.timedelta(0):
@@ -549,11 +588,14 @@ class MongoDAO:
         trans_id: str | None = None,
         subjob_id: int | None = None,
         recovery_cooldown: datetime.timedelta | None = None,
+        last_update_time: datetime.datetime | None = None,
     ):
         filter_ = {models.FLD_COMMON_ID: _require_string(job_id, "job_id")}
         if subjob_id is not None:
             filter_[models.FLD_SUBJOB_ID] = _check_num(subjob_id, "subjob_id", minimum=0)
-        apply_cond = self._update_job_state_condition(time, update, recovery_cooldown)
+        apply_cond = self._update_job_state_condition(
+            time, update, recovery_cooldown, last_update_time
+        )
         pipeline = self._update_job_state_pipeline(
             apply_cond, update, time, trans_id, recovery_cooldown
         )
@@ -569,7 +611,7 @@ class MongoDAO:
             return_document=ReturnDocument.BEFORE,
         )
         self._update_job_state_check_result(
-            pre_doc, job_id, update, time, subjob_id, recovery_cooldown
+            pre_doc, job_id, update, time, subjob_id, recovery_cooldown, last_update_time
         )
 
     _FLD_NERSC_DL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_DL_TASK_ID}"
@@ -925,14 +967,18 @@ class MongoDAO:
         subjob_id: int,
         update: JobUpdate,
         time: datetime.datetime,
+        last_update_time: datetime.datetime | None = None,
     ):
         """
         Update the sub job state.
-    
+
         job_id - the job ID.
         subjob_id - the subjob ID.
         update - the update to apply to the job.
         time - the time at which the job transitioned to the new state.
+        last_update_time - if provided, gates the write on the subjob's update time matching
+            this value (optimistic lock). If the subjob was modified since this time was read,
+            the write is skipped and SubJobUpdateConflictError is raised.
         """
         await self._update_job_state(
             self._col_subjobs,
@@ -940,7 +986,8 @@ class MongoDAO:
             update,
             time,
             # if not an int, error will occur. Could add a more stringent check later
-            subjob_id=_check_num(subjob_id, "subjob_id", minimum=0)
+            subjob_id=_check_num(subjob_id, "subjob_id", minimum=0),
+            last_update_time=last_update_time,
         )
 
     async def update_subjob_heartbeat(
@@ -964,6 +1011,59 @@ class MongoDAO:
             {"$set": {models.FLD_SUBJOB_HEARTBEAT: time}},
         )
 
+    async def get_subjobs_with_missing_heartbeat(
+        self,
+    ) -> dict[str, dict[int, datetime.datetime]]:
+        """
+        Return a mapping of job ID to {subjob_id: last_update_time} for active subjobs with
+        no heartbeat recorded.
+
+        Active means not terminal, not canceling, and not recovering.
+        Matches subjobs where the heartbeat field is null or absent.
+        """
+        query = {
+            models.FLD_COMMON_STATE: {"$in": _SUBJOB_ACTIVE_STATES},
+            models.FLD_SUBJOB_HEARTBEAT: None,
+        }
+        return await self._aggregate_subjob_job_map(query)
+
+    async def get_subjobs_with_stale_heartbeat(
+        self, older_than: datetime.datetime
+    ) -> dict[str, dict[int, datetime.datetime]]:
+        """
+        Return a mapping of job ID to {subjob_id: last_update_time} for active subjobs whose
+        heartbeat is older than older_than.
+
+        Active means not terminal, not canceling, and not recovering.
+
+        older_than - only subjobs with a heartbeat strictly before this time are returned.
+            Must be timezone-aware.
+        """
+        verify_aware_datetime(older_than, "older_than")
+        query = {
+            models.FLD_COMMON_STATE: {"$in": _SUBJOB_ACTIVE_STATES},
+            models.FLD_SUBJOB_HEARTBEAT: {"$ne": None, "$lt": older_than},
+        }
+        return await self._aggregate_subjob_job_map(query)
+
+    async def _aggregate_subjob_job_map(
+        self, query: dict
+    ) -> dict[str, dict[int, datetime.datetime]]:
+        pipeline = [
+            {"$match": query},
+            {"$group": {
+                "_id": f"${models.FLD_COMMON_ID}",
+                "subjobs": {"$push": {
+                    "id": f"${models.FLD_SUBJOB_ID}",
+                    "t": f"${_FLD_UPDATE_TIME}",
+                }},
+            }},
+        ]
+        result = {}
+        async for doc in self._col_subjobs.aggregate(pipeline):
+            result[doc["_id"]] = {sj["id"]: sj["t"] for sj in doc["subjobs"]}
+        return result
+
     async def recover_subjobs(
         self,
         job_id: str,
@@ -980,7 +1080,7 @@ class MongoDAO:
           - Appends the current admin_error to admin_error_history
           - Resets transition_times to a single DOWNLOAD_SUBMITTED entry
           - Sets state to DOWNLOAD_SUBMITTED
-          - Clears exit_code, error, admin_error, and traceback
+          - Clears exit_code, error, admin_error, traceback, and heartbeat
 
         Null is recorded in the history arrays when a field was not set, preserving
         alignment between history entries and recovery attempts.
@@ -1344,6 +1444,10 @@ class NoSuchJobError(Exception):
 
 class NoSuchSubJobError(Exception):
     """ The sub job does not exist in the system. """
+
+
+class SubJobUpdateConflictError(Exception):
+    """ The subjob was updated by another process since it was last read. """
 
 
 class MissingSubJobError(Exception):

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -15,6 +15,7 @@ from cdmtaskservice.mongo import (
     NoSuchJobError,
     NoSuchReferenceDataError,
     NoSuchSubJobError,
+    SubJobUpdateConflictError,
 )
 from cdmtaskservice.update_state import (
     error,
@@ -134,7 +135,18 @@ async def test_indexes(mongo, mondb):
         "id_1_transition_times.state_1_transition_times._retry_1": {
             "key": [("id", 1), ("transition_times.state", 1), ("transition_times._retry", 1)],
             "v": 2
-        }
+        },
+        "state_1_heartbeat_1": {
+            "v": 2,
+            "key": [("state", 1), ("heartbeat", 1)],
+            "partialFilterExpression": SON([
+                ("state", SON([("$in", [
+                    "created", "download_submitted", "error_processing_submitted",
+                    "error_processing_submitting", "job_submitted", "job_submitting",
+                    "upload_submitted", "upload_submitting",
+                ])]))
+            ]),
+        },
     }
     ecindex = mongo.client[MONGO_TEST_DB]["exitcodes"].index_information()
     assert ecindex == {
@@ -379,7 +391,9 @@ async def test_update_job(mondb):
 
 
 async def test_update_job_htcondor_stats(mondb):
-    """HTCondor stats fields are written to htcondor_details subdocument and read back correctly."""
+    """
+    HTCondor stats fields are written to htcondor_details subdocument and read back correctly.
+    """
     mc = await MongoDAO.create(mondb)
     # HTCondorDetails.cluster_id is required, so initialise it before setting the stats fields
     job = _BASEJOB.model_copy(deep=True)
@@ -908,7 +922,9 @@ async def test_update_subjob_container_stats(mondb):
     await mc.initialize_subjobs([sj])
     await mc.update_subjob_state(
         "bar", 0,
-        submitting_upload_with_exit_code(0, cpu_hours=1.5, max_memory=536870912, runtime_seconds=1800.0),
+        submitting_upload_with_exit_code(
+            0, cpu_hours=1.5, max_memory=536870912, runtime_seconds=1800.0
+        ),
         dt2,
     )
 
@@ -949,14 +965,77 @@ async def test_update_subjob_fail(mondb):
     await fail_update_subjob(mc, "bar", 0, u, _SAFE_TIME + datetime.timedelta(milliseconds=-1),
         ValueError("Job 'bar' with subjob ID 0 last update time is after the provided time")
     )
+    await fail_update_subjob(mc, "bar", 0, u, dt,
+        ValueError("last_update_time must be a timezone aware datetime"),
+        last_update_time=datetime.datetime(2025, 4, 2, 12, 0, 0),
+    )
     assert await mondb.subjobs.find_one({"id": "bar", "sub_id": 0}) == initial_doc
 
 
-async def fail_update_subjob(mc, job_id, subjob_id, update, dt, expected, expected_actual_state=None):
+async def fail_update_subjob(
+    mc, job_id, subjob_id, update, dt, expected, expected_actual_state=None, last_update_time=None
+):
     with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$") as exc_info:
-        await mc.update_subjob_state(job_id, subjob_id, update, dt)
+        await mc.update_subjob_state(
+            job_id, subjob_id, update, dt, last_update_time=last_update_time
+        )
     if isinstance(expected, InvalidJobStateError):
         assert exc_info.value.actual_state == expected_actual_state
+
+
+async def test_update_subjob_last_update_time_conflict(mondb):
+    """
+    When last_update_time is provided, the write is gated on the subjob's _update_time matching
+    that value (optimistic lock). If another write has occurred since the caller read _update_time,
+    SubJobUpdateConflictError is raised and the subjob is unchanged. If the value matches,
+    the write proceeds normally.
+
+    SubJobUpdateConflictError is raised even when the concurrent write's _update_time is after
+    the provided time — i.e. the conflict error takes priority over the time ordering error.
+    """
+    mc = await MongoDAO.create(mondb)
+    dt1 = _SAFE_TIME + datetime.timedelta(minutes=1)
+    dt2 = dt1 + datetime.timedelta(minutes=1)
+
+    await mc.initialize_subjobs([_BASESUBJOB1])
+
+    # Advance the subjob to DOWNLOAD_SUBMITTED; _update_time becomes dt1
+    # initial _update_time is _SAFE_TIME — set by initialize_subjobs from the last transition time
+    await mc.update_subjob_state("bar", 0, submitted_download(), dt1)
+
+    conflict_match = "^Job 'bar' subjob 0 _update_time .* does not match expected "
+
+    # Stale lock (_update_time in DB is dt1, not _SAFE_TIME); provided time dt2 > dt1.
+    with pytest.raises(SubJobUpdateConflictError, match=conflict_match):
+        await mc.update_subjob_state(
+            "bar", 0, error("conflict test"), dt2, last_update_time=_SAFE_TIME
+        )
+
+    # Stale lock where the concurrent write's _update_time (dt1) is also after our time
+    # (dt0 < dt1). Without the fix this would raise ValueError("last update time is after...")
+    # instead of SubJobUpdateConflictError.
+    dt0 = _SAFE_TIME - datetime.timedelta(minutes=1)
+    with pytest.raises(SubJobUpdateConflictError, match=conflict_match):
+        await mc.update_subjob_state(
+            "bar", 0, error("conflict test"), dt0, last_update_time=_SAFE_TIME
+        )
+
+    # State is still DOWNLOAD_SUBMITTED (both optimistic-lock-gated writes were rejected)
+    expected = _BASESUBJOB1.model_copy(deep=True)
+    expected.state = models.JobState.DOWNLOAD_SUBMITTED
+    expected.transition_times.append(
+        models.JobStateTransition(state=models.JobState.DOWNLOAD_SUBMITTED, time=dt1)
+    )
+    assert await mc.get_subjob("bar", 0) == expected
+
+    # Writing ERROR with the current _update_time (dt1) succeeds
+    await mc.update_subjob_state("bar", 0, error("conflict test"), dt2, last_update_time=dt1)
+    expected.state = models.JobState.ERROR
+    expected.admin_error = "conflict test"
+    expected.transition_times.append(
+        models.JobStateTransition(state=models.JobState.ERROR, time=dt2)
+    )
+    assert await mc.get_subjob("bar", 0) == expected
 
 
 async def test_update_subjob_heartbeat(mondb):
@@ -1057,7 +1136,7 @@ async def test_recover_subjobs(mondb):
         return models.JobStateTransition(state=state, time=time)
 
     # subjob 0: error fields cleared, trans_history contains all prior transitions,
-    #           exit_code and admin_error captured into history arrays
+    #           exit_code and admin_error captured into history arrays, heartbeat cleared
     got0 = await mc.get_subjob("bar", 0)
     assert got0 == models.SubJob(
         id="bar",
@@ -1080,7 +1159,7 @@ async def test_recover_subjobs(mondb):
     assert "traceback" not in raw0
     assert "heartbeat" not in raw0
 
-    # subjob 2: no exit_code → null recorded in history; admin_error captured
+    # subjob 2: no exit_code → null recorded in history; admin_error captured; heartbeat cleared
     got2 = await mc.get_subjob("bar", 2)
     assert got2 == models.SubJob(
         id="bar",
@@ -1710,3 +1789,87 @@ async def test_process_dirty_refdata_fail(mondb):
 async def _process_dirty_refdata_fail(mc, older_than, op, expected):
     with pytest.raises(type(expected), match=f"^{expected.args[0]}$"):
         await mc.process_dirty_refdata(older_than, op)
+
+
+def _make_sj(job_id, sub_id, state=models.JobState.CREATED, *, time=_SAFE_TIME, heartbeat=None):
+    return models.SubJob(
+        id=job_id,
+        sub_id=sub_id,
+        state=state,
+        heartbeat=heartbeat,
+        transition_times=[models.JobStateTransition(state=state, time=time)],
+    )
+
+
+_HB_THRESHOLD  = datetime.datetime(2025, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+_HB_OLD        = _HB_THRESHOLD - datetime.timedelta(seconds=1)
+_HB_NEW        = _HB_THRESHOLD + datetime.timedelta(seconds=1)
+_HB_T0         = datetime.datetime(2025, 6, 1, 1, tzinfo=datetime.timezone.utc)  # j1/0 absent hb
+_HB_T1         = datetime.datetime(2025, 6, 1, 2, tzinfo=datetime.timezone.utc)  # j1/1 null hb
+_HB_T2         = datetime.datetime(2025, 6, 1, 3, tzinfo=datetime.timezone.utc)  # j2/0 null hb
+_HB_T3         = datetime.datetime(2025, 6, 1, 4, tzinfo=datetime.timezone.utc)  # j3/0 stale hb
+_HB_T4         = datetime.datetime(2025, 6, 1, 5, tzinfo=datetime.timezone.utc)  # j3/1 stale hb
+_HB_T5         = datetime.datetime(2025, 6, 1, 6, tzinfo=datetime.timezone.utc)  # j4/0 stale hb
+
+
+async def _setup_heartbeat_subjobs(mc, mondb):
+    await mc.initialize_subjobs([
+        # heartbeat absent after $unset → missing:in, stale:out
+        _make_sj("j1", 0, time=_HB_T0),
+        # heartbeat null → missing:in, stale:out
+        _make_sj("j1", 1, time=_HB_T1),
+        # heartbeat null, different active state → missing:in, stale:out
+        _make_sj("j2", 0, models.JobState.DOWNLOAD_SUBMITTED, time=_HB_T2),
+        # recent hb on same job → missing:out, stale:out
+        _make_sj("j2", 1, models.JobState.JOB_SUBMITTED, heartbeat=_HB_NEW),
+        # stale hb → missing:out, stale:in
+        _make_sj("j3", 0, models.JobState.JOB_SUBMITTED, heartbeat=_HB_OLD, time=_HB_T3),
+        # stale hb, different active state and time → missing:out, stale:in
+        _make_sj("j3", 1, models.JobState.DOWNLOAD_SUBMITTED, heartbeat=_HB_OLD, time=_HB_T4),
+        # recent hb on same job → missing:out, stale:out
+        _make_sj("j3", 2, heartbeat=_HB_NEW),
+        # stale hb, second job → missing:out, stale:in
+        _make_sj("j4", 0, heartbeat=_HB_OLD, time=_HB_T5),
+        # terminal → neither (one with stale hb, one with no hb)
+        _make_sj("j5", 0, models.JobState.ERROR, heartbeat=_HB_OLD),
+        _make_sj("j5", 1, models.JobState.ERROR),
+        _make_sj("j5", 2, models.JobState.COMPLETE, heartbeat=_HB_OLD),
+        _make_sj("j5", 3, models.JobState.COMPLETE),
+        # canceling → neither (one with stale hb, one with no hb)
+        _make_sj("j6", 0, models.JobState.CANCELING, heartbeat=_HB_OLD),
+        _make_sj("j6", 1, models.JobState.CANCELING),
+        _make_sj("j6", 2, models.JobState.CANCELED, heartbeat=_HB_OLD),
+        _make_sj("j6", 3, models.JobState.CANCELED),
+        # recovering → neither (one with stale hb, one with no hb)
+        _make_sj("j7", 0, models.JobState.RECOVERING, heartbeat=_HB_OLD),
+        _make_sj("j7", 1, models.JobState.RECOVERING),
+    ])
+    await mondb.subjobs.update_one({"id": "j1", "sub_id": 0}, {"$unset": {"heartbeat": ""}})
+
+
+async def test_get_subjobs_with_missing_heartbeat(mondb):
+    mc = await MongoDAO.create(mondb)
+    await _setup_heartbeat_subjobs(mc, mondb)
+
+    assert await mc.get_subjobs_with_missing_heartbeat() == {
+        "j1": {0: _HB_T0, 1: _HB_T1},
+        "j2": {0: _HB_T2},
+    }
+
+
+async def test_get_subjobs_with_stale_heartbeat(mondb):
+    mc = await MongoDAO.create(mondb)
+    await _setup_heartbeat_subjobs(mc, mondb)
+
+    assert await mc.get_subjobs_with_stale_heartbeat(_HB_THRESHOLD) == {
+        "j3": {0: _HB_T3, 1: _HB_T4},
+        "j4": {0: _HB_T5},
+    }
+
+
+async def test_get_subjobs_with_stale_heartbeat_fail(mondb):
+    mc = await MongoDAO.create(mondb)
+    with pytest.raises(ValueError, match="^older_than is required$"):
+        await mc.get_subjobs_with_stale_heartbeat(None)
+    with pytest.raises(ValueError, match="^older_than must be a timezone aware datetime$"):
+        await mc.get_subjobs_with_stale_heartbeat(datetime.datetime(2025, 1, 1))


### PR DESCRIPTION
Add get_subjobs_with_missing_heartbeat and
get_subjobs_with_stale_heartbeat
to MongoDAO, backed by a partial index on (state, heartbeat) restricted to
active states.

Add last_update_time parameter to update_subjob_state for optimistic concurrency control: gates the write on the subjob's _update_time matching
the caller's last-read value, raising SubJobUpdateConflictError if another
write has intervened. The conflict check runs before the time-ordering check
so a concurrent write that advances _update_time past the provided time raises SubJobUpdateConflictError rather than a misleading ValueError.