### PR TITLE
Harden job recovery against HTCondor history purging

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -433,44 +433,69 @@ class CondorClient:
         self,
         cluster_id: int,
         projection: list[str],
-        proc_ids: Collection[int] | None,
+        expected_procs: int | Collection[int],
         transform: Callable[[Any], _V],
+        missing: _V | None = None,
     ) -> dict[int, _V]:
         _check_num(cluster_id, "cluster_id")
-        if proc_ids is not None and not proc_ids:
+        if expected_procs is None:
+            raise ValueError("expected_procs is required")
+        if isinstance(expected_procs, int):
+            if expected_procs < 0:
+                raise ValueError("expected_procs must be >= 0")
+            filter_ids: Collection[int] | None = None
+            expected_ids: Collection[int] = range(expected_procs)
+        else:
+            invalid = sorted(pid for pid in expected_procs if pid < 0)
+            if invalid:
+                raise ValueError(f"expected_procs contains proc IDs less than 0: {invalid}")
+            filter_ids = expected_procs
+            expected_ids = expected_procs
+        if filter_ids is not None and not filter_ids:
             return {}
-        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, projection, proc_ids)
+        active_ads, complete_ads = await self._fetch_cluster_ads(cluster_id, projection, filter_ids)
         result: dict[int, _V] = {}
         for ad in active_ads:
             result[ad[_AD_PROC_ID]] = transform(ad)
         for ad in complete_ads:
             # override active entry if a proc raced from query to history between calls
             result[ad[_AD_PROC_ID]] = transform(ad)
+        if filter_ids is None:  # unrestricted query — check for unexpected proc IDs
+            expected_set = set(expected_ids)
+            unexpected = sorted(pid for pid in result if pid not in expected_set)
+            if unexpected:
+                raise ValueError(
+                    f"HTCondor returned unexpected proc IDs {unexpected} "
+                    f"for cluster {cluster_id}"
+                )
+        for proc_id in expected_ids:
+            if proc_id not in result:
+                result[proc_id] = missing
         return result
 
     async def get_cluster_proc_states(
         self,
         cluster_id: int,
-        proc_ids: Collection[int] | None = None,
+        expected_procs: int | Collection[int],
     ) -> dict[int, ProcState]:
         """
         Get the state of each process in an HTC cluster using minimal data transfer.
 
-        Returns a dict mapping proc ID (== container number) to ProcState.
-        Raises ValueError if no records are found for cluster_id and proc_ids is None.
+        Returns a dict mapping proc ID (== container number) to ProcState, with a full
+        entry for every expected proc. Procs absent from both the active queue and history
+        are returned with ProcState.MISSING.
 
         cluster_id - the HTCondor cluster ID.
-        proc_ids - if provided, the HTCondor constraint is restricted to these proc IDs and
-            an empty result is returned (rather than an error) if none are found.
-            An empty list returns an empty dict without querying HTCondor.
+        expected_procs - the expected set of proc IDs. If an int n, the expected set is
+            range(n) and the HTCondor query is unrestricted to proc IDs. If a collection,
+            it is used directly as both the expected set and the query filter. An empty
+            collection returns an empty dict without querying HTCondor.
         """
-        result = await self._fetch_proc_map(
-            cluster_id, _STATUS_ONLY, proc_ids,
+        return await self._fetch_proc_map(
+            cluster_id, _STATUS_ONLY, expected_procs,
             lambda ad: _status_to_proc_state(ad[_AD_JOB_STATUS]),
+            missing=ProcState.MISSING,
         )
-        if proc_ids is None and not result:
-            raise ValueError(f"No records found for cluster ID {cluster_id}")
-        return result
 
     async def get_cluster_proc_details(
         self,
@@ -490,38 +515,15 @@ class CondorClient:
             it is used directly as both the expected set and the query filter. An empty
             collection returns an empty dict without querying HTCondor.
         """
-        if expected_procs is None:
-            raise ValueError("expected_procs is required")
-        if isinstance(expected_procs, int):
-            if expected_procs < 0:
-                raise ValueError("expected_procs must be >= 0")
-            filter_ids: Collection[int] | None = None
-            expected_ids: Collection[int] = range(expected_procs)
-        else:
-            invalid = sorted(pid for pid in expected_procs if pid < 0)
-            if invalid:
-                raise ValueError(f"expected_procs contains proc IDs less than 0: {invalid}")
-            filter_ids = expected_procs
-            expected_ids = expected_procs
-        result = await self._fetch_proc_map(
-            cluster_id, _STATUS_AND_HOLD, filter_ids,
+        return await self._fetch_proc_map(
+            cluster_id, _STATUS_AND_HOLD, expected_procs,
             lambda ad: ProcDetails(
                 state=_status_to_proc_state(ad[_AD_JOB_STATUS]),
                 hold_reason=ad.get(_AD_HOLD_REASON),
                 hold_reason_code=ad.get(_AD_HOLD_REASON_CODE),
             ),
+            missing=ProcDetails(state=ProcState.MISSING),
         )
-        if isinstance(expected_procs, int):
-            unexpected = sorted(pid for pid in result if pid not in expected_ids)
-            if unexpected:
-                raise ValueError(
-                    f"HTCondor returned unexpected proc IDs {unexpected} for cluster "
-                    f"{cluster_id}; expected_procs={expected_procs}"
-                )
-        for proc_id in expected_ids:
-            if proc_id not in result:
-                result[proc_id] = ProcDetails(state=ProcState.MISSING)
-        return result
 
     async def release_job(self, cluster_id: int):
         """

--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -54,7 +54,8 @@ _PROC_STATE_TO_EXTERNAL = {
     ProcState.HELD:      models.ExternalRunnerState.ERROR,
     ProcState.COMPLETE:  models.ExternalRunnerState.COMPLETE,
     ProcState.CANCELED:  models.ExternalRunnerState.CANCELED,
-    ProcState.OTHER:     models.ExternalRunnerState.UNKNOWN,
+    ProcState.OTHER:     models.ExternalRunnerState.UNRECOGNIZED,
+    ProcState.MISSING:   models.ExternalRunnerState.MISSING,
 }
 
 _RETRY_DELAY_SEC = 5 * 60  # configurable?
@@ -261,8 +262,8 @@ class KBaseRunner(JobFlow):
                 states=[models.ExternalRunnerState.NONE] * n,
             )
         cluster_id = job.htcondor_details.cluster_id[-1]
-        proc_states = await self._condor.get_cluster_proc_states(cluster_id)
         n = job.job_input.num_containers
+        proc_states = await self._condor.get_cluster_proc_states(cluster_id, n)
         return models.ExternalRunnerStatus(
             manages_containers=False,
             states=[_PROC_STATE_TO_EXTERNAL[proc_states[i]] for i in range(n)],
@@ -796,8 +797,21 @@ class KBaseRunner(JobFlow):
                 "moment. If submission failed, create a new job rather than recovering."
             )
         proc_states = await self._condor.get_cluster_proc_states(
-            job.htcondor_details.cluster_id[-1]
+            job.htcondor_details.cluster_id[-1], job.job_input.num_containers
         )
+        missing = [i for i, s in proc_states.items() if s == ProcState.MISSING]
+        if missing:
+            subjobs = await self._mongo.get_subjobs(job.id, subjob_ids=missing)
+            subjob_map = {sj.sub_id: sj for sj in subjobs}
+            not_complete = [
+                i for i in missing if subjob_map[i].state != models.JobState.COMPLETE
+            ]
+            if not_complete:
+                raise InvalidJobStateError(
+                    f"External processor has no record of proc(s) {not_complete} for cluster "
+                    f"{job.htcondor_details.cluster_id[-1]} and the corresponding subjobs are "
+                    "not complete — job cannot be recovered."
+                )
         if {ProcState.OTHER, ProcState.CANCELED} & set(proc_states.values()):
             raise InvalidJobStateError(
                 "External processor contains processes in an unexpected state. Unable to recover "

--- a/cdmtaskservice/jobflows/nersc_jaws.py
+++ b/cdmtaskservice/jobflows/nersc_jaws.py
@@ -58,7 +58,7 @@ _JAWS_STATUS_TO_EXTERNAL = {
     jaws_client.JAWSStatus.QUEUED:   models.ExternalRunnerState.QUEUED,
     jaws_client.JAWSStatus.RUNNING:  models.ExternalRunnerState.RUNNING,
     jaws_client.JAWSStatus.COMPLETE: models.ExternalRunnerState.COMPLETE,
-    jaws_client.JAWSStatus.UNKNOWN:  models.ExternalRunnerState.UNKNOWN,
+    jaws_client.JAWSStatus.UNKNOWN:  models.ExternalRunnerState.UNRECOGNIZED,
 }
 
 _JAWS_RESULT_TO_EXTERNAL = {

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -898,8 +898,10 @@ class ExternalRunnerState(str, Enum):
     """ The job completed with an error. """
     CANCELED = "canceled"
     """ The job was canceled. """
-    UNKNOWN = "unknown"
+    UNRECOGNIZED = "unrecognized"
     """ The external runner reported a state this service does not recognize. """
+    MISSING = "missing"
+    """ No record exists for this proc in the external runner (e.g. purged from HTCondor history). """
 
 
 class ExternalRunnerStatus(BaseModel):

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -49,6 +49,7 @@ def test_proc_state_is_healthy():
     assert ProcState.HELD.is_healthy() is False
     assert ProcState.CANCELED.is_healthy() is False
     assert ProcState.OTHER.is_healthy() is False
+    assert ProcState.MISSING.is_healthy() is False
 
 
 def test_condor_client_bad_heartbeat_interval():
@@ -258,21 +259,31 @@ async def test_get_cluster_classads_race_dedup():
 async def test_get_cluster_proc_states_bad_args():
     client, _ = _make_client()
     with pytest.raises(ValueError, match="^cluster_id is required$"):
-        await client.get_cluster_proc_states(None)
+        await client.get_cluster_proc_states(None, 1)
     with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
-        await client.get_cluster_proc_states(0)
+        await client.get_cluster_proc_states(0, 1)
     with pytest.raises(ValueError, match="^cluster_id must be >= 1$"):
-        await client.get_cluster_proc_states(-1)
+        await client.get_cluster_proc_states(-1, 1)
+    with pytest.raises(ValueError, match="^expected_procs is required$"):
+        await client.get_cluster_proc_states(1, None)
+    with pytest.raises(ValueError, match="^expected_procs must be >= 0$"):
+        await client.get_cluster_proc_states(1, -1)
+    with pytest.raises(
+        ValueError,
+        match=r"^expected_procs contains proc IDs less than 0: \[-3, -1\]$",
+    ):
+        await client.get_cluster_proc_states(1, [0, -1, 2, -3])
 
 
 async def test_get_cluster_proc_states_no_records():
+    """All expected procs absent from condor return as MISSING; no error raised."""
     client, schedd = _make_client()
     schedd.query.return_value = []
     schedd.history.return_value = []
 
-    with pytest.raises(ValueError, match="^No records found for cluster ID 123$"):
-        await client.get_cluster_proc_states(123)
+    states = await client.get_cluster_proc_states(123, 2)
 
+    assert states == {0: ProcState.MISSING, 1: ProcState.MISSING}
     schedd.query.assert_called_once_with(
         constraint="ClusterId == 123", projection=["ProcId", "JobStatus"]
     )
@@ -287,7 +298,7 @@ async def test_get_cluster_proc_states_all_complete():
     schedd.query.return_value = []
     schedd.history.return_value = [{"ProcId": 0, "JobStatus": 4}, {"ProcId": 1, "JobStatus": 4}]
 
-    states = await client.get_cluster_proc_states(123)
+    states = await client.get_cluster_proc_states(123, 2)
 
     assert states == {0: ProcState.COMPLETE, 1: ProcState.COMPLETE}
     schedd.query.assert_called_once_with(
@@ -314,7 +325,7 @@ async def test_get_cluster_proc_states_mixed():
         {"ProcId": 5, "JobStatus": 3},  # Removed → CANCELED
     ]
 
-    states = await client.get_cluster_proc_states(123)
+    states = await client.get_cluster_proc_states(123, 7)
 
     assert states == {
         0: ProcState.RUNNING,   # Running
@@ -333,6 +344,39 @@ async def test_get_cluster_proc_states_mixed():
     )
 
 
+async def test_get_cluster_proc_states_partial_missing_with_count():
+    """When an int count is given, procs absent from condor fill in as MISSING."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [{"ProcId": 0, "JobStatus": 2}]   # Running
+    schedd.history.return_value = [{"ProcId": 2, "JobStatus": 4}]  # Completed
+
+    states = await client.get_cluster_proc_states(123, 4)
+
+    assert states == {
+        0: ProcState.RUNNING,
+        1: ProcState.MISSING,
+        2: ProcState.COMPLETE,
+        3: ProcState.MISSING,
+    }
+    constraint = "ClusterId == 123"
+    proj = ["ProcId", "JobStatus"]
+    schedd.query.assert_called_once_with(constraint=constraint, projection=proj)
+    schedd.history.assert_called_once_with(constraint=constraint, projection=proj)
+
+
+async def test_get_cluster_proc_states_unexpected_proc_id_raises():
+    """When an int count is given, a returned proc ID >= n raises ValueError."""
+    client, schedd = _make_client()
+    schedd.query.return_value = [{"ProcId": 0, "JobStatus": 2}, {"ProcId": 3, "JobStatus": 4}]
+    schedd.history.return_value = []
+
+    with pytest.raises(
+        ValueError,
+        match=r"^HTCondor returned unexpected proc IDs \[3\] for cluster 123$",
+    ):
+        await client.get_cluster_proc_states(123, 3)
+
+
 async def test_get_cluster_proc_states_unknown_status():
     """An unrecognised JobStatus value (outside 1-7) raises ValueError."""
     client, schedd = _make_client()
@@ -340,14 +384,14 @@ async def test_get_cluster_proc_states_unknown_status():
     for status in (0, 8, 99):
         schedd.query.return_value = [{"ProcId": 0, "JobStatus": status}]
         with pytest.raises(ValueError, match=f"^Unknown HTCondor job status: {status}$"):
-            await client.get_cluster_proc_states(123)
+            await client.get_cluster_proc_states(123, 1)
 
 
 async def test_get_cluster_proc_states_empty_proc_ids():
-    """Empty proc_ids list returns empty dict without querying condor."""
+    """Empty expected_procs collection returns empty dict without querying condor."""
     client, schedd = _make_client()
 
-    states = await client.get_cluster_proc_states(123, proc_ids=[])
+    states = await client.get_cluster_proc_states(123, [])
 
     assert states == {}
     schedd.query.assert_not_called()
@@ -355,12 +399,12 @@ async def test_get_cluster_proc_states_empty_proc_ids():
 
 
 async def test_get_cluster_proc_states_proc_ids_filter():
-    """The proc_ids list is pushed into the HTCondor constraint, not filtered in Python."""
+    """The proc_ids collection is pushed into the HTCondor constraint, not filtered in Python."""
     client, schedd = _make_client()
     schedd.query.return_value = [{"ProcId": 1, "JobStatus": 5}]   # Held
     schedd.history.return_value = [{"ProcId": 3, "JobStatus": 4}]  # Complete
 
-    states = await client.get_cluster_proc_states(123, proc_ids=[1, 3])
+    states = await client.get_cluster_proc_states(123, [1, 3])
 
     assert states == {1: ProcState.HELD, 3: ProcState.COMPLETE}
     constraint = "ClusterId == 123 && (ProcId == 1 || ProcId == 3)"
@@ -370,14 +414,14 @@ async def test_get_cluster_proc_states_proc_ids_filter():
 
 
 async def test_get_cluster_proc_states_proc_ids_not_found():
-    """Requested proc IDs absent from both queues returns empty dict, not an error."""
+    """Expected proc IDs absent from both queues are returned as MISSING, not an error."""
     client, schedd = _make_client()
     schedd.query.return_value = []
     schedd.history.return_value = []
 
-    states = await client.get_cluster_proc_states(123, proc_ids=[0, 1])
+    states = await client.get_cluster_proc_states(123, [0, 1])
 
-    assert states == {}
+    assert states == {0: ProcState.MISSING, 1: ProcState.MISSING}
     constraint = "ClusterId == 123 && (ProcId == 0 || ProcId == 1)"
     proj = ["ProcId", "JobStatus"]
     schedd.query.assert_called_once_with(constraint=constraint, projection=proj)
@@ -475,7 +519,7 @@ async def test_get_cluster_proc_details_unexpected_proc_id_raises():
 
     with pytest.raises(
         ValueError,
-        match=r"^HTCondor returned unexpected proc IDs \[3\] for cluster 123; expected_procs=3$",
+        match=r"^HTCondor returned unexpected proc IDs \[3\] for cluster 123$",
     ):
         await client.get_cluster_proc_details(123, 3)
 

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -76,13 +76,13 @@ def _job(num_containers=2):
 _UNSET = object()
 
 
-def _recovery_job(state=models.JobState.ERROR, cluster_ids=_UNSET):
+def _recovery_job(state=models.JobState.ERROR, cluster_ids=_UNSET, num_containers=2):
     if cluster_ids is _UNSET:
         cluster_ids = [123]
     return models.AdminJobDetails.model_construct(
         id="jid",
         state=state,
-        job_input=models.JobInput.model_construct(num_containers=2, cpus=1),
+        job_input=models.JobInput.model_construct(num_containers=num_containers, cpus=1),
         htcondor_details=None if cluster_ids is None
             else models.HTCondorDetails(cluster_id=cluster_ids),
     )
@@ -163,7 +163,7 @@ async def test_get_job_external_runner_status_submitted():
     runner, _, condor, _, _ = _make_runner()
     job = models.AdminJobDetails.model_construct(
         id="jid",
-        job_input=models.JobInput.model_construct(num_containers=6, cluster=sites.Cluster.KBASE),
+        job_input=models.JobInput.model_construct(num_containers=7, cluster=sites.Cluster.KBASE),
         htcondor_details=models.HTCondorDetails(cluster_id=[123]),
     )
     condor.get_cluster_proc_states.return_value = {
@@ -173,6 +173,7 @@ async def test_get_job_external_runner_status_submitted():
         3: ProcState.COMPLETE,
         4: ProcState.CANCELED,
         5: ProcState.OTHER,
+        6: ProcState.MISSING,
     }
     result = await runner.get_job_external_runner_status(job)
     assert result == models.ExternalRunnerStatus(
@@ -183,10 +184,11 @@ async def test_get_job_external_runner_status_submitted():
             models.ExternalRunnerState.ERROR,
             models.ExternalRunnerState.COMPLETE,
             models.ExternalRunnerState.CANCELED,
-            models.ExternalRunnerState.UNKNOWN,
+            models.ExternalRunnerState.UNRECOGNIZED,
+            models.ExternalRunnerState.MISSING,
         ],
     )
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 7)
 
 
 ######
@@ -997,7 +999,7 @@ async def test_recover_job_unexpected_proc_state(force, bad_state):
     ):
         await runner.recover_job(job, force=force)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_not_called()
 
 
@@ -1010,7 +1012,7 @@ async def test_recover_job_condor_raises(force):
     with pytest.raises(IOError, match="condor unavailable"):
         await runner.recover_job(job, force=force)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_not_called()
 
 
@@ -1167,7 +1169,7 @@ async def test_recover_job_error_state_advance_to_complete():
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
     # Called twice: once for UPLOAD_SUBMITTING stats, once in _complete_job for outputs
@@ -1218,7 +1220,7 @@ async def test_recover_job_error_state_advance_fails():
     with pytest.raises(IOError, match="mongo blew up"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_not_called()
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
     mongo.get_subjobs.assert_not_called()
@@ -1247,7 +1249,7 @@ async def test_recover_job_error_state_lock_fails():
     with pytest.raises(InvalidJobStateError, match="concurrent recovery won"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_not_called()
     mongo.recover_job.assert_not_called()
     mongo.get_subjobs.assert_not_called()
@@ -1302,7 +1304,7 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_called_once_with(123)
     # get_subjobs called once per UPLOAD_SUBMITTING (stats) plus once in _complete_job (outputs)
     mongo.get_subjobs.assert_called_with("jid")
@@ -1344,7 +1346,7 @@ async def test_recover_job_complete_job_no_outputs():
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_subjobs.assert_called_once_with("jid")
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.COMPLETE)
@@ -1375,7 +1377,7 @@ async def test_recover_job_complete_job_checksum_mismatch():
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.get_subjobs.assert_called_once_with("jid")
     s3.get_object_meta.assert_called_once_with(S3Paths(["bucket/f.txt"]))
@@ -1407,7 +1409,7 @@ async def test_recover_job_complete_job_condor_stats_timeout():
         ):
             await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.COMPLETE)
     assert condor.get_cluster_classads.call_count == 12
     condor.get_cluster_classads.assert_called_with(123)
@@ -1422,7 +1424,7 @@ async def test_recover_job_standard_advance_invalid_state():
     with pytest.raises(RuntimeError, match="Unexpected job state"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_not_called()
 
 
@@ -1438,7 +1440,7 @@ async def test_recover_job_standard_advance_update_raises():
     with pytest.raises(InvalidJobStateError, match="job was canceled"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.JOB_SUBMITTING)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.submitting_job(), update_time=_T
@@ -1458,7 +1460,7 @@ async def test_recover_job_standard_advance_parent_update_none():
     with pytest.raises(RuntimeError, match="Not all subjobs have reached state"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.get_parent_job_update.assert_called_once_with(job, models.JobState.JOB_SUBMITTING)
     updates.update_job_state.assert_not_called()
 
@@ -1475,7 +1477,60 @@ async def test_recover_job_standard_running_only():
     ):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
+    updates.update_job_state.assert_not_called()
+
+
+async def test_recover_job_missing_procs_all_complete():
+    """
+    MISSING procs whose mongo subjobs are COMPLETE are excluded from recovery — normal
+    held-container recovery proceeds for the non-missing procs.
+    """
+    lock_time = _T
+    reset_time = _T + datetime.timedelta(seconds=1)
+    ts = iter([lock_time, reset_time])
+    runner, mongo, condor, updates, _ = _make_runner(_timestamp_fn=lambda: next(ts))
+    job = _recovery_job(state=models.JobState.JOB_SUBMITTING, num_containers=3)
+    condor.get_cluster_proc_states.return_value = {
+        0: ProcState.HELD, 1: ProcState.MISSING, 2: ProcState.COMPLETE
+    }
+    mongo.get_subjobs.return_value = [
+        models.SubJob.model_construct(sub_id=1, state=models.JobState.COMPLETE)
+    ]
+
+    await runner.recover_job(job)
+
+    condor.get_cluster_proc_states.assert_called_once_with(123, 3)
+    mongo.get_subjobs.assert_called_once_with("jid", subjob_ids=[1])
+    updates.update_job_state.assert_called_once_with(
+        "jid", update_state.recovering(),
+        update_time=lock_time, recovery_cooldown=datetime.timedelta(0),
+    )
+    mongo.recover_subjobs.assert_called_once_with("jid", [0], lock_time, reset_time)
+    condor.release_job.assert_called_once_with(123)
+    mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
+
+
+async def test_recover_job_missing_procs_not_complete():
+    """
+    MISSING procs with non-COMPLETE mongo subjobs raise InvalidJobStateError; job stays
+    in its current state (no state update).
+    """
+    runner, mongo, condor, updates, _ = _make_runner()
+    job = _recovery_job(state=models.JobState.JOB_SUBMITTING)
+    condor.get_cluster_proc_states.return_value = {0: ProcState.COMPLETE, 1: ProcState.MISSING}
+    mongo.get_subjobs.return_value = [
+        models.SubJob.model_construct(sub_id=1, state=models.JobState.JOB_SUBMITTED)
+    ]
+
+    with pytest.raises(
+        InvalidJobStateError,
+        match=r"External processor has no record of proc\(s\) \[1\] for cluster 123",
+    ):
+        await runner.recover_job(job)
+
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
+    mongo.get_subjobs.assert_called_once_with("jid", subjob_ids=[1])
     updates.update_job_state.assert_not_called()
 
 
@@ -1496,7 +1551,7 @@ async def test_recover_job_standard_held_containers():
 
     await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.recovering(),
         update_time=lock_time, recovery_cooldown=datetime.timedelta(0),
@@ -1525,7 +1580,7 @@ async def test_recover_job_standard_held_release_fails():
     ):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.recovering(),
         update_time=lock_time, recovery_cooldown=datetime.timedelta(0),
@@ -1548,7 +1603,7 @@ async def test_recover_job_standard_held_lock_fails():
     with pytest.raises(InvalidJobStateError, match="concurrent recovery won"):
         await runner.recover_job(job)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.recovering(),
         update_time=_T, recovery_cooldown=datetime.timedelta(0),
@@ -1570,7 +1625,7 @@ async def test_recover_job_force_running_containers(running_state):
     ):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_not_called()
 
 
@@ -1603,7 +1658,7 @@ async def test_recover_job_force_all_complete():
     with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_called_once_with(123)
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
     # Called twice: once for UPLOAD_SUBMITTING stats, once in _complete_job for outputs
@@ -1654,7 +1709,7 @@ async def test_recover_job_force_all_complete_advance_fails():
     with pytest.raises(IOError, match="mongo blew up"):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_not_called()
     mongo.recover_job.assert_called_once_with("jid", reset_time, _TRANS_ID)
     mongo.get_subjobs.assert_not_called()
@@ -1685,7 +1740,7 @@ async def test_recover_job_force_all_complete_lock_fails():
     with pytest.raises(InvalidJobStateError, match="expected 'recovering'"):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     condor.get_cluster_classads.assert_not_called()
     mongo.recover_job.assert_not_called()
     mongo.get_subjobs.assert_not_called()
@@ -1714,7 +1769,7 @@ async def test_recover_job_force_held_containers():
 
     await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.force_recovering(),
         update_time=lock_time, recovery_cooldown=datetime.timedelta(minutes=10),
@@ -1743,7 +1798,7 @@ async def test_recover_job_force_held_release_fails():
     ):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.force_recovering(),
         update_time=lock_time, recovery_cooldown=datetime.timedelta(minutes=10),
@@ -1766,7 +1821,7 @@ async def test_recover_job_force_held_lock_fails():
     with pytest.raises(JobRecoveryError, match="cooldown not expired"):
         await runner.recover_job(job, force=True)
 
-    condor.get_cluster_proc_states.assert_called_once_with(123)
+    condor.get_cluster_proc_states.assert_called_once_with(123, 2)
     updates.update_job_state.assert_called_once_with(
         "jid", update_state.force_recovering(),
         update_time=_T, recovery_cooldown=datetime.timedelta(minutes=10),


### PR DESCRIPTION
  Refactor get_cluster_proc_states to require an expected_procs argument
  (int or collection) and return ProcState.MISSING for procs absent from
  both the active queue and history, rather than raising ValueError.
Inline
  the expected-proc resolution and MISSING fill-in into _fetch_proc_map
so
  get_cluster_proc_details shares the same logic with no duplication.

  Add ExternalRunnerState.MISSING (rename UNKNOWN → UNRECOGNIZED) so
  missing procs are surfaced correctly through the external status API.

  In recovery, detect MISSING procs and cross-check their mongo subjobs:
  if all are COMPLETE the recovery proceeds for the remaining procs; if
  any are not COMPLETE, raise InvalidJobStateError so the job stays in
  RECOVERING for admin triage.