### PR TITLE
Add get_cluster_proc_stats to the condor client

### DIFF
--- a/cdmtaskservice/condor/client.py
+++ b/cdmtaskservice/condor/client.py
@@ -79,6 +79,9 @@ def _status_to_proc_state(status: int) -> ProcState:
 
 _STATUS_ONLY = [_AD_PROC_ID, _AD_JOB_STATUS]
 _STATUS_AND_HOLD = [_AD_PROC_ID, _AD_JOB_STATUS, _AD_HOLD_REASON, _AD_HOLD_REASON_CODE]
+_STATUS_AND_STATS = [
+    _AD_PROC_ID, _AD_JOB_STATUS, _AD_MEM, _AD_CPU_USER, _AD_CPU_SYS, _AD_COMMITTED_TIME,
+]
 
 _LOCATIONS = ["Iwd", "Err", "Out", "UserLog"]
 _IDS = [_AD_CLUSTER_ID, _AD_PROC_ID, _AD_JOB_ID, _AD_CONTAINER_NUMBER]
@@ -173,6 +176,31 @@ class ProcDetails:
     state: ProcState
     hold_reason: str | None = None
     hold_reason_code: int | None = None
+
+
+@dataclass
+class ProcStats:
+    """State and resource usage stats for an HTCondor process."""
+    state: ProcState
+    cpu_hours: float | None = None
+    max_memory: int | None = None
+    runtime_seconds: float | None = None
+
+
+def _proc_stats_from_ad(ad: Any) -> ProcStats:
+    # Seems like condor uses MiB, although docs aren't great
+    # https://htcondor.readthedocs.io/en/24.x/man-pages/condor_submit.html?utm_source=chatgpt.com#request_memory
+    mem = ad.get(_AD_MEM)
+    if isinstance(mem, ExprTree):
+        mem = mem.eval(scope=ad)
+    cpu_sec = (ad.get(_AD_CPU_USER) or 0) + (ad.get(_AD_CPU_SYS) or 0)
+    rt = ad.get(_AD_COMMITTED_TIME)
+    return ProcStats(
+        state=_status_to_proc_state(ad[_AD_JOB_STATUS]),
+        cpu_hours=cpu_sec / 3600.0 if cpu_sec else None,
+        max_memory=mem * 1024 * 1024 if mem is not None else None,
+        runtime_seconds=float(rt) if rt is not None else None,
+    )
 
 
 @dataclass
@@ -523,6 +551,30 @@ class CondorClient:
                 hold_reason_code=ad.get(_AD_HOLD_REASON_CODE),
             ),
             missing=ProcDetails(state=ProcState.MISSING),
+        )
+
+    async def get_cluster_proc_stats(
+        self,
+        cluster_id: int,
+        expected_procs: int | Collection[int],
+    ) -> dict[int, ProcStats]:
+        """
+        Get the state and resource usage stats of each process in an HTC cluster.
+
+        Returns a dict mapping proc ID (== container number) to ProcStats, with a full
+        entry for every expected proc. Procs absent from both the active queue and history
+        are returned with ProcStats(state=ProcState.MISSING) and all stat fields None.
+
+        cluster_id - the HTCondor cluster ID.
+        expected_procs - the expected set of proc IDs. If an int n, the expected set is
+            range(n) and the HTCondor query is unrestricted to proc IDs. If a collection,
+            it is used directly as both the expected set and the query filter. An empty
+            collection returns an empty dict without querying HTCondor.
+        """
+        return await self._fetch_proc_map(
+            cluster_id, _STATUS_AND_STATS, expected_procs,
+            _proc_stats_from_ad,
+            missing=ProcStats(state=ProcState.MISSING),
         )
 
     async def release_job(self, cluster_id: int):

--- a/test/condor/condor_client_test.py
+++ b/test/condor/condor_client_test.py
@@ -7,7 +7,9 @@ import htcondor2
 
 from classad2 import ClassAd, ExprTree
 
-from cdmtaskservice.condor.client import CondorClient, ProcDetails, ProcState, _RETURNED_JOB_ADS
+from cdmtaskservice.condor.client import (
+    CondorClient, ProcDetails, ProcState, ProcStats, _RETURNED_JOB_ADS,
+)
 from cdmtaskservice.condor.config import CondorClientConfig
 from cdmtaskservice.config_s3 import S3Config
 
@@ -20,22 +22,33 @@ from cdmtaskservice.config_s3 import S3Config
 # ─── shared mock ads for parametrized value-assertion tests ──────────────────
 
 # Two procs that both finished cleanly.
-_ALL_COMPLETE_ADS = [{"ProcId": 0, "JobStatus": 4}, {"ProcId": 1, "JobStatus": 4}]
+# Proc 0 has cpu/runtime stats; proc 1 uses a real ClassAd with ExprTree MemoryUsage —
+# together they exercise stat extraction and ExprTree evaluation for the stats spec.
+_ALL_COMPLETE_ADS = [
+    {"ProcId": 0, "JobStatus": 4, "RemoteUserCpu": 60.0, "RemoteSysCpu": 10.0,
+     "CommittedTime": 1800},
+    ClassAd(
+        "[ProcId = 1; JobStatus = 4;"
+        " MemoryUsage = ceiling(ResidentSetSize_RAW / 1024.0); ResidentSetSize_RAW = 524288]"
+    ),
+]
 
 # Mixed scenario: every HTCondor status code covered, plus a race-dedup case.
 # Hold fields are always present so detail-aware methods can read them; state-only
 # methods ignore them. Proc 6 appears in both active and history to test dedup.
 _MIXED_ACTIVE_ADS = [
     {"ProcId": 0, "JobStatus": 2},
-    {"ProcId": 1, "JobStatus": 5, "HoldReason": "timeout", "HoldReasonCode": 3},
+    {"ProcId": 1, "JobStatus": 5, "HoldReason": "timeout", "HoldReasonCode": 3,
+     "MemoryUsage": 400, "CommittedTime": 900},
     {"ProcId": 2, "JobStatus": 5},
     {"ProcId": 3, "JobStatus": 1},
     {"ProcId": 4, "JobStatus": 7},
     {"ProcId": 5, "JobStatus": 6},
     {"ProcId": 6, "JobStatus": 2},
 ]
+# Proc 6 in history overrides the active entry; its stats come from the history record.
 _MIXED_HISTORY_ADS = [
-    {"ProcId": 6, "JobStatus": 4},
+    {"ProcId": 6, "JobStatus": 4, "RemoteUserCpu": 30.0, "RemoteSysCpu": 5.0},
     {"ProcId": 7, "JobStatus": 3},
 ]
 
@@ -120,7 +133,40 @@ _DETAILS_SPEC = _ProcMapSpec(
     },
 )
 
-_PROC_MAP_SPECS = [_STATES_SPEC, _DETAILS_SPEC]
+_STATS_SPEC = _ProcMapSpec(
+    label="stats",
+    call=lambda c, cid, ep: c.get_cluster_proc_stats(cid, ep),
+    missing=ProcStats(state=ProcState.MISSING),
+    projection=["ProcId", "JobStatus", "MemoryUsage", "RemoteUserCpu", "RemoteSysCpu",
+                "CommittedTime"],
+    all_complete_expected={
+        # proc 0: cpu/runtime present, no memory; proc 1: ExprTree MemoryUsage, no cpu/runtime
+        0: ProcStats(state=ProcState.COMPLETE, cpu_hours=70.0 / 3600, runtime_seconds=1800.0),
+        1: ProcStats(state=ProcState.COMPLETE, max_memory=512 * 1024 * 1024),
+    },
+    mixed_expected={
+        0: ProcStats(state=ProcState.RUNNING),
+        1: ProcStats(state=ProcState.HELD, max_memory=400 * 1024 * 1024, runtime_seconds=900.0),
+        2: ProcStats(state=ProcState.HELD),
+        3: ProcStats(state=ProcState.QUEUED),
+        4: ProcStats(state=ProcState.OTHER),
+        5: ProcStats(state=ProcState.RUNNING),
+        6: ProcStats(state=ProcState.COMPLETE, cpu_hours=35.0 / 3600),
+        7: ProcStats(state=ProcState.CANCELED),
+    },
+    partial_missing_expected={
+        0: ProcStats(state=ProcState.RUNNING),
+        1: ProcStats(state=ProcState.MISSING),
+        2: ProcStats(state=ProcState.COMPLETE),
+        3: ProcStats(state=ProcState.MISSING),
+    },
+    filter_expected={
+        1: ProcStats(state=ProcState.HELD),
+        3: ProcStats(state=ProcState.COMPLETE),
+    },
+)
+
+_PROC_MAP_SPECS = [_STATES_SPEC, _DETAILS_SPEC, _STATS_SPEC]
 
 
 def _make_dependencies():


### PR DESCRIPTION
  Adds ProcStats (state + cpu_hours/max_memory/runtime_seconds, same units as   CondorJobStats) and get_cluster_proc_stats, which uses _fetch_proc_map with a   narrow six-field projection to return per-proc stats for every expected proc.
  Missing procs get ProcStats(state=MISSING) with all stat fields None.