### PR TITLE
Make get_cluster_proc_details explicit about missing procs

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -52,6 +52,7 @@ class ProcState(enum.Enum):
     COMPLETE = "complete"
     CANCELED = "canceled"
     OTHER = "other"
+    MISSING = "missing"
 
     def is_healthy(self) -> bool:
         """ Return True if this state does not indicate a problem requiring intervention. """
@@ -399,6 +400,8 @@ class CondorClient:
         running_job_ads, complete_job_ads = await self._fetch_cluster_ads(
             cluster_id, _RETURNED_JOB_ADS
         )
+        if not running_job_ads and not complete_job_ads:
+            raise ValueError(f"No records found for cluster ID {cluster_id}")
         id2ad = {ad[_AD_PROC_ID]: ad for ad in running_job_ads}
         for ad in complete_job_ads:
             # remove jobs that have transitioned to complete between the queries
@@ -425,8 +428,6 @@ class CondorClient:
             constraint=constraint,
             projection=projection,
         )
-        if not active_ads and not complete_ads and proc_ids is None:
-            raise ValueError(f"No records found for cluster ID {cluster_id}")
         return active_ads, complete_ads
 
     async def _fetch_proc_map(
@@ -464,35 +465,64 @@ class CondorClient:
             an empty result is returned (rather than an error) if none are found.
             An empty list returns an empty dict without querying HTCondor.
         """
-        return await self._fetch_proc_map(
+        result = await self._fetch_proc_map(
             cluster_id, _STATUS_ONLY, proc_ids,
             lambda ad: _status_to_proc_state(ad[_AD_JOB_STATUS]),
         )
+        if proc_ids is None and not result:
+            raise ValueError(f"No records found for cluster ID {cluster_id}")
+        return result
 
     async def get_cluster_proc_details(
         self,
         cluster_id: int,
-        proc_ids: Collection[int] | None = None,
+        expected_procs: int | Collection[int],
     ) -> dict[int, ProcDetails]:
         """
         Get the state and hold details of each process in an HTC cluster.
 
-        Returns a dict mapping proc ID (== container number) to ProcDetails.
-        Raises ValueError if no records are found for cluster_id and proc_ids is None.
+        Returns a dict mapping proc ID (== container number) to ProcDetails, with a full
+        entry for every expected proc. Procs absent from both the active queue and history
+        are returned with ProcDetails(state=ProcState.MISSING).
 
         cluster_id - the HTCondor cluster ID.
-        proc_ids - if provided, the HTCondor constraint is restricted to these proc IDs and
-            an empty result is returned (rather than an error) if none are found.
-            An empty list returns an empty dict without querying HTCondor.
+        expected_procs - the expected set of proc IDs. If an int n, the expected set is
+            range(n) and the HTCondor query is unrestricted to proc IDs. If a collection,
+            it is used directly as both the expected set and the query filter. An empty
+            collection returns an empty dict without querying HTCondor.
         """
-        return await self._fetch_proc_map(
-            cluster_id, _STATUS_AND_HOLD, proc_ids,
+        if expected_procs is None:
+            raise ValueError("expected_procs is required")
+        if isinstance(expected_procs, int):
+            if expected_procs < 0:
+                raise ValueError("expected_procs must be >= 0")
+            filter_ids: Collection[int] | None = None
+            expected_ids: Collection[int] = range(expected_procs)
+        else:
+            invalid = sorted(pid for pid in expected_procs if pid < 0)
+            if invalid:
+                raise ValueError(f"expected_procs contains proc IDs less than 0: {invalid}")
+            filter_ids = expected_procs
+            expected_ids = expected_procs
+        result = await self._fetch_proc_map(
+            cluster_id, _STATUS_AND_HOLD, filter_ids,
             lambda ad: ProcDetails(
                 state=_status_to_proc_state(ad[_AD_JOB_STATUS]),
                 hold_reason=ad.get(_AD_HOLD_REASON),
                 hold_reason_code=ad.get(_AD_HOLD_REASON_CODE),
             ),
         )
+        if isinstance(expected_procs, int):
+            unexpected = sorted(pid for pid in result if pid not in expected_ids)
+            if unexpected:
+                raise ValueError(
+                    f"HTCondor returned unexpected proc IDs {unexpected} for cluster "
+                    f"{cluster_id}; expected_procs={expected_procs}"
+                )
+        for proc_id in expected_ids:
+            if proc_id not in result:
+                result[proc_id] = ProcDetails(state=ProcState.MISSING)
+        return result
 
     async def release_job(self, cluster_id: int):
         """

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -725,7 +725,7 @@ class KBaseRunner(JobFlow):
         subjob_ids = list(subjob_last_times.keys())
         try:
             proc_details = await self._condor.get_cluster_proc_details(
-                cluster_id, proc_ids=subjob_ids
+                cluster_id, subjob_ids
             )
         except Exception as e:
             self._logr.error(
@@ -735,13 +735,9 @@ class KBaseRunner(JobFlow):
             )
             return
         for sub_id, last_update_time in subjob_last_times.items():
-            details = proc_details.get(sub_id)
-            if details is None:
-                details = ProcDetails(
-                    state=ProcState.OTHER,
-                    hold_reason=f"HTCondor proc absent from cluster {cluster_id} response",
-                )
-            await self._error_proc_if_unhealthy(job, sub_id, details, last_update_time)
+            await self._error_proc_if_unhealthy(
+                job, sub_id, proc_details[sub_id], last_update_time
+            )
 
     async def _error_proc_if_unhealthy(
         self,
@@ -755,6 +751,11 @@ class KBaseRunner(JobFlow):
         admin_error = (
             f"No active executor heartbeat; HTCondor proc is in state {details.state.value}"
         )
+        if details.state is ProcState.MISSING:
+            admin_error = (
+                "No active executor heartbeat; HTCondor has no record of this proc "
+                "(absent from both active queue and history — likely purged)"
+            )
         if details.hold_reason_code is not None:
             admin_error += f"; HTCondor hold reason code: {details.hold_reason_code}"
         if details.hold_reason:

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -386,21 +386,34 @@ async def test_get_cluster_proc_states_proc_ids_not_found():
 async def test_get_cluster_proc_details_bad_args():
     client, _ = _make_client()
     with pytest.raises(ValueError, match="^cluster_id is required$"):
-        await client.get_cluster_proc_details(None)
+        await client.get_cluster_proc_details(None, 1)
     with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
-        await client.get_cluster_proc_details(0)
+        await client.get_cluster_proc_details(0, 1)
     with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
-        await client.get_cluster_proc_details(-1)
+        await client.get_cluster_proc_details(-1, 1)
+    with pytest.raises(ValueError, match="^expected_procs is required$"):
+        await client.get_cluster_proc_details(1, None)
+    with pytest.raises(ValueError, match="^expected_procs must be >= 0$"):
+        await client.get_cluster_proc_details(1, -1)
+    with pytest.raises(
+        ValueError,
+        match=r"^expected_procs contains proc IDs less than 0: \[-3, -1\]$",
+    ):
+        await client.get_cluster_proc_details(1, [0, -1, 2, -3])
 
 
 async def test_get_cluster_proc_details_no_records():
+    """All expected procs absent from condor return as MISSING; no error raised."""
     client, schedd = _make_client()
     schedd.query.return_value = []
     schedd.history.return_value = []
 
-    with pytest.raises(ValueError, match="^No records found for cluster ID 123$"):
-        await client.get_cluster_proc_details(123)
+    details = await client.get_cluster_proc_details(123, 2)
 
+    assert details == {
+        0: ProcDetails(state=ProcState.MISSING),
+        1: ProcDetails(state=ProcState.MISSING),
+    }
     constraint = "ClusterId == 123"
     schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
     schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
@@ -420,7 +433,7 @@ async def test_get_cluster_proc_details_mixed():
         {"ProcId": 4, "JobStatus": 3},   # Removed
     ]
 
-    details = await client.get_cluster_proc_details(123)
+    details = await client.get_cluster_proc_details(123, 5)
 
     assert details == {
         0: ProcDetails(state=ProcState.RUNNING),
@@ -434,11 +447,43 @@ async def test_get_cluster_proc_details_mixed():
     schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
 
 
+async def test_get_cluster_proc_details_partial_missing_with_count():
+    """When an int count is given, procs absent from condor fill in as MISSING."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [{"ProcId": 0, "JobStatus": 2}]   # Running
+    schedd.history.return_value = [{"ProcId": 2, "JobStatus": 4}]  # Completed
+
+    details = await client.get_cluster_proc_details(123, 4)
+
+    assert details == {
+        0: ProcDetails(state=ProcState.RUNNING),
+        1: ProcDetails(state=ProcState.MISSING),
+        2: ProcDetails(state=ProcState.COMPLETE),
+        3: ProcDetails(state=ProcState.MISSING),
+    }
+    constraint = "ClusterId == 123"
+    schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
+
+
+async def test_get_cluster_proc_details_unexpected_proc_id_raises():
+    """When an int count is given, a returned proc ID >= n raises ValueError."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [{"ProcId": 0, "JobStatus": 2}, {"ProcId": 3, "JobStatus": 4}]
+    schedd.history.return_value = []
+
+    with pytest.raises(
+        ValueError,
+        match=r"^HTCondor returned unexpected proc IDs \[3\] for cluster 123; expected_procs=3$",
+    ):
+        await client.get_cluster_proc_details(123, 3)
+
+
 async def test_get_cluster_proc_details_empty_proc_ids():
-    """Empty proc_ids list returns empty dict without querying condor."""
+    """Empty expected_procs collection returns empty dict without querying condor."""
     client, schedd = _make_client()
 
-    details = await client.get_cluster_proc_details(123, proc_ids=[])
+    details = await client.get_cluster_proc_details(123, [])
 
     assert details == {}
     schedd.query.assert_not_called()
@@ -453,7 +498,7 @@ async def test_get_cluster_proc_details_proc_ids_filter():
     ]
     schedd.history.return_value = [{"ProcId": 3, "JobStatus": 4}]
 
-    details = await client.get_cluster_proc_details(123, proc_ids=[1, 3])
+    details = await client.get_cluster_proc_details(123, [1, 3])
 
     assert details == {
         1: ProcDetails(state=ProcState.HELD, hold_reason="oom", hold_reason_code=7),
@@ -471,18 +516,21 @@ async def test_get_cluster_proc_details_unknown_status():
     for status in (0, 8, 99):
         schedd.query.return_value = [{"ProcId": 0, "JobStatus": status}]
         with pytest.raises(ValueError, match=f"^Unknown HTCondor job status: {status}$"):
-            await client.get_cluster_proc_details(123)
+            await client.get_cluster_proc_details(123, 1)
 
 
 async def test_get_cluster_proc_details_proc_ids_not_found():
-    """Requested proc IDs absent from both queues returns empty dict, not an error."""
+    """Expected proc IDs absent from both queues are returned as MISSING, not an error."""
     client, schedd = _make_client()
     schedd.query.return_value = []
     schedd.history.return_value = []
 
-    details = await client.get_cluster_proc_details(123, proc_ids=[0, 1])
+    details = await client.get_cluster_proc_details(123, [0, 1])
 
-    assert details == {}
+    assert details == {
+        0: ProcDetails(state=ProcState.MISSING),
+        1: ProcDetails(state=ProcState.MISSING),
+    }
     constraint = "ClusterId == 123 && (ProcId == 0 || ProcId == 1)"
     schedd.query.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)
     schedd.history.assert_called_once_with(constraint=constraint, projection=_HOLD_PROJ)

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -1977,7 +1977,7 @@ async def test_error_unhealthy_subjobs_condor_fails(caplog):
         await runner.error_unhealthy_subjobs("jid", {0: _T, 1: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0, 1])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0, 1])
     updates.get_parent_job_update.assert_not_called()
     mongo.update_subjob_state.assert_not_called()
     assert (
@@ -1994,29 +1994,29 @@ async def test_error_unhealthy_subjobs_healthy_proc_no_update(proc_state):
     await runner.error_unhealthy_subjobs("jid", {0: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0])
     updates.get_parent_job_update.assert_not_called()
     mongo.update_subjob_state.assert_not_called()
 
 
 async def test_error_unhealthy_subjobs_absent_proc_errors_subjob():
-    """Proc missing from condor response is treated as OTHER state and errored."""
+    """Proc absent from condor is returned as MISSING by the client and errored."""
     runner, mongo, condor, updates, _ = _make_runner()
     job = _htcondor_job()
     mongo.get_job.return_value = job
-    condor.get_cluster_proc_details.return_value = {}
+    condor.get_cluster_proc_details.return_value = {0: ProcDetails(state=ProcState.MISSING)}
     updates.get_parent_job_update.return_value = None
 
     await runner.error_unhealthy_subjobs("jid", {0: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0])
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.ERROR)
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.error(
-            "No active executor heartbeat; HTCondor proc is in state other"
-            "; HTCondor hold reason: HTCondor proc absent from cluster 123 response",
+            "No active executor heartbeat; HTCondor has no record of this proc "
+            "(absent from both active queue and history — likely purged)",
             traceback=None,
         ),
         _T,
@@ -2035,7 +2035,7 @@ async def test_error_unhealthy_subjobs_unhealthy_proc_errors_subjob(proc_state):
     await runner.error_unhealthy_subjobs("jid", {3: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[3])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [3])
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.ERROR)
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 3,
@@ -2075,7 +2075,7 @@ async def test_error_unhealthy_subjobs_held_proc_includes_hold_details(
     await runner.error_unhealthy_subjobs("jid", {0: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0])
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.ERROR)
     expected_admin_error = (
         f"No active executor heartbeat; HTCondor proc is in state held{expected_suffix}"
@@ -2103,7 +2103,7 @@ async def test_error_unhealthy_subjobs_update_conflict_recovery_won(caplog):
         await runner.error_unhealthy_subjobs("jid", {0: stale_t})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0])
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.error(
@@ -2138,7 +2138,7 @@ async def test_error_unhealthy_subjobs_per_subjob_exception_isolation(caplog):
         await runner.error_unhealthy_subjobs("jid", {0: _T, 1: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0, 1])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0, 1])
     # Subjob 0 throws before get_parent_job_update; subjob 1 succeeds so it's called once.
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.ERROR)
     _admin_error = "No active executor heartbeat; HTCondor proc is in state held"
@@ -2173,7 +2173,7 @@ async def test_error_unhealthy_subjobs_active_job_triggers_terminal_parent():
         await runner.error_unhealthy_subjobs("jid", {0: _T})
 
     mongo.get_job.assert_called_once_with("jid", as_admin=True)
-    condor.get_cluster_proc_details.assert_called_once_with(123, proc_ids=[0])
+    condor.get_cluster_proc_details.assert_called_once_with(123, [0])
     mongo.update_subjob_state.assert_called_once_with(
         "jid", 0,
         update_state.error(


### PR DESCRIPTION
  Add ProcState.MISSING to the condor client enum. Rewrite
  get_cluster_proc_details to accept expected_procs: int |
Collection[int]
  instead of an optional proc_ids collection. When an int n is given the
  expected set is range(n) and the query is unrestricted; when a
collection
  is given it doubles as the query filter. Any expected proc absent from
  both the active queue and history is returned as
  ProcDetails(state=ProcState.MISSING) rather than being omitted or
raising
  ValueError. Proc IDs returned by condor that exceed the expected range
  raise ValueError. Negative expected proc IDs are rejected.

  Update _check_condor_and_error_subjobs in kbase.py to pass subjob_ids
  positionally and remove the manual None-check that synthesised
  ProcDetails(state=ProcState.OTHER) for absent procs — the client now
  handles this. Give the MISSING state a distinct admin error message
that
  explains condor has no record of the proc and why.