### PR TITLE
Add _state field to get_container_classad response

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -41,6 +41,7 @@ _AD_COMMITTED_TIME = "CommittedTime"
 _AD_JOB_STATUS = "JobStatus"
 _AD_HOLD_REASON = "HoldReason"
 _AD_HOLD_REASON_CODE = "HoldReasonCode"
+_AD_STATE = "_state"
 _JOB_STATUS_HELD = 5
 
 
@@ -382,11 +383,9 @@ class CondorClient:
                 projection=_RETURNED_JOB_ADS,
             )
         if not job_ads:
-            raise ValueError(
-                f"No record found for cluster ID {cluster_id} and container number "
-                + f"{container_number}"
-            )
-        return self._classad_to_dict(job_ads[0])
+            return {_AD_STATE: ProcState.MISSING}
+        classad = self._classad_to_dict(job_ads[0])
+        return {_AD_STATE: _status_to_proc_state(classad[_AD_JOB_STATUS])} | classad
         
     async def get_cluster_classads(self, cluster_id: int
     ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -74,15 +74,14 @@ async def test_get_container_classad_bad_args():
 
 
 async def test_get_container_classad_no_records():
+    """Absent proc returns _state=MISSING only; no error raised."""
     client, schedd = _make_client()
     schedd.query.return_value = []
     schedd.history.return_value = []
 
-    with pytest.raises(
-        ValueError, match="^No record found for cluster ID 123 and container number 0$"
-    ):
-        await client.get_container_classad(123, 0)
+    result = await client.get_container_classad(123, 0)
 
+    assert result == {"_state": ProcState.MISSING}
     constraint = "ClusterId == 123 && CTSContainerNumber == 0"
     schedd.query.assert_called_once_with(constraint=constraint, projection=_RETURNED_JOB_ADS)
     schedd.history.assert_called_once_with(constraint=constraint, projection=_RETURNED_JOB_ADS)
@@ -104,6 +103,7 @@ async def test_get_container_classad_in_active():
     result = await client.get_container_classad(123, 1)
 
     assert result == {
+        "_state": ProcState.RUNNING,
         "ClusterId": 123,
         "ProcId": 1,
         "JobStatus": 2,
@@ -135,6 +135,7 @@ async def test_get_container_classad_in_history():
     result = await client.get_container_classad(123, 0)
 
     assert result == {
+        "_state": ProcState.COMPLETE,
         "ClusterId": 123,
         "ProcId": 0,
         "JobStatus": 4,


### PR DESCRIPTION
  Replace the ValueError on missing records with a {"_state":
ProcState.MISSING}
  return. When a record is found, prepend "_state" to the classad dict
with
  the parsed ProcState derived from JobStatus, so callers always receive
an
  explicit proc state alongside the raw classad data.