### PR TITLE
Prevent ERROR write from overwriting recovered job

### DIFF
--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -33,8 +33,9 @@ from cdmtaskservice.exceptions import (
 )
 from cdmtaskservice.jobflows.flowmanager import JobFlow, JobFlowOrError
 from cdmtaskservice.jobflows.state_updates import SubjobFlowStateUpdates
+from cdmtaskservice import logfields
 from cdmtaskservice import models
-from cdmtaskservice.mongo import MongoDAO
+from cdmtaskservice.mongo import JobUpdateConflictError, MongoDAO
 from cdmtaskservice.notifications.kafka_notifications import KafkaNotifier
 from cdmtaskservice.refserv.client import RefdataServiceClient
 from cdmtaskservice.s3.client import S3ObjectMeta
@@ -386,11 +387,45 @@ class KBaseRunner(JobFlow):
     async def _run_terminal_update(
         self, job: models.AdminJobDetails, parent_update
     ):
+        # Use last update time to ensure that if a recovery starts between pulling the job
+        # and erroring out the job the error is ignored. Otherwise after _run_terminal_update
+        # starts, job recovery could occur while htcondor is being polled waiting for jobs to
+        # finish and then this coroutine would error out the just recovered job
+        error_last_update_time = None
         try:
             if parent_update.state == models.JobState.ERROR:
-                await self._error_job(job)
+                error_last_update_time = job.transition_times[-1].time
+                await self._error_job(job, error_last_update_time)
             else:
                 await self._complete_job(job, update_time=parent_update.time)
+        except JobUpdateConflictError as e:
+            # Recovery modified the job between our read and the ERROR write; recovery wins.
+            self._logr.info(
+                "Job update conflict on terminal error write, ignoring: %s", e,
+                extra={logfields.JOB_ID: job.id},
+            )
+        except ExternalRunnerTimeoutError as e:
+            if error_last_update_time:
+                try:
+                    await self._updates.update_job_state(
+                        job.id,
+                        update_state.error(
+                            str(e),
+                            user_error="An unexpected error occurred.",
+                        ),
+                        last_update_time=error_last_update_time,
+                    )
+                except JobUpdateConflictError as juce:
+                    self._logr.info(
+                        "Job update conflict on timeout error write, ignoring: %s", juce,
+                        extra={logfields.JOB_ID: job.id},
+                    )
+            else:
+                # COMPLETE path: leave the job in its current state so recovery can retry.
+                self._logr.info(
+                    "External runner timeout on complete path, job may be recovered: %s", e,
+                    extra={logfields.JOB_ID: job.id},
+                )
         except Exception as e:
             await self._handle_parent_update_error(e, job.id)
 
@@ -409,7 +444,9 @@ class KBaseRunner(JobFlow):
             update_time=update_time,
         )
 
-    async def _error_job(self, job: models.AdminJobDetails):
+    async def _error_job(
+        self, job: models.AdminJobDetails, last_update_time: datetime.datetime
+    ):
         condor_stats = await self._fetch_condor_classad_stats(job)
         exit_codes = await self._mongo.get_exit_codes_for_subjobs(job.id)
         # if any exit codes are present and > 0, a container failed. Exit codes can be None
@@ -420,14 +457,18 @@ class KBaseRunner(JobFlow):
                    + "error code. Please examine the logs for details.")
         else:
             err = "An unexpected error occurred."
-        await self._updates.update_job_state(job.id, update_state.error(
-            "Check subjobs / containers for admin errors",  # maybe improve later
-            user_error=err,
-            log_files_path=str(Path(self._s3logdir) / job.id) if err_exit else None,
-            htcondor_cpu_hours=condor_stats.cpu_hours,
-            htcondor_max_memory=condor_stats.max_memory,
-            htcondor_runtime_seconds=condor_stats.runtime_seconds,
-        ))
+        await self._updates.update_job_state(
+            job.id,
+            update_state.error(
+                "Check subjobs / containers for admin errors",  # maybe improve later
+                user_error=err,
+                log_files_path=str(Path(self._s3logdir) / job.id) if err_exit else None,
+                htcondor_cpu_hours=condor_stats.cpu_hours,
+                htcondor_max_memory=condor_stats.max_memory,
+                htcondor_runtime_seconds=condor_stats.runtime_seconds,
+            ),
+            last_update_time=last_update_time,
+        )
         
     async def _complete_job(
         self, job: models.AdminJobDetails, update_time: datetime.datetime | None = None
@@ -523,7 +564,9 @@ class KBaseRunner(JobFlow):
             if not running or condor_jobs_all_held(running):
                 return condor_job_stats(running + complete)
             attempts += 1
-        raise IOError("Condor jobs didn't complete for 60s after all executors sent termination")
+        raise ExternalRunnerTimeoutError(
+            "External runner jobs didn't complete for 60s after all executors sent termination"
+        )
 
     async def _get_subjob_stats(
         self, job: models.AdminJobDetails
@@ -968,3 +1011,8 @@ class KBaseFlowProvider:
         except Exception as e:
             self._logr.exception(f"Failed to initialize KBase job flow dependencies: {e}")
             return None
+
+
+class ExternalRunnerTimeoutError(Exception):
+    """The external runner did not complete jobs within the expected polling window."""
+

--- a/cdmtaskservice/jobflows/state_updates.py
+++ b/cdmtaskservice/jobflows/state_updates.py
@@ -129,6 +129,7 @@ class JobFlowStateUpdates:
         update: JobUpdate,
         update_time: datetime.datetime = None,
         recovery_cooldown: datetime.timedelta | None = None,
+        last_update_time: datetime.datetime | None = None,
     ):
         """
         Update the state of a job.
@@ -139,6 +140,9 @@ class JobFlowStateUpdates:
         recovery_cooldown - if provided and > 0, prevents a job recovery attempt if the prior
             recovery, if any, was less than the time provided in the past. If provided at all,
             sets the time of the last recovery attempt.
+        last_update_time - if provided, gates the write on the job's update time matching this
+            value. If the job was modified by another process since it was last read, the write
+            is skipped and JobUpdateConflictError is raised.
         """
         _require_string(job_id, "job_id")
         _not_falsy(update, "update")
@@ -147,7 +151,9 @@ class JobFlowStateUpdates:
         async def cb():
             await self._mongo.job_update_sent(job_id, trans_id)
         await self._mongo.update_job_state(
-            job_id, update, update_time, trans_id, recovery_cooldown=recovery_cooldown
+            job_id, update, update_time, trans_id,
+            recovery_cooldown=recovery_cooldown,
+            last_update_time=last_update_time,
         )
         await self._kafka.update_job_state(
             job_id, update.new_state, update_time, trans_id, callback=cb()

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -481,7 +481,8 @@ class MongoDAO:
             # Optimistic lock: gate the write on the subjob's _update_time not having changed
             # since the caller read it. If recovery (or any other write) has modified the
             # subjob since the caller's read, the condition fails and the write is skipped.
-            # _update_job_state_check_result detects this and raises SubJobUpdateConflictError.
+            # _update_job_state_check_result detects this and raises JobUpdateConflictError
+            # (job-level) or SubJobUpdateConflictError (subjob-level).
             conditions.append({"$eq": [f"${_FLD_UPDATE_TIME}", last_update_time]})
         return {"$and": conditions} if len(conditions) > 1 else conditions[0]
 
@@ -522,13 +523,18 @@ class MongoDAO:
             # update but still returned pre_doc. Detect that by comparing _update_time in
             # pre_doc against the expected value: if they differ, the lock was not held.
             # Checked before the time check so that a concurrent write advancing _update_time
-            # past `time` raises SubJobUpdateConflictError rather than the misleading
-            # "last update time is after the provided time" ValueError.
+            # past `time` raises a conflict error rather than the misleading "last update time
+            # is after the provided time" ValueError.
             actual_update_time = pre_doc[_FLD_UPDATE_TIME]
             if actual_update_time != last_update_time:
+                if subjob_id is None:
+                    raise JobUpdateConflictError(
+                        f"Job '{job_id}' update time {actual_update_time} "
+                        f"does not match expected {last_update_time}"
+                    )
                 raise SubJobUpdateConflictError(
-                    f"Job '{job_id}' subjob {subjob_id} _update_time {actual_update_time!r} "
-                    f"does not match expected {last_update_time!r}"
+                    f"Job '{job_id}' subjob {subjob_id} update time {actual_update_time} "
+                    f"does not match expected {last_update_time}"
                 )
         if pre_doc[_FLD_UPDATE_TIME] > time:
             raise ValueError(f"{entity} last update time is after the provided time")
@@ -661,6 +667,7 @@ class MongoDAO:
         trans_id: str,
         *,
         recovery_cooldown: datetime.timedelta | None = None,
+        last_update_time: datetime.datetime | None = None,
     ):
         """
         Update the job state, marking it as not yet sent to the notification system.
@@ -677,6 +684,9 @@ class MongoDAO:
             JobRecoveryError otherwise. Pass timedelta(0) for a regular (non-force) recovery
             that sets the timestamp without a minimum-time constraint, or a positive timedelta
             for a forced recovery that enforces a minimum wait between recoveries.
+        last_update_time - if provided, gates the write on the job's _update_time matching this
+            value. If the job was modified by another process since it was last read, the write
+            is skipped and JobUpdateConflictError is raised.
         """
         # If we need to send notifications to more than one place this will need a refactor. YAGNI
         await self._update_job_state(
@@ -686,6 +696,7 @@ class MongoDAO:
             time,
             trans_id=_require_string(trans_id, "trans_id"),
             recovery_cooldown=recovery_cooldown,
+            last_update_time=last_update_time,
         )
 
     @staticmethod
@@ -1444,6 +1455,10 @@ class NoSuchJobError(Exception):
 
 class NoSuchSubJobError(Exception):
     """ The sub job does not exist in the system. """
+
+
+class JobUpdateConflictError(Exception):
+    """ The job was updated by another process since it was last read. """
 
 
 class SubJobUpdateConflictError(Exception):

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import pytest
 from unittest.mock import call, create_autospec, patch, PropertyMock
 
@@ -6,11 +7,11 @@ from cdmtaskservice.condor.client import CondorClient, ProcState
 from cdmtaskservice import sites
 from cdmtaskservice.config_s3 import S3Config
 from cdmtaskservice.exceptions import InvalidJobStateError, JobRecoveryError, UnsupportedOperationError
-from cdmtaskservice.jobflows.kbase import KBaseRunner
+from cdmtaskservice.jobflows.kbase import ExternalRunnerTimeoutError, KBaseRunner
 from cdmtaskservice.jobflows.state_updates import SubjobFlowStateUpdates, ParentJobUpdate
 from cdmtaskservice import models
 from cdmtaskservice import update_state
-from cdmtaskservice.mongo import MongoDAO
+from cdmtaskservice.mongo import JobUpdateConflictError, MongoDAO
 from cdmtaskservice.refserv.client import RefdataServiceClient
 from cdmtaskservice.s3.client import S3Client, S3ObjectMeta
 from cdmtaskservice.s3.paths import S3Paths
@@ -57,6 +58,12 @@ def _job(num_containers=2):
         id="jid",
         job_input=models.JobInput.model_construct(num_containers=num_containers, cpus=1),
         htcondor_details=models.HTCondorDetails(cluster_id=[123]),
+        transition_times=[models.AdminJobStateTransition(
+            state=models.JobState.JOB_SUBMITTED,
+            time=_T,
+            trans_id=_TRANS_ID,
+            notif_sent=True,
+        )],
     )
 
 
@@ -487,6 +494,7 @@ async def test_update_container_state_terminal_error():
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
+        last_update_time=_T,
     )
 
 
@@ -601,6 +609,7 @@ async def test_update_container_state_recovering_ignored_terminal():
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
+        last_update_time=_T,
     )
     updates.handle_exception.assert_not_called()
 
@@ -673,6 +682,7 @@ async def test_update_container_state_error_job_no_nonzero_exit_codes():
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
+        last_update_time=_T,
     )
 
 
@@ -712,11 +722,17 @@ async def test_update_container_state_error_job_held_running_containers():
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
         ),
+        last_update_time=_T,
     )
 
 
+_CONDOR_TIMEOUT_MSG = (
+    "External runner jobs didn't complete for 60s after all executors sent termination"
+)
+
+
 async def test_update_container_state_condor_stats_timeout():
-    """_fetch_condor_classad_stats raises IOError after 12 attempts; handle_exception is called."""
+    """ExternalRunnerTimeoutError is caught; update_job_state is called with last_update_time."""
     runner, mongo, condor, updates, _ = _make_runner()
     updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
     # JobStatus=2 (running, not held) keeps the loop going until the 12-attempt limit
@@ -735,14 +751,116 @@ async def test_update_container_state_condor_stats_timeout():
     )
     assert condor.get_cluster_classads.call_count == 12
     condor.get_cluster_classads.assert_called_with(123)
-    # IOError raised before get_subjobs is reached
+    # Error raised before get_subjobs is reached
     mongo.get_subjobs.assert_not_called()
     mongo.get_exit_codes_for_subjobs.assert_not_called()
     updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
-    exc = updates.handle_exception.call_args.args[0]
-    assert isinstance(exc, IOError)
-    assert str(exc) == "Condor jobs didn't complete for 60s after all executors sent termination"
-    updates.handle_exception.assert_called_once_with(exc, "jid", "updating state for")
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.error(_CONDOR_TIMEOUT_MSG, user_error="An unexpected error occurred."),
+        last_update_time=_T,
+    )
+    updates.handle_exception.assert_not_called()
+
+
+async def test_update_container_state_condor_stats_timeout_recovery_wins(caplog):
+    """When recovery modifies the job during the timeout, JobUpdateConflictError is swallowed."""
+    runner, mongo, condor, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
+    condor.get_cluster_classads.return_value = ([{"JobStatus": 2}], [])
+    updates.update_job_state.side_effect = JobUpdateConflictError("conflict")
+
+    with caplog.at_level(logging.INFO, logger="cdmtaskservice.jobflows.kbase"):
+        with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
+            await runner.update_container_state(
+                _JOB, 0, models.JobState.ERROR,
+                _update(admin_error="container failed", traceback="Traceback: container failed"),
+            )
+
+    mongo.update_subjob_state.assert_called_once_with(
+        "jid", 0,
+        update_state.error("container failed", traceback="Traceback: container failed"), _T,
+    )
+    condor.get_cluster_classads.assert_called_with(123)
+    assert condor.get_cluster_classads.call_count == 12
+    mongo.get_exit_codes_for_subjobs.assert_not_called()
+    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.error(_CONDOR_TIMEOUT_MSG, user_error="An unexpected error occurred."),
+        last_update_time=_T,
+    )
+    updates.handle_exception.assert_not_called()
+    assert "Job update conflict on timeout error write, ignoring: conflict" in caplog.text
+
+
+async def test_update_container_state_condor_stats_timeout_complete_path(caplog):
+    """
+    On the COMPLETE path, ExternalRunnerTimeoutError is swallowed so the job may be recovered.
+    """
+    runner, mongo, condor, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.COMPLETE, _T)
+    condor.get_cluster_classads.return_value = ([{"JobStatus": 2}], [])
+
+    with caplog.at_level(logging.INFO, logger="cdmtaskservice.jobflows.kbase"):
+        with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
+            await runner.update_container_state(
+                _JOB, 0, models.JobState.COMPLETE, _update(outputs=[]),
+            )
+
+    mongo.update_subjob_state.assert_called_once_with(
+        "jid", 0, update_state.complete([]), _T,
+    )
+    condor.get_cluster_classads.assert_called_with(123)
+    assert condor.get_cluster_classads.call_count == 12
+    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.COMPLETE)
+    updates.update_job_state.assert_not_called()
+    updates.handle_exception.assert_not_called()
+    assert (
+        f"External runner timeout on complete path, job may be recovered: {_CONDOR_TIMEOUT_MSG}"
+        in caplog.text
+    )
+
+
+async def test_update_container_state_error_job_update_conflict(caplog):
+    """When recovery beats the ERROR terminal write, JobUpdateConflictError is swallowed."""
+    runner, mongo, condor, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
+    condor.get_cluster_classads.return_value = ([], [_CONDOR_AD])
+    mongo.get_exit_codes_for_subjobs.return_value = [1]
+    updates.update_job_state.side_effect = JobUpdateConflictError("conflict")
+
+    with caplog.at_level(logging.INFO, logger="cdmtaskservice.jobflows.kbase"):
+        with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
+            await runner.update_container_state(
+                _JOB, 0, models.JobState.ERROR,
+                _update(admin_error="container failed", traceback="Traceback: container failed"),
+            )
+
+    mongo.update_subjob_state.assert_called_once_with(
+        "jid", 0,
+        update_state.error("container failed", traceback="Traceback: container failed"), _T,
+    )
+    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
+    condor.get_cluster_classads.assert_called_once_with(123)
+    mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.error(
+            "Check subjobs / containers for admin errors",
+            user_error=(
+                "At least one container exited with a non-zero "
+                "error code. Please examine the logs for details."
+            ),
+            log_files_path="logs/jid",
+            htcondor_cpu_hours=_HTC_CPU_HOURS,
+            htcondor_max_memory=_HTC_MAX_MEM,
+            htcondor_runtime_seconds=_HTC_RUNTIME,
+        ),
+        last_update_time=_T,
+    )
+    updates.handle_exception.assert_not_called()
+    assert "Job update conflict on terminal error write, ignoring: conflict" in caplog.text
 
 
 async def test_update_container_state_complete_job_no_outputs():
@@ -1244,7 +1362,7 @@ async def test_recover_job_complete_job_checksum_mismatch():
 
 
 async def test_recover_job_complete_job_condor_stats_timeout():
-    """Unlike update_container_state, the IOError propagates directly to the caller."""
+    """Unlike update_container_state, ExternalRunnerTimeoutError propagates to the caller."""
     runner, _, condor, updates, _ = _make_runner()
     job = _recovery_job(state=models.JobState.UPLOAD_SUBMITTED)
     condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
@@ -1252,7 +1370,7 @@ async def test_recover_job_complete_job_condor_stats_timeout():
     condor.get_cluster_classads.return_value = ([{"JobStatus": 2}], [])
 
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
-        with pytest.raises(IOError, match="Condor jobs didn't complete"):
+        with pytest.raises(ExternalRunnerTimeoutError, match="External runner jobs didn't complete"):
             await runner.recover_job(job)
 
     condor.get_cluster_proc_states.assert_called_once_with(123)

--- a/test/jobflows/state_updates_test.py
+++ b/test/jobflows/state_updates_test.py
@@ -93,7 +93,7 @@ async def test_update_job_state():
     await jfsu.update_job_state("jid", upd)
 
     mongo.update_job_state.assert_called_once_with(
-        "jid", upd, _T, _TRANS_ID, recovery_cooldown=None
+        "jid", upd, _T, _TRANS_ID, recovery_cooldown=None, last_update_time=None
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", upd.new_state, _T, _TRANS_ID, callback=ANY
@@ -109,7 +109,7 @@ async def test_update_job_state_explicit_time():
     await jfsu.update_job_state("jid", upd, update_time=_EXPLICIT_T)
 
     mongo.update_job_state.assert_called_once_with(
-        "jid", upd, _EXPLICIT_T, _TRANS_ID, recovery_cooldown=None
+        "jid", upd, _EXPLICIT_T, _TRANS_ID, recovery_cooldown=None, last_update_time=None
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", upd.new_state, _EXPLICIT_T, _TRANS_ID, callback=ANY
@@ -126,7 +126,25 @@ async def test_update_job_state_with_recovery_cooldown():
     await jfsu.update_job_state("jid", upd, recovery_cooldown=cooldown)
 
     mongo.update_job_state.assert_called_once_with(
-        "jid", upd, _T, _TRANS_ID, recovery_cooldown=cooldown
+        "jid", upd, _T, _TRANS_ID, recovery_cooldown=cooldown, last_update_time=None
+    )
+    kafka.update_job_state.assert_called_once_with(
+        "jid", upd.new_state, _T, _TRANS_ID, callback=ANY
+    )
+    await kafka.update_job_state.call_args.kwargs["callback"]
+    mongo.job_update_sent.assert_called_once_with("jid", _TRANS_ID)
+
+
+async def test_update_job_state_with_last_update_time():
+    """last_update_time is threaded through to mongo.update_job_state."""
+    mongo, kafka, jfsu = _make_jfsu()
+    upd = update_state.submitting_job()
+    lut = datetime.datetime(2025, 6, 1, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+    await jfsu.update_job_state("jid", upd, last_update_time=lut)
+
+    mongo.update_job_state.assert_called_once_with(
+        "jid", upd, _T, _TRANS_ID, recovery_cooldown=None, last_update_time=lut
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", upd.new_state, _T, _TRANS_ID, callback=ANY
@@ -177,6 +195,7 @@ async def test_save_error_job():
         update_state.error("admin err", user_error="user err"),
         _T, _TRANS_ID,
         recovery_cooldown=None,
+        last_update_time=None,
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", models.JobState.ERROR, _T, _TRANS_ID, callback=ANY
@@ -197,6 +216,7 @@ async def test_save_error_job_with_traceback_and_logpath():
         ),
         _T, _TRANS_ID,
         recovery_cooldown=None,
+        last_update_time=None,
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", models.JobState.ERROR, _T, _TRANS_ID, callback=ANY
@@ -261,6 +281,7 @@ async def test_handle_exception_job(caplog):
         _T,
         _TRANS_ID,
         recovery_cooldown=None,
+        last_update_time=None,
     )
     kafka.update_job_state.assert_called_once_with(
         "jid", models.JobState.ERROR, _T, _TRANS_ID, callback=ANY

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -11,6 +11,7 @@ from cdmtaskservice import sites
 from cdmtaskservice.exceptions import InvalidJobStateError, JobRecoveryError
 from cdmtaskservice.mongo import (
     MissingSubJobError,
+    JobUpdateConflictError,
     MongoDAO,
     NoSuchJobError,
     NoSuchReferenceDataError,
@@ -649,6 +650,64 @@ async def test_update_job_recovery_cooldown_fail(mondb):
     assert job["_last_recover"] == dt3
 
 
+async def test_update_job_last_update_time_conflict(mondb):
+    """
+    When last_update_time is provided, the write is gated on the job's _update_time matching
+    that value (optimistic lock). If another write has occurred since the caller read _update_time,
+    JobUpdateConflictError is raised and the job is unchanged. If the value matches, the write
+    proceeds normally.
+
+    JobUpdateConflictError is raised even when the concurrent write's _update_time is after the
+    provided time — conflict takes priority over the time ordering error.
+    """
+    mc = await MongoDAO.create(mondb)
+    dt1 = _SAFE_TIME + datetime.timedelta(minutes=1)
+    dt2 = dt1 + datetime.timedelta(minutes=1)
+
+    await mc.save_job(_BASEJOB)
+    # Advance the job to JOB_SUBMITTING; _update_time becomes dt1
+    # initial _update_time is _SAFE_TIME — set by save_job from the last transition time
+    await mc.update_job_state("foo", submitting_job(), dt1, "tid1")
+
+    conflict_match = re.escape(
+        "Job 'foo' update time 2025-03-31 12:01:00.345000+00:00"
+        " does not match expected 2025-03-31 12:00:00.345000+00:00"
+    )
+
+    # Stale lock (_update_time in DB is dt1, not _SAFE_TIME); provided time dt2 > dt1.
+    with pytest.raises(JobUpdateConflictError, match=conflict_match):
+        await mc.update_job_state("foo", error("conflict test"), dt2, "tid2",
+                                  last_update_time=_SAFE_TIME)
+
+    # Stale lock where the concurrent write's _update_time (dt1) is also after our time
+    # (dt0 < dt1). Should raise conflict error, not value error.
+    dt0 = _SAFE_TIME - datetime.timedelta(minutes=1)
+    with pytest.raises(JobUpdateConflictError, match=conflict_match):
+        await mc.update_job_state("foo", error("conflict test"), dt0, "tid3",
+                                  last_update_time=_SAFE_TIME)
+
+    # Job is still JOB_SUBMITTING (both lock-gated writes were rejected)
+    expected = _BASEJOB.model_copy(deep=True)
+    expected.state = models.JobState.JOB_SUBMITTING
+    expected.transition_times.append(
+        models.AdminJobStateTransition(
+            state=models.JobState.JOB_SUBMITTING, time=dt1, trans_id="tid1", notif_sent=False
+        )
+    )
+    assert await mc.get_job("foo", as_admin=True) == expected
+
+    # Writing with the current _update_time (dt1) succeeds
+    await mc.update_job_state("foo", error("accepted"), dt2, "tid4", last_update_time=dt1)
+    expected.state = models.JobState.ERROR
+    expected.admin_error = "accepted"
+    expected.transition_times.append(
+        models.AdminJobStateTransition(
+            state=models.JobState.ERROR, time=dt2, trans_id="tid4", notif_sent=False
+        )
+    )
+    assert await mc.get_job("foo", as_admin=True) == expected
+
+
 async def test_recover_job(mondb):
     mc = await MongoDAO.create(mondb)
 
@@ -1003,7 +1062,10 @@ async def test_update_subjob_last_update_time_conflict(mondb):
     # initial _update_time is _SAFE_TIME — set by initialize_subjobs from the last transition time
     await mc.update_subjob_state("bar", 0, submitted_download(), dt1)
 
-    conflict_match = "^Job 'bar' subjob 0 _update_time .* does not match expected "
+    conflict_match = re.escape(
+        "Job 'bar' subjob 0 update time 2025-03-31 12:01:00.345000+00:00"
+        " does not match expected 2025-03-31 12:00:00.345000+00:00"
+    )
 
     # Stale lock (_update_time in DB is dt1, not _SAFE_TIME); provided time dt2 > dt1.
     with pytest.raises(SubJobUpdateConflictError, match=conflict_match):


### PR DESCRIPTION
  After all containers signal terminal state, KBaseRunner polls
  HTCondor for up to 60s before writing ERROR to Mongo. Job
  recovery can win that window: the admin calls recover_job,
  which resets the job to DOWNLOAD_SUBMITTED while the polling
  loop is still running. When the loop exits, the stale ERROR
  write would overwrite the recovered job.

  Fix: record the job's _update_time before entering the condor
  polling loop (error_last_update_time). Pass it as an optimistic
  lock to update_job_state. Mongo gates the write on _update_time
  still matching; if recovery has written in between, the write is
  skipped and JobUpdateConflictError is raised and swallowed.

  On the COMPLETE path condor timeouts are also swallowed (logged
  at INFO) so the job stays in its pre-terminal state and can be
  retried via the recovery flow.