### PR TITLE
Guard save_subjob_htcondor_stats against overwriting existing stats

### DIFF
--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -1121,8 +1121,10 @@ class MongoDAO:
     ):
         """
         Persist HTCondor per-proc stats (or the permanent-missing flag) for a subjob without
-        changing its state. Gated on last_update_time so that a concurrent job recovery that
-        resets the subjob wins; raises SubJobUpdateConflictError in that case.
+        changing its state. Raises SubJobHtcondorStatsAlreadySetError if stats have already
+        been written. Gated on last_update_time so that a concurrent job recovery that resets
+        the subjob wins; raises SubJobUpdateConflictError in that case. Raises MissingSubJobError
+        if the subjob does not exist.
 
         job_id - the job ID.
         subjob_id - the subjob ID (same as the HTCondor proc ID).
@@ -1135,8 +1137,7 @@ class MongoDAO:
             are trusted not to pass True with non-None stats or False with contradictory intent.
         last_update_time - the subjob's last update time as read by the caller; used as an
             optimistic lock. Raises SubJobUpdateConflictError if the subjob was modified
-            since this time. The subjob is expected to exist; a missing subjob and a genuine
-            conflict are not distinguished — both raise SubJobUpdateConflictError.
+            since this time.
         """
         _require_string(job_id, "job_id")
         _check_num(subjob_id, "subjob_id", minimum=0)
@@ -1152,6 +1153,7 @@ class MongoDAO:
                 models.FLD_COMMON_ID: job_id,
                 models.FLD_SUBJOB_ID: subjob_id,
                 _FLD_UPDATE_TIME: last_update_time,
+                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_SUBJOB_HTC_STATS_MISSING}": None,
             },
             {"$set": {
                 models.FLD_COMMON_HTC_DETAILS: {
@@ -1163,6 +1165,18 @@ class MongoDAO:
             }},
         )
         if not result.matched_count:
+            doc = await self._col_subjobs.find_one(
+                {models.FLD_COMMON_ID: job_id, models.FLD_SUBJOB_ID: subjob_id},
+                {_FLD_UPDATE_TIME: 1},
+            )
+            if not doc:
+                raise MissingSubJobError(
+                    f"Job '{job_id}' subjob {subjob_id} does not exist"
+                )
+            if doc.get(_FLD_UPDATE_TIME) == last_update_time:
+                raise SubJobHtcondorStatsAlreadySetError(
+                    f"Job '{job_id}' subjob {subjob_id} already has HTCondor stats set"
+                )
             raise SubJobUpdateConflictError(
                 f"Job '{job_id}' subjob {subjob_id} was modified since update time "
                 f"{last_update_time} was read; skipping HTCondor stats write"
@@ -1579,6 +1593,10 @@ class JobUpdateConflictError(Exception):
 
 class SubJobUpdateConflictError(Exception):
     """ The subjob was updated by another process since it was last read. """
+
+
+class SubJobHtcondorStatsAlreadySetError(Exception):
+    """ HTCondor stats for this subjob have already been persisted. """
 
 
 class MissingSubJobError(Exception):

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -16,6 +16,7 @@ from cdmtaskservice.mongo import (
     NoSuchJobError,
     NoSuchReferenceDataError,
     NoSuchSubJobError,
+    SubJobHtcondorStatsAlreadySetError,
     SubJobUpdateConflictError,
 )
 from cdmtaskservice.update_state import (
@@ -2041,6 +2042,7 @@ async def test_save_subjob_htcondor_stats(mondb):
     await mc.initialize_subjobs([
         _make_sj("j1", 0, models.JobState.COMPLETE, time=_HTC_T0),
         _make_sj("j1", 1, models.JobState.ERROR, time=_HTC_T1),
+        _make_sj("j1", 2, models.JobState.COMPLETE, time=_HTC_T0),
     ])
 
     # stats_missing=False (default) with full stats
@@ -2060,9 +2062,9 @@ async def test_save_subjob_htcondor_stats(mondb):
     )
 
     # stats_missing=False (default) with all-None stats (proc found but HTCondor reported nothing)
-    await mc.save_subjob_htcondor_stats("j1", 0, None, None, None, _HTC_T0)
-    assert await mc.get_subjob("j1", 0) == _make_sj(
-        "j1", 0, models.JobState.COMPLETE, time=_HTC_T0,
+    await mc.save_subjob_htcondor_stats("j1", 2, None, None, None, _HTC_T0)
+    assert await mc.get_subjob("j1", 2) == _make_sj(
+        "j1", 2, models.JobState.COMPLETE, time=_HTC_T0,
         htcondor_details=models.SubJobHTCondorDetails(stats_missing=False),
     )
 
@@ -2079,6 +2081,33 @@ async def test_save_subjob_htcondor_stats_conflict(mondb):
     assert await mc.get_subjob("j1", 0) == _make_sj(
         "j1", 0, models.JobState.COMPLETE, time=_HTC_T0
     )
+
+
+async def test_save_subjob_htcondor_stats_already_set(mondb):
+    mc = await MongoDAO.create(mondb)
+    await mc.initialize_subjobs([_make_sj("j1", 0, models.JobState.COMPLETE, time=_HTC_T0)])
+
+    await mc.save_subjob_htcondor_stats("j1", 0, 1.5, None, None, _HTC_T0)
+
+    with pytest.raises(SubJobHtcondorStatsAlreadySetError):
+        await mc.save_subjob_htcondor_stats("j1", 0, 2.0, None, None, _HTC_T0)
+
+    # Verify original stats were not overwritten
+    assert await mc.get_subjob("j1", 0) == _make_sj(
+        "j1", 0, models.JobState.COMPLETE, time=_HTC_T0,
+        htcondor_details=models.SubJobHTCondorDetails(
+            cpu_hours=1.5, stats_missing=False
+        ),
+    )
+
+
+async def test_save_subjob_htcondor_stats_missing_subjob(mondb):
+    mc = await MongoDAO.create(mondb)
+    await mc.initialize_subjobs([_make_sj("j1", 1, models.JobState.COMPLETE, time=_HTC_T0)])
+    await mc.initialize_subjobs([_make_sj("j2", 0, models.JobState.COMPLETE, time=_HTC_T0)])
+
+    with pytest.raises(MissingSubJobError):
+        await mc.save_subjob_htcondor_stats("j1", 0, None, None, None, _HTC_T0)
 
 
 async def test_save_subjob_htcondor_stats_fail(mondb):


### PR DESCRIPTION
Add htcondor_stats_missing: None to the update filter so a concurrent second write (e.g. two backfiller instances racing) cannot overwrite already-persisted stats. On a missed update, a follow-up find_one distinguishes three cases: stats already set
(SubJobHtcondorStatsAlreadySetError,
new), subjob missing (MissingSubJobError), or optimistic-lock conflict (SubJobUpdateConflictError).