### PR TITLE
Add MongoDB layer for HTCondor per-proc stats backfilling

### DIFF
--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -54,15 +54,8 @@ FLD_NERSC_DETAILS_UL_TASK_ID = "upload_task_id"
 FLD_NERSC_DETAILS_LOG_UL_TASK_ID = "log_upload_task_id"
 FLD_JOB_JAWS_DETAILS = "jaws_details"
 FLD_JAWS_DETAILS_RUN_ID = "run_id"
-FLD_JOB_HTC_DETAILS = "htcondor_details"
-FLD_HTC_DETAILS_CLUSTER_ID = "cluster_id"
-FLD_HTC_DETAILS_CPU_HOURS = "cpu_hours"
-FLD_HTC_DETAILS_MAX_MEM = "max_memory"
-FLD_HTC_DETAILS_RUNTIME = "runtime_seconds"
-FLD_JOB_CPU_HOURS = "cpu_hours"
+FLD_JOB_HTC_CLUSTER_ID = "cluster_id"
 FLD_JOB_CPU_FACTOR = "cpu_factor"
-FLD_JOB_MAX_MEM = "max_memory"
-FLD_JOB_OUTPUTS = "outputs"
 FLD_JOB_OUTPUT_FILE_COUNT = "output_file_count"
 FLD_JOB_LOGPATH = "logpath"
 FLD_SUBJOB_ID = "sub_id"
@@ -70,6 +63,7 @@ FLD_SUBJOB_EXIT_CODE = "exit_code"
 FLD_SUBJOB_EXIT_CODE_HISTORY = "exit_code_history"
 FLD_SUBJOB_RUNTIME = "runtime_seconds"
 FLD_SUBJOB_HEARTBEAT = "heartbeat"
+FLD_SUBJOB_HTC_STATS_MISSING = "stats_missing"
 FLD_REFDATA_FILE = "file"
 FLD_REFDATA_STATUSES = "statuses"
 FLD_REFDATA_CLUSTER = "cluster"
@@ -80,6 +74,13 @@ FLD_COMMON_ID = "id"
 FLD_COMMON_STATE = "state"
 FLD_COMMON_TRANS_TIMES = "transition_times"
 FLD_COMMON_TRANS_HISTORY = "trans_history"
+FLD_COMMON_CPU_HOURS = "cpu_hours"
+FLD_COMMON_MAX_MEM = "max_memory"
+FLD_COMMON_OUTPUTS = "outputs"
+FLD_COMMON_HTC_DETAILS = "htcondor_details"
+FLD_COMMON_HTC_CPU_HOURS = "cpu_hours"
+FLD_COMMON_HTC_MAX_MEM = "max_memory"
+FLD_COMMON_HTC_RUNTIME = "runtime_seconds"
 FLD_COMMON_CLEANED = "cleaned"
 FLD_COMMON_ERROR = "error"
 FLD_COMMON_ADMIN_ERROR = "admin_error"
@@ -947,6 +948,32 @@ class _JobBase(BaseModel):
     )]
 
 
+class SubJobHTCondorDetails(BaseModel):
+    """
+    HTCondor statistics for a single container (proc) within a job.
+    """
+    cpu_hours: Annotated[float | None, Field(
+        examples=[1.5],
+        description="CPU hours used by this container as reported by HTCondor, if available."
+    )] = None
+    max_memory: Annotated[int | None, Field(
+        examples=[536870912],
+        description="Peak memory in bytes used by this container as reported by HTCondor, "
+            + "if available."
+    )] = None
+    runtime_seconds: Annotated[float | None, Field(
+        examples=[600.0],
+        description="Wall-clock runtime in seconds for this container as reported by HTCondor, "
+            + "if available."
+    )] = None
+    stats_missing: Annotated[bool | None, Field(
+        description="None if the background HTCondor stats fetcher has not yet checked this "
+            + "container. True if HTCondor has no record of this proc. False if stats were "
+            + "successfully fetched (individual stats fields may still be null if HTCondor "
+            + "reported nothing for them)."
+    )] = None
+
+
 class SubJob(_JobBase):
     """
     Information about the state of a subjob that is running as part of a job.
@@ -995,6 +1022,10 @@ class SubJob(_JobBase):
     heartbeat: Annotated[datetime.datetime | None, Field(
         description="The last time the external executor running this container sent a heartbeat."
             "null if the job has not yet started on the external runner"
+    )] = None
+    htcondor_details: Annotated[SubJobHTCondorDetails | None, Field(
+        description="HTCondor statistics for this container, populated by the background "
+            + "stats backfiller. Null if not yet processed."
     )] = None
 
 

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -37,6 +37,9 @@ _FLD_LAST_RECOVER = "_last_recover"
 
 # Sorted so the partial index definition is deterministic for tests
 _SUBJOB_ACTIVE_STATES = sorted(s.value for s in models.JobState.active_states())
+# Subjobs only reach COMPLETE or ERROR; CANCELED is included via terminal_states() but is
+# unreachable for subjobs, so it's harmless. Sorted for index determinism.
+_SUBJOB_HTC_STATS_STATES = sorted([s.value for s in models.JobState.terminal_states()])
 
 
 class MongoDAO:
@@ -163,6 +166,20 @@ class MongoDAO:
                 ],
                 partialFilterExpression={
                     models.FLD_COMMON_STATE: {"$in": _SUBJOB_ACTIVE_STATES}
+                },
+            ),
+            # Find terminal subjobs whose HTCondor per-proc stats have not yet been fetched.
+            # Partial filter restricts to COMPLETE/ERROR so the index stays small and fast.
+            IndexModel(
+                [
+                    (models.FLD_COMMON_STATE, ASCENDING),
+                    (
+                        f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_SUBJOB_HTC_STATS_MISSING}",
+                        ASCENDING,
+                    ),
+                ],
+                partialFilterExpression={
+                    models.FLD_COMMON_STATE: {"$in": _SUBJOB_HTC_STATS_STATES}
                 },
             ),
         ])
@@ -407,7 +424,7 @@ class MongoDAO:
             query[_FLD_UPDATE_TIME] = timequery
         # drop the potentially large fields
         project = {
-            models.FLD_JOB_OUTPUTS: 0,
+            models.FLD_COMMON_OUTPUTS: 0,
             f"{models.FLD_JOB_JOB_INPUT}.{models.FLD_JOB_INPUT_INPUT_FILES}": 0
         }
         sort = [(_FLD_UPDATE_TIME, DESCENDING)]
@@ -622,10 +639,10 @@ class MongoDAO:
 
     _FLD_NERSC_DL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_DL_TASK_ID}"
     _FLD_JAWS_RUN_ID = f"{models.FLD_JOB_JAWS_DETAILS}.{models.FLD_JAWS_DETAILS_RUN_ID}"
-    _FLD_HTC_CLUSTER_ID = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_CLUSTER_ID}"
-    _FLD_HTC_CPU_HOURS = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_CPU_HOURS}"
-    _FLD_HTC_MAX_MEM = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_MAX_MEM}"
-    _FLD_HTC_RUNTIME = f"{models.FLD_JOB_HTC_DETAILS}.{models.FLD_HTC_DETAILS_RUNTIME}"
+    _FLD_HTC_CLUSTER_ID = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_JOB_HTC_CLUSTER_ID}"
+    _FLD_HTC_CPU_HOURS = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_CPU_HOURS}"
+    _FLD_HTC_MAX_MEM = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_MAX_MEM}"
+    _FLD_HTC_RUNTIME = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_RUNTIME}"
     _FLD_NERSC_UL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_UL_TASK_ID}"
     _FLD_NERSC_LOG_UL_TASK = (
         f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_LOG_UL_TASK_ID}"
@@ -638,11 +655,11 @@ class MongoDAO:
             UpdateField.HTCONDOR_CPU_HOURS: (self._FLD_HTC_CPU_HOURS, False),
             UpdateField.HTCONDOR_MAX_MEM: (self._FLD_HTC_MAX_MEM, False),
             UpdateField.HTCONDOR_RUNTIME: (self._FLD_HTC_RUNTIME, False),
-            UpdateField.CPU_HOURS: (models.FLD_JOB_CPU_HOURS, False),
+            UpdateField.CPU_HOURS: (models.FLD_COMMON_CPU_HOURS, False),
             UpdateField.CPU_FACTOR: (models.FLD_JOB_CPU_FACTOR, False),
-            UpdateField.MAX_MEMORY: (models.FLD_JOB_MAX_MEM, False),
+            UpdateField.MAX_MEMORY: (models.FLD_COMMON_MAX_MEM, False),
             UpdateField.NERSC_UPLOAD_TASK_ID: (self._FLD_NERSC_UL_TASK, True),
-            UpdateField.OUTPUT_FILE_PATHS: (models.FLD_JOB_OUTPUTS, False),
+            UpdateField.OUTPUT_FILE_PATHS: (models.FLD_COMMON_OUTPUTS, False),
             UpdateField.OUTPUT_FILE_COUNT: (models.FLD_JOB_OUTPUT_FILE_COUNT, False),
             UpdateField.NERSC_LOG_UPLOAD_TASK_ID: (self._FLD_NERSC_LOG_UL_TASK, True),
             UpdateField.EXIT_CODE: (models.FLD_SUBJOB_EXIT_CODE, False),
@@ -729,6 +746,9 @@ class MongoDAO:
           - Sets state to DOWNLOAD_SUBMITTED
           - Sets cleaned to False
           - Clears error, admin_error, and traceback
+          - Clears executor cpu_hours, cpu_factor, and max_memory
+          - Clears htcondor_details cpu_hours, max_memory, and runtime_seconds
+            (cluster_id is preserved)
 
         job_id - the job ID.
         download_submitted_time - the time for the new DOWNLOAD_SUBMITTED transition.
@@ -761,6 +781,12 @@ class MongoDAO:
                 models.FLD_COMMON_ERROR,
                 models.FLD_COMMON_ADMIN_ERROR,
                 models.FLD_COMMON_TRACEBACK,
+                models.FLD_COMMON_CPU_HOURS,
+                models.FLD_JOB_CPU_FACTOR,
+                models.FLD_COMMON_MAX_MEM,
+                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_CPU_HOURS}",
+                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_MAX_MEM}",
+                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_RUNTIME}",
             ]},
         ]
         result = await self._col_jobs.update_one({models.FLD_COMMON_ID: job_id}, pipeline)
@@ -1066,6 +1092,80 @@ class MongoDAO:
         }
         return await self._aggregate_subjob_job_map(query)
 
+    async def get_subjobs_missing_htcondor_stats(
+        self,
+    ) -> dict[str, dict[int, datetime.datetime]]:
+        """
+        Return a mapping of job ID to {subjob_id: last_update_time} for subjobs in the
+        COMPLETE or ERROR state that have not yet had their HTCondor per-proc stats checked.
+
+        A subjob is unchecked when its htcondor_details.stats_missing field is null or absent.
+        """
+        query = {
+            models.FLD_COMMON_STATE: {"$in": _SUBJOB_HTC_STATS_STATES},
+            f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_SUBJOB_HTC_STATS_MISSING}": None,
+        }
+        return await self._aggregate_subjob_job_map(query)
+
+    async def save_subjob_htcondor_stats(
+        self,
+        job_id: str,
+        subjob_id: int,
+        cpu_hours: float | None,
+        max_memory: int | None,
+        runtime_seconds: float | None,
+        last_update_time: datetime.datetime,
+        stats_missing: bool = False,
+    ):
+        """
+        Persist HTCondor per-proc stats (or the permanent-missing flag) for a subjob without
+        changing its state. Gated on last_update_time so that a concurrent job recovery that
+        resets the subjob wins; raises SubJobUpdateConflictError in that case.
+
+        job_id - the job ID.
+        subjob_id - the subjob ID (same as the HTCondor proc ID).
+        cpu_hours - CPU hours as reported by HTCondor for this proc, or None.
+        max_memory - peak memory in bytes as reported by HTCondor for this proc, or None.
+        runtime_seconds - wall-clock runtime in seconds as reported by HTCondor, or None.
+        stats_missing - True if HTCondor has no record of this proc; False if stats were
+            fetched (individual fields may still be None if HTCondor reported nothing).
+            No validation is performed between stats_missing and the stat fields — callers
+            are trusted not to pass True with non-None stats or False with contradictory intent.
+        last_update_time - the subjob's last update time as read by the caller; used as an
+            optimistic lock. Raises SubJobUpdateConflictError if the subjob was modified
+            since this time. The subjob is expected to exist; a missing subjob and a genuine
+            conflict are not distinguished — both raise SubJobUpdateConflictError.
+        """
+        _require_string(job_id, "job_id")
+        _check_num(subjob_id, "subjob_id", minimum=0)
+        if cpu_hours is not None:
+            _check_num(cpu_hours, "cpu_hours", minimum=0)
+        if max_memory is not None:
+            _check_num(max_memory, "max_memory", minimum=0)
+        if runtime_seconds is not None:
+            _check_num(runtime_seconds, "runtime_seconds", minimum=0)
+        _not_falsy(last_update_time, "last_update_time")
+        result = await self._col_subjobs.update_one(
+            {
+                models.FLD_COMMON_ID: job_id,
+                models.FLD_SUBJOB_ID: subjob_id,
+                _FLD_UPDATE_TIME: last_update_time,
+            },
+            {"$set": {
+                models.FLD_COMMON_HTC_DETAILS: {
+                    models.FLD_COMMON_HTC_CPU_HOURS: cpu_hours,
+                    models.FLD_COMMON_HTC_MAX_MEM: max_memory,
+                    models.FLD_COMMON_HTC_RUNTIME: runtime_seconds,
+                    models.FLD_SUBJOB_HTC_STATS_MISSING: stats_missing,
+                }
+            }},
+        )
+        if not result.matched_count:
+            raise SubJobUpdateConflictError(
+                f"Job '{job_id}' subjob {subjob_id} was modified since update time "
+                f"{last_update_time} was read; skipping HTCondor stats write"
+            )
+
     async def _aggregate_subjob_job_map(
         self, query: dict
     ) -> dict[str, dict[int, datetime.datetime]]:
@@ -1100,7 +1200,8 @@ class MongoDAO:
           - Appends the current admin_error to admin_error_history
           - Resets transition_times to a single DOWNLOAD_SUBMITTED entry
           - Sets state to DOWNLOAD_SUBMITTED
-          - Clears exit_code, error, admin_error, traceback, and heartbeat
+          - Clears exit_code, error, admin_error, traceback, heartbeat,
+            executor cpu_hours, max_memory, and runtime_seconds, and htcondor_details
 
         Null is recorded in the history arrays when a field was not set, preserving
         alignment between history entries and recovery attempts.
@@ -1150,6 +1251,10 @@ class MongoDAO:
                 models.FLD_COMMON_ADMIN_ERROR,
                 models.FLD_COMMON_TRACEBACK,
                 models.FLD_SUBJOB_HEARTBEAT,
+                models.FLD_COMMON_CPU_HOURS,
+                models.FLD_COMMON_MAX_MEM,
+                models.FLD_SUBJOB_RUNTIME,
+                models.FLD_COMMON_HTC_DETAILS,
             ]},
         ]
         result = await self._col_subjobs.update_many(

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -148,6 +148,13 @@ async def test_indexes(mongo, mondb):
                 ])]))
             ]),
         },
+        "state_1_htcondor_details.stats_missing_1": {
+            "v": 2,
+            "key": [("state", 1), ("htcondor_details.stats_missing", 1)],
+            "partialFilterExpression": SON([
+                ("state", SON([("$in", ["canceled", "complete", "error"])]))
+            ]),
+        },
     }
     ecindex = mongo.client[MONGO_TEST_DB]["exitcodes"].index_information()
     assert ecindex == {
@@ -711,12 +718,18 @@ async def test_update_job_last_update_time_conflict(mondb):
 async def test_recover_job(mondb):
     mc = await MongoDAO.create(mondb)
 
-    # save a job with extra transitions and error fields to verify clearing and history capture
+    # save a job with extra transitions, error fields, and executor/HTC stats to verify clearing
     job = _BASEJOB.model_copy(deep=True)
     job.cleaned = True
     job.error = "some error"
     job.admin_error = "some admin error"
     job.traceback = "some traceback"
+    job.cpu_hours = 5.0
+    job.cpu_factor = 0.8
+    job.max_memory = 1024 * 1024 * 1024
+    job.htcondor_details = models.HTCondorDetails(
+        cluster_id=[123], cpu_hours=3.0, max_memory=512 * 1024 * 1024, runtime_seconds=1800.0
+    )
     dt1 = _SAFE_TIME + datetime.timedelta(minutes=1)
     dt2 = dt1 + datetime.timedelta(minutes=1)
     job.transition_times.extend([
@@ -752,6 +765,7 @@ async def test_recover_job(mondb):
         _tt(models.JobState.RECOVERING, dt2, "t4", False),
     ]
     expected.admin_error_history = ["some admin error"]
+    expected.htcondor_details = models.HTCondorDetails(cluster_id=[123])
     assert got == expected
 
     raw = await mondb.jobs.find_one({"id": "foo"})
@@ -759,6 +773,14 @@ async def test_recover_job(mondb):
     assert "error" not in raw
     assert "admin_error" not in raw
     assert "traceback" not in raw
+    assert "cpu_hours" not in raw
+    assert "cpu_factor" not in raw
+    assert "max_memory" not in raw
+    htc = raw["htcondor_details"]
+    assert htc["cluster_id"] == [123]
+    assert "cpu_hours" not in htc
+    assert "max_memory" not in htc
+    assert "runtime_seconds" not in htc
 
 
 async def test_recover_job_second_recovery(mondb):
@@ -1200,6 +1222,12 @@ async def test_recover_subjobs(mondb):
     sj0.admin_error = "some admin error"
     sj0.traceback = "some traceback"
     sj0.heartbeat = dt2
+    sj0.cpu_hours = 2.5
+    sj0.max_memory = 256 * 1024 * 1024
+    sj0.runtime_seconds = 900.0
+    sj0.htcondor_details = models.SubJobHTCondorDetails(
+        cpu_hours=2.0, max_memory=200 * 1024 * 1024, runtime_seconds=850.0, stats_missing=False
+    )
     sj2 = _BASESUBJOB3.model_copy(deep=True)
     sj2.admin_error = "sj2 error"
     await mc.initialize_subjobs([sj0, _BASESUBJOB2, sj2])
@@ -1235,6 +1263,10 @@ async def test_recover_subjobs(mondb):
     assert "admin_error" not in raw0
     assert "traceback" not in raw0
     assert "heartbeat" not in raw0
+    assert "cpu_hours" not in raw0
+    assert "max_memory" not in raw0
+    assert "runtime_seconds" not in raw0
+    assert "htcondor_details" not in raw0
 
     # subjob 2: no exit_code → null recorded in history; admin_error captured; heartbeat cleared
     got2 = await mc.get_subjob("bar", 2)
@@ -1868,13 +1900,15 @@ async def _process_dirty_refdata_fail(mc, older_than, op, expected):
         await mc.process_dirty_refdata(older_than, op)
 
 
-def _make_sj(job_id, sub_id, state=models.JobState.CREATED, *, time=_SAFE_TIME, heartbeat=None):
+def _make_sj(job_id, sub_id, state=models.JobState.CREATED, *, time=_SAFE_TIME, heartbeat=None,
+             htcondor_details=None):
     return models.SubJob(
         id=job_id,
         sub_id=sub_id,
         state=state,
         heartbeat=heartbeat,
         transition_times=[models.JobStateTransition(state=state, time=time)],
+        htcondor_details=htcondor_details,
     )
 
 
@@ -1950,3 +1984,116 @@ async def test_get_subjobs_with_stale_heartbeat_fail(mondb):
         await mc.get_subjobs_with_stale_heartbeat(None)
     with pytest.raises(ValueError, match="^older_than must be a timezone aware datetime$"):
         await mc.get_subjobs_with_stale_heartbeat(datetime.datetime(2025, 1, 1))
+
+
+# === HTCondor per-proc stats methods ===
+
+_HTC_T0 = datetime.datetime(2025, 7, 1, 1, tzinfo=datetime.timezone.utc)
+_HTC_T1 = datetime.datetime(2025, 7, 1, 2, tzinfo=datetime.timezone.utc)
+_HTC_T2 = datetime.datetime(2025, 7, 1, 3, tzinfo=datetime.timezone.utc)
+_HTC_T3 = datetime.datetime(2025, 7, 1, 4, tzinfo=datetime.timezone.utc)
+_HTC_T4 = datetime.datetime(2025, 7, 1, 5, tzinfo=datetime.timezone.utc)
+_HTC_T5 = datetime.datetime(2025, 7, 1, 6, tzinfo=datetime.timezone.utc)
+_HTC_T6 = datetime.datetime(2025, 7, 1, 7, tzinfo=datetime.timezone.utc)
+_HTC_T7 = datetime.datetime(2025, 7, 1, 8, tzinfo=datetime.timezone.utc)
+
+
+async def _setup_htcondor_stats_subjobs(mc, mondb):
+    await mc.initialize_subjobs([
+        # COMPLETE, htcondor_details=null (new subjob, backfiller not yet run) → in
+        _make_sj("j1", 0, models.JobState.COMPLETE, time=_HTC_T0),
+        _make_sj("j1", 1, models.JobState.COMPLETE, time=_HTC_T1),
+        # ERROR, htcondor_details=null → in
+        _make_sj("j2", 0, models.JobState.ERROR, time=_HTC_T2),
+        # COMPLETE, htcondor_stats_missing=False → out
+        _make_sj("j3", 0, models.JobState.COMPLETE, time=_HTC_T3,
+                 htcondor_details=models.SubJobHTCondorDetails(stats_missing=False)),
+        # COMPLETE, htcondor_stats_missing=True → out
+        _make_sj("j3", 1, models.JobState.COMPLETE, time=_HTC_T4,
+                 htcondor_details=models.SubJobHTCondorDetails(stats_missing=True)),
+        # Active state → out
+        _make_sj("j4", 0, models.JobState.JOB_SUBMITTED, time=_HTC_T5),
+        # COMPLETE, htcondor_details field entirely absent (pre-migration document) → in
+        _make_sj("j6", 0, models.JobState.COMPLETE, time=_HTC_T6),
+        # COMPLETE, htcondor_details present but stats_missing=null → in
+        _make_sj("j7", 0, models.JobState.COMPLETE, time=_HTC_T7,
+                 htcondor_details=models.SubJobHTCondorDetails()),
+    ])
+    # Simulate a pre-migration document by removing the field entirely
+    await mondb.subjobs.update_one({"id": "j6", "sub_id": 0}, {"$unset": {"htcondor_details": ""}})
+
+
+async def test_get_subjobs_missing_htcondor_stats(mondb):
+    mc = await MongoDAO.create(mondb)
+    await _setup_htcondor_stats_subjobs(mc, mondb)
+
+    assert await mc.get_subjobs_missing_htcondor_stats() == {
+        "j1": {0: _HTC_T0, 1: _HTC_T1},
+        "j2": {0: _HTC_T2},
+        "j6": {0: _HTC_T6},
+        "j7": {0: _HTC_T7},
+    }
+
+
+async def test_save_subjob_htcondor_stats(mondb):
+    mc = await MongoDAO.create(mondb)
+    await mc.initialize_subjobs([
+        _make_sj("j1", 0, models.JobState.COMPLETE, time=_HTC_T0),
+        _make_sj("j1", 1, models.JobState.ERROR, time=_HTC_T1),
+    ])
+
+    # stats_missing=False (default) with full stats
+    await mc.save_subjob_htcondor_stats("j1", 0, 1.5, 512 * 1024 * 1024, 600.0, _HTC_T0)
+    assert await mc.get_subjob("j1", 0) == _make_sj(
+        "j1", 0, models.JobState.COMPLETE, time=_HTC_T0,
+        htcondor_details=models.SubJobHTCondorDetails(
+            cpu_hours=1.5, max_memory=512 * 1024 * 1024, runtime_seconds=600.0, stats_missing=False
+        ),
+    )
+
+    # stats_missing=True: proc absent from HTCondor — stats stay None
+    await mc.save_subjob_htcondor_stats("j1", 1, None, None, None, _HTC_T1, stats_missing=True)
+    assert await mc.get_subjob("j1", 1) == _make_sj(
+        "j1", 1, models.JobState.ERROR, time=_HTC_T1,
+        htcondor_details=models.SubJobHTCondorDetails(stats_missing=True),
+    )
+
+    # stats_missing=False (default) with all-None stats (proc found but HTCondor reported nothing)
+    await mc.save_subjob_htcondor_stats("j1", 0, None, None, None, _HTC_T0)
+    assert await mc.get_subjob("j1", 0) == _make_sj(
+        "j1", 0, models.JobState.COMPLETE, time=_HTC_T0,
+        htcondor_details=models.SubJobHTCondorDetails(stats_missing=False),
+    )
+
+
+async def test_save_subjob_htcondor_stats_conflict(mondb):
+    mc = await MongoDAO.create(mondb)
+    await mc.initialize_subjobs([_make_sj("j1", 0, models.JobState.COMPLETE, time=_HTC_T0)])
+
+    stale_time = _HTC_T0 - datetime.timedelta(seconds=1)
+    with pytest.raises(SubJobUpdateConflictError):
+        await mc.save_subjob_htcondor_stats("j1", 0, 1.5, None, None, stale_time)
+
+    # Verify nothing was written
+    assert await mc.get_subjob("j1", 0) == _make_sj(
+        "j1", 0, models.JobState.COMPLETE, time=_HTC_T0
+    )
+
+
+async def test_save_subjob_htcondor_stats_fail(mondb):
+    mc = await MongoDAO.create(mondb)
+    t = _HTC_T0
+    with pytest.raises(ValueError, match="^job_id is required$"):
+        await mc.save_subjob_htcondor_stats(None, 0, None, None, None, t)
+    with pytest.raises(ValueError, match="^job_id is required$"):
+        await mc.save_subjob_htcondor_stats("  ", 0, None, None, None, t)
+    with pytest.raises(ValueError, match="^subjob_id must be >= 0$"):
+        await mc.save_subjob_htcondor_stats("j1", -1, None, None, None, t)
+    with pytest.raises(ValueError, match="^cpu_hours must be >= 0$"):
+        await mc.save_subjob_htcondor_stats("j1", 0, -0.1, None, None, t)
+    with pytest.raises(ValueError, match="^max_memory must be >= 0$"):
+        await mc.save_subjob_htcondor_stats("j1", 0, None, -1, None, t)
+    with pytest.raises(ValueError, match="^runtime_seconds must be >= 0$"):
+        await mc.save_subjob_htcondor_stats("j1", 0, None, None, -1.0, t)
+    with pytest.raises(ValueError, match="^last_update_time is required$"):
+        await mc.save_subjob_htcondor_stats("j1", 0, None, None, None, None)


### PR DESCRIPTION
SubJob gains an htcondor_details embedded subdocument (SubJobHTCondorDetails:
cpu_hours, max_memory, runtime_seconds, stats_missing) mirroring the structure
of HTCondorDetails on Job. stats_missing=null means unchecked, False means the
proc was found, True means permanently absent from HTCondor history.

Field constants reorganised: cpu_hours, max_memory, and outputs are now FLD_COMMON_* (shared across job and subjob documents); htcondor_details and
its three stat subfields are FLD_COMMON_HTC_*; cluster_id is FLD_JOB_HTC_CLUSTER_ID; stats_missing is FLD_SUBJOB_HTC_STATS_MISSING.

MongoDAO additions:
- Partial index on (state, htcondor_details.stats_missing) covering terminal
  subjob states, for efficient backfill queries.
- get_subjobs_missing_htcondor_stats: returns job→{subjob_id: last_update_time} for terminal subjobs not yet processed by the backfiller (stats_missing null
  or absent, including pre-migration documents with no htcondor_details field).
- save_subjob_htcondor_stats: writes the htcondor_details subdocument atomically, gated on last_update_time to lose gracefully to concurrent job recovery.
- recover_job: now also clears cpu_hours, cpu_factor, max_memory, and the three
  htcondor_details stat fields (cluster_id preserved for re-submission).
- recover_subjobs: now also clears cpu_hours, max_memory, runtime_seconds, and
  the entire htcondor_details subdocument.