### PR TITLE
Bound the HTC stats partial index

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -169,7 +169,8 @@ class MongoDAO:
                 },
             ),
             # Find terminal subjobs whose HTCondor per-proc stats have not yet been fetched.
-            # Partial filter restricts to COMPLETE/ERROR so the index stays small and fast.
+            # stats_missing=None restricts the index to unprocessed subjobs so it stays bounded —
+            # once the backfiller sets stats_missing to True/False the subjob exits the index.
             IndexModel(
                 [
                     (models.FLD_COMMON_STATE, ASCENDING),
@@ -179,7 +180,8 @@ class MongoDAO:
                     ),
                 ],
                 partialFilterExpression={
-                    models.FLD_COMMON_STATE: {"$in": _SUBJOB_HTC_STATS_STATES}
+                    models.FLD_COMMON_STATE: {"$in": _SUBJOB_HTC_STATS_STATES},
+                    f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_SUBJOB_HTC_STATS_MISSING}": None,
                 },
             ),
         ])

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -152,7 +152,8 @@ async def test_indexes(mongo, mondb):
             "v": 2,
             "key": [("state", 1), ("htcondor_details.stats_missing", 1)],
             "partialFilterExpression": SON([
-                ("state", SON([("$in", ["canceled", "complete", "error"])]))
+                ("state", SON([("$in", ["canceled", "complete", "error"])])),
+                ("htcondor_details.stats_missing", None),
             ]),
         },
     }


### PR DESCRIPTION
The partial filter previously covered all terminal subjobs (COMPLETE/ERROR/CANCELED),
meaning processed subjobs accumulated in the index indefinitely. Adding htcondor_details.stats_missing: null to the filter ensures documents exit the
index as soon as the backfiller writes True or False