### PR TITLE
Add subjob_ids filter to MongoDAO.get_subjobs

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -9,7 +9,7 @@ from motor.motor_asyncio import AsyncIOMotorDatabase, AsyncIOMotorCollection
 from pymongo import IndexModel, ASCENDING, DESCENDING, ReturnDocument
 from pymongo.errors import DuplicateKeyError
 from pymongo.results import DeleteResult
-from typing import Any, Awaitable, Callable, Coroutine, Iterable
+from typing import Any, Awaitable, Callable, Collection, Coroutine, Iterable
 
 from cdmtaskservice import models
 from cdmtaskservice import sites
@@ -944,17 +944,26 @@ class MongoDAO:
         doc = self._clean_doc(doc)
         return models.SubJob(**doc)
 
-    async def get_subjobs(self, job_id: str) -> list[models.SubJob]:
+    async def get_subjobs(
+        self, job_id: str, subjob_ids: Collection[int] | None = None
+    ) -> list[models.SubJob]:
         """
-        Get all subjobs for a job given the job ID.
+        Get subjobs for a job given the job ID.
+
+        subjob_ids - if provided, only return subjobs whose id is in this collection.
         """
-        docs = await self._col_subjobs.find(
-            {models.FLD_COMMON_ID: _require_string(job_id, "job_id")}
-        ).sort(models.FLD_SUBJOB_ID, 1
+        job_id = _require_string(job_id, "job_id")
+        if subjob_ids is not None and not subjob_ids:
+            raise ValueError("subjob_ids cannot be empty")
+        query = {models.FLD_COMMON_ID: job_id}
+        if subjob_ids is not None:
+            query[models.FLD_SUBJOB_ID] = {"$in": list(subjob_ids)}
+        docs = await self._col_subjobs.find(query).sort(models.FLD_SUBJOB_ID, 1
         ).to_list(length=None)  # Currently the API enforces a limit of 1000
         sjs = [models.SubJob(**self._clean_doc(d)) for d in docs]
         if not sjs:
-            raise NoSuchSubJobError(f"No sub jobs found for job ID '{job_id}'")
+            ids = f" with sub job IDs {sorted(subjob_ids)}" if subjob_ids is not None else ""
+            raise NoSuchSubJobError(f"No sub jobs found for job ID '{job_id}'{ids}")
         return sjs
 
     async def get_exit_codes_for_subjobs(self, job_id: str) -> list[int | None]:

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -850,6 +850,15 @@ async def test_subjob_basic_roundtrip(mondb):
     assert sjs_got == sjs 
 
 
+async def test_get_subjobs(mondb):
+    mc = await MongoDAO.create(mondb)
+    await mc.initialize_subjobs([_BASESUBJOB1, _BASESUBJOB2, _BASESUBJOB3])
+
+    assert await mc.get_subjobs("bar") == [_BASESUBJOB1, _BASESUBJOB2, _BASESUBJOB3]
+    assert await mc.get_subjobs("bar", subjob_ids=[1]) == [_BASESUBJOB2]
+    assert await mc.get_subjobs("bar", subjob_ids=[0, 2]) == [_BASESUBJOB1, _BASESUBJOB3]
+
+
 async def test_initialize_subjobs_fail_bad_args(mondb):
     mc = await MongoDAO.create(mondb)
     
@@ -906,15 +915,21 @@ async def get_subjob_fail(mc, job_id, subjob_id, expected):
 async def test_get_subjobs_fail(mondb):
     mc = await MongoDAO.create(mondb)
     await mc.initialize_subjobs([_BASESUBJOB2])
-    
+
     await get_subjobs_fail(mc, None, ValueError("job_id is required"))
     await get_subjobs_fail(mc, "   \t   ", ValueError("job_id is required"))
     await get_subjobs_fail(mc, "foo", NoSuchSubJobError("No sub jobs found for job ID 'foo'"))
+    await get_subjobs_fail(
+        mc, "bar",
+        NoSuchSubJobError("No sub jobs found for job ID 'bar' with sub job IDs [5]"),
+        subjob_ids=[5],
+    )
+    await get_subjobs_fail(mc, "bar", ValueError("subjob_ids cannot be empty"), subjob_ids=[])
 
 
-async def get_subjobs_fail(mc, job_id, expected):
-    with pytest.raises(type(expected), match=f"^{expected.args[0]}$"):
-        await mc.get_subjobs(job_id)
+async def get_subjobs_fail(mc, job_id, expected, subjob_ids=None):
+    with pytest.raises(type(expected), match=f"^{re.escape(expected.args[0])}$"):
+        await mc.get_subjobs(job_id, subjob_ids=subjob_ids)
 
 
 async def test_get_exit_codes_for_subjobs(mondb):


### PR DESCRIPTION
  Allows callers to fetch only a specific subset of subjobs by sub_id
  rather than always retrieving all subjobs for a job.