### PR TITLE
Handle missing HTCondor processes at job completion time

### DIFF
--- a/cdmtaskservice/jobflows/kbase.py
+++ b/cdmtaskservice/jobflows/kbase.py
@@ -73,17 +73,7 @@ class _CondorJobStats:
     cpu_hours: float | None
     max_memory: int | None
     runtime_seconds: float | None
-
-
-def _aggregate_condor_stats(proc_stats: dict[int, ProcStats]) -> _CondorJobStats:
-    cpu = sum(s.cpu_hours for s in proc_stats.values() if s.cpu_hours is not None)
-    mems = [s.max_memory for s in proc_stats.values() if s.max_memory is not None]
-    rt = sum(s.runtime_seconds for s in proc_stats.values() if s.runtime_seconds is not None)
-    return _CondorJobStats(
-        cpu_hours=cpu or None,
-        max_memory=max(mems) if mems else None,
-        runtime_seconds=rt or None,
-    )
+    stats_incomplete: bool = False
 
 
 class KBaseRunner(JobFlow):
@@ -507,6 +497,7 @@ class KBaseRunner(JobFlow):
                 htcondor_cpu_hours=condor_stats.cpu_hours,
                 htcondor_max_memory=condor_stats.max_memory,
                 htcondor_runtime_seconds=condor_stats.runtime_seconds,
+                htcondor_stats_incomplete=condor_stats.stats_incomplete,
             ),
             last_update_time=last_update_time,
         )
@@ -525,6 +516,7 @@ class KBaseRunner(JobFlow):
             htcondor_cpu_hours=condor_stats.cpu_hours,
             htcondor_max_memory=condor_stats.max_memory,
             htcondor_runtime_seconds=condor_stats.runtime_seconds,
+            htcondor_stats_incomplete=condor_stats.stats_incomplete,
         )
         subjobs = await self.get_subjobs(job.id)
         filechecksums = {}
@@ -588,7 +580,42 @@ class KBaseRunner(JobFlow):
             htcondor_cpu_hours=condor_stats.cpu_hours if condor_stats else None,
             htcondor_max_memory=condor_stats.max_memory if condor_stats else None,
             htcondor_runtime_seconds=condor_stats.runtime_seconds if condor_stats else None,
+            htcondor_stats_incomplete=condor_stats.stats_incomplete if condor_stats else None,
         ))
+
+    async def _aggregate_condor_stats(
+        self, job_id: str, proc_stats: dict[int, ProcStats]
+    ) -> _CondorJobStats:
+        missing_ids = [i for i, s in proc_stats.items() if s.state is ProcState.MISSING]
+        if missing_ids:
+            # Some procs are absent from both HTCondor's active queue and history. Check if the
+            # background stats backfiller has resolved them. The backfiller may not have run yet
+            # if the CTS or HTCondor was down long enough for procs to be purged from history
+            # before the backfiller could record their stats — in that case stats are incomplete.
+            subjobs = await self._mongo.get_subjobs(job_id, subjob_ids=missing_ids)
+            for sj in subjobs:
+                htc = sj.htcondor_details
+                if htc is None or htc.stats_missing is not False:
+                    # Backfiller hasn't run (htc absent or stats_missing not yet set), or the proc
+                    # is permanently absent from HTCondor history; stats are incomplete either way.
+                    return _CondorJobStats(
+                        cpu_hours=None, max_memory=None, runtime_seconds=None,
+                        stats_incomplete=True,
+                    )
+                proc_stats[sj.sub_id] = ProcStats(
+                    state=ProcState.COMPLETE,  # arbitrary
+                    cpu_hours=htc.cpu_hours,
+                    max_memory=htc.max_memory,
+                    runtime_seconds=htc.runtime_seconds,
+                )
+        cpu = sum(s.cpu_hours for s in proc_stats.values() if s.cpu_hours is not None)
+        mems = [s.max_memory for s in proc_stats.values() if s.max_memory is not None]
+        rt = sum(s.runtime_seconds for s in proc_stats.values() if s.runtime_seconds is not None)
+        return _CondorJobStats(
+            cpu_hours=cpu or None,
+            max_memory=max(mems) if mems else None,
+            runtime_seconds=rt or None,
+        )
 
     async def _poll_condor_stats(
         self, job: models.AdminJobDetails
@@ -605,7 +632,7 @@ class KBaseRunner(JobFlow):
             await asyncio.sleep(5)  # give Condor a few seconds to finish up
             proc_stats = await self._condor.get_cluster_proc_stats(cluster_id, num_containers)
             if not any(s.state.is_queued_or_running() for s in proc_stats.values()):
-                return _aggregate_condor_stats(proc_stats)
+                return await self._aggregate_condor_stats(job.id, proc_stats)
             attempts += 1
         raise ExternalRunnerTimeoutError(
             "External runner jobs didn't complete for 60s after all executors sent termination"

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -55,6 +55,7 @@ FLD_NERSC_DETAILS_LOG_UL_TASK_ID = "log_upload_task_id"
 FLD_JOB_JAWS_DETAILS = "jaws_details"
 FLD_JAWS_DETAILS_RUN_ID = "run_id"
 FLD_JOB_HTC_CLUSTER_ID = "cluster_id"
+FLD_JOB_HTC_STATS_INCOMPLETE = "stats_incomplete"
 FLD_JOB_CPU_FACTOR = "cpu_factor"
 FLD_JOB_OUTPUT_FILE_COUNT = "output_file_count"
 FLD_JOB_LOGPATH = "logpath"
@@ -1173,6 +1174,11 @@ class HTCondorDetails(BaseModel):
         examples=[1800.0],
         description="Total wall-clock runtime in seconds across all containers as reported by "
             + "HTCondor, if available."
+    )] = None
+    stats_incomplete: Annotated[bool | None, Field(
+        description="True if HTCondor stats could not be fully computed because one or more "
+            + "procs are permanently absent from HTCondor history. False if stats are "
+            + "complete. None if the job has not yet reached a terminal state."
     )] = None
 
 

--- a/cdmtaskservice/mongo.py
+++ b/cdmtaskservice/mongo.py
@@ -645,6 +645,9 @@ class MongoDAO:
     _FLD_HTC_CPU_HOURS = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_CPU_HOURS}"
     _FLD_HTC_MAX_MEM = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_MAX_MEM}"
     _FLD_HTC_RUNTIME = f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_RUNTIME}"
+    _FLD_HTC_STATS_INCOMPLETE = (
+        f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_JOB_HTC_STATS_INCOMPLETE}"
+    )
     _FLD_NERSC_UL_TASK = f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_UL_TASK_ID}"
     _FLD_NERSC_LOG_UL_TASK = (
         f"{models.FLD_JOB_NERSC_DETAILS}.{models.FLD_NERSC_DETAILS_LOG_UL_TASK_ID}"
@@ -657,6 +660,7 @@ class MongoDAO:
             UpdateField.HTCONDOR_CPU_HOURS: (self._FLD_HTC_CPU_HOURS, False),
             UpdateField.HTCONDOR_MAX_MEM: (self._FLD_HTC_MAX_MEM, False),
             UpdateField.HTCONDOR_RUNTIME: (self._FLD_HTC_RUNTIME, False),
+            UpdateField.HTCONDOR_STATS_INCOMPLETE: (self._FLD_HTC_STATS_INCOMPLETE, False),
             UpdateField.CPU_HOURS: (models.FLD_COMMON_CPU_HOURS, False),
             UpdateField.CPU_FACTOR: (models.FLD_JOB_CPU_FACTOR, False),
             UpdateField.MAX_MEMORY: (models.FLD_COMMON_MAX_MEM, False),
@@ -786,9 +790,10 @@ class MongoDAO:
                 models.FLD_COMMON_CPU_HOURS,
                 models.FLD_JOB_CPU_FACTOR,
                 models.FLD_COMMON_MAX_MEM,
-                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_CPU_HOURS}",
-                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_MAX_MEM}",
-                f"{models.FLD_COMMON_HTC_DETAILS}.{models.FLD_COMMON_HTC_RUNTIME}",
+                self._FLD_HTC_CPU_HOURS,
+                self._FLD_HTC_MAX_MEM,
+                self._FLD_HTC_RUNTIME,
+                self._FLD_HTC_STATS_INCOMPLETE,
             ]},
         ]
         result = await self._col_jobs.update_one({models.FLD_COMMON_ID: job_id}, pipeline)

--- a/cdmtaskservice/update_state.py
+++ b/cdmtaskservice/update_state.py
@@ -64,7 +64,10 @@ class UpdateField(StrEnum):
 
     HTCONDOR_RUNTIME = auto()
     """ The total wall-clock runtime in seconds for a job as reported by HTCondor. """
-    
+
+    HTCONDOR_STATS_INCOMPLETE = auto()
+    """ True if HTCondor stats are incomplete due to missing proc data. """
+
     USER_ERROR = auto()
     """ Error information about a process targeted at a user. """
     
@@ -327,6 +330,7 @@ def _set_htcondor_stats(
     htcondor_cpu_hours: float | None,
     htcondor_max_memory: int | None,
     htcondor_runtime_seconds: float | None,
+    htcondor_stats_incomplete: bool | None = None,
 ):
     if htcondor_cpu_hours is not None:
         flds[UpdateField.HTCONDOR_CPU_HOURS] = _check_num(
@@ -340,6 +344,11 @@ def _set_htcondor_stats(
         flds[UpdateField.HTCONDOR_RUNTIME] = _check_num(
             htcondor_runtime_seconds, "htcondor_runtime_seconds", minimum=0
         )
+    # None means no HTCondor context (non-KBase job); avoids creating a partial
+    # htcondor_details subdocument on NERSC/JAWS jobs. KBase callers always pass True or False
+    # except for canceled jobs.
+    if htcondor_stats_incomplete is not None:
+        flds[UpdateField.HTCONDOR_STATS_INCOMPLETE] = htcondor_stats_incomplete
 
 
 def complete(
@@ -348,6 +357,7 @@ def complete(
     htcondor_cpu_hours: float | None = None,
     htcondor_max_memory: int | None = None,
     htcondor_runtime_seconds: float | None = None,
+    htcondor_stats_incomplete: bool | None = None,
 ) -> JobUpdate:
     """
     Update a job's state from upload submitted to complete.
@@ -355,6 +365,8 @@ def complete(
     output_file_paths - the output file paths.
     htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
         htcondor_details, if available.
+    htcondor_stats_incomplete - True if HTCondor stats could not be fully computed due to
+        missing proc data.
     """
     output_file_paths = output_file_paths or []
     out = [o.model_dump() for o in output_file_paths]
@@ -362,7 +374,10 @@ def complete(
         UpdateField.OUTPUT_FILE_PATHS: out,
         UpdateField.OUTPUT_FILE_COUNT: len(out),
     }
-    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
+    _set_htcondor_stats(
+        flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds,
+        htcondor_stats_incomplete,
+    )
     return JobUpdate(
         )._set_current_state(models.JobState.UPLOAD_SUBMITTED
         )._set_new_state(models.JobState.COMPLETE
@@ -416,6 +431,7 @@ def canceled(
     htcondor_cpu_hours: float | None = None,
     htcondor_max_memory: int | None = None,
     htcondor_runtime_seconds: float | None = None,
+    htcondor_stats_incomplete: bool | None = None,
 ) -> JobUpdate:
     """
     Set a job to the canceled state.
@@ -425,10 +441,15 @@ def canceled(
     max_memory - the maximum memory used by the job in bytes, if available.
     htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
         htcondor_details, if available.
+    htcondor_stats_incomplete - True if HTCondor stats could not be fully computed due to
+        missing proc data.
     """
     flds = {}
     _set_job_stats(flds, cpu_hours, max_memory, cpu_factor)
-    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
+    _set_htcondor_stats(
+        flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds,
+        htcondor_stats_incomplete,
+    )
     return JobUpdate(
         )._set_current_state(models.JobState.CANCELING
         )._set_new_state(models.JobState.CANCELED
@@ -513,6 +534,7 @@ def error(
     htcondor_cpu_hours: float | None = None,
     htcondor_max_memory: int | None = None,
     htcondor_runtime_seconds: float | None = None,
+    htcondor_stats_incomplete: bool | None = None,
 ) -> JobUpdate:
     """
     Update a job's state to error.
@@ -524,6 +546,8 @@ def error(
     log_files_path - the path to any logs for the job.
     htcondor_cpu_hours/max_memory/runtime_seconds - HTCondor-reported stats stored in
         htcondor_details, if available.
+    htcondor_stats_incomplete - True if HTCondor stats could not be fully computed due to
+        missing proc data.
     """
     flds = {
         UpdateField.ADMIN_ERROR: _require_string(admin_error, "admin_error"),
@@ -532,7 +556,10 @@ def error(
     }
     if user_error is not None:
         flds[UpdateField.USER_ERROR] = user_error
-    _set_htcondor_stats(flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds)
+    _set_htcondor_stats(
+        flds, htcondor_cpu_hours, htcondor_max_memory, htcondor_runtime_seconds,
+        htcondor_stats_incomplete,
+    )
     return JobUpdate(
         )._set_new_state(models.JobState.ERROR
         )._set_disallowed_current_states(

--- a/test/jobflows/kbase_test.py
+++ b/test/jobflows/kbase_test.py
@@ -522,6 +522,7 @@ async def test_update_container_state_terminal_error():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -558,6 +559,97 @@ async def test_update_container_state_terminal_error_no_condor_stats():
             htcondor_cpu_hours=None,
             htcondor_max_memory=None,
             htcondor_runtime_seconds=None,
+            htcondor_stats_incomplete=False,
+        ),
+        last_update_time=_T,
+    )
+
+
+_MISSING_PROC_STATS = {
+    0: ProcStats(state=ProcState.COMPLETE, cpu_hours=0.6, max_memory=300 * 1024 * 1024,
+                 runtime_seconds=500.0),
+    1: ProcStats(state=ProcState.MISSING),
+}
+
+
+@pytest.mark.parametrize("htc_details", [
+    pytest.param(None, id="no_htcondor_details"),
+    pytest.param(models.SubJobHTCondorDetails(stats_missing=None), id="stats_missing_none"),
+    pytest.param(models.SubJobHTCondorDetails(stats_missing=True), id="permanently_absent"),
+])
+async def test_update_container_state_terminal_error_missing_proc_incomplete(htc_details):
+    """
+    MISSING proc → stats_incomplete=True, all htc stats None. Covers all cases where stats
+    cannot be substituted: backfiller not yet run (htc absent or stats_missing=None), and
+    proc permanently absent from HTCondor history (stats_missing=True).
+    """
+    runner, mongo, condor, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
+    mongo.get_exit_codes_for_subjobs.return_value = [1]
+    condor.get_cluster_proc_stats.return_value = _MISSING_PROC_STATS
+    sj = models.SubJob.model_construct(sub_id=1, htcondor_details=htc_details)
+    mongo.get_subjobs.return_value = [sj]
+
+    with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
+        await runner.update_container_state(
+            _JOB, 1, models.JobState.ERROR,
+            _update(admin_error="container failed"),
+        )
+
+    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
+    condor.get_cluster_proc_stats.assert_called_once_with(123, 2)
+    mongo.get_subjobs.assert_called_once_with("jid", subjob_ids=[1])
+    mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.error(
+            "Check subjobs / containers for admin errors",
+            user_error=(
+                "At least one container exited with a non-zero "
+                "error code. Please examine the logs for details."
+            ),
+            log_files_path="logs/jid",
+            htcondor_stats_incomplete=True,
+        ),
+        last_update_time=_T,
+    )
+
+
+async def test_update_container_state_terminal_error_missing_proc_resolved_by_backfiller():
+    """MISSING proc resolved by backfiller (stats_missing=False) → saved stats merged in."""
+    runner, mongo, condor, updates, _ = _make_runner()
+    updates.get_parent_job_update.return_value = ParentJobUpdate(models.JobState.ERROR, _T)
+    mongo.get_exit_codes_for_subjobs.return_value = [1]
+    condor.get_cluster_proc_stats.return_value = _MISSING_PROC_STATS
+    htc = models.SubJobHTCondorDetails(
+        stats_missing=False, cpu_hours=0.4, max_memory=512 * 1024 * 1024, runtime_seconds=700.0,
+    )
+    sj = models.SubJob.model_construct(sub_id=1, htcondor_details=htc)
+    mongo.get_subjobs.return_value = [sj]
+
+    with patch("cdmtaskservice.jobflows.kbase.asyncio.sleep"):
+        await runner.update_container_state(
+            _JOB, 1, models.JobState.ERROR,
+            _update(admin_error="container failed"),
+        )
+
+    updates.get_parent_job_update.assert_called_once_with(_JOB, models.JobState.ERROR)
+    condor.get_cluster_proc_stats.assert_called_once_with(123, 2)
+    mongo.get_subjobs.assert_called_once_with("jid", subjob_ids=[1])
+    mongo.get_exit_codes_for_subjobs.assert_called_once_with("jid")
+    updates.update_job_state.assert_called_once_with(
+        "jid",
+        update_state.error(
+            "Check subjobs / containers for admin errors",
+            user_error=(
+                "At least one container exited with a non-zero "
+                "error code. Please examine the logs for details."
+            ),
+            log_files_path="logs/jid",
+            htcondor_cpu_hours=1.0,
+            htcondor_max_memory=512 * 1024 * 1024,
+            htcondor_runtime_seconds=1200.0,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -646,6 +738,7 @@ async def test_update_container_state_terminal_complete():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         update_time=_T,
     )
@@ -776,6 +869,7 @@ async def test_update_container_state_recovering_ignored_terminal():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -851,6 +945,7 @@ async def test_update_container_state_error_job_no_nonzero_exit_codes():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -899,6 +994,7 @@ async def test_update_container_state_error_job_held_running_containers():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -1047,6 +1143,7 @@ async def test_update_container_state_error_job_update_conflict(caplog):
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )
@@ -1081,6 +1178,7 @@ async def test_update_container_state_complete_job_no_outputs():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
     )
 
@@ -1116,6 +1214,7 @@ async def test_update_container_state_complete_job_checksum_mismatch():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
     )
 
@@ -1241,6 +1340,7 @@ async def test_recover_job_standard_canceling_with_cluster_id():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
     )
 
@@ -1355,6 +1455,7 @@ async def test_recover_job_error_state_advance_to_complete():
                 htcondor_cpu_hours=_HTC_CPU_HOURS,
                 htcondor_max_memory=_HTC_MAX_MEM,
                 htcondor_runtime_seconds=_HTC_RUNTIME,
+                htcondor_stats_incomplete=False,
             ),
             update_time=advance_times[4],
         ),
@@ -1482,6 +1583,7 @@ async def test_recover_job_standard_advance_to_complete(start_state, state_updat
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         update_time=complete_time,
     )]
@@ -1519,6 +1621,7 @@ async def test_recover_job_complete_job_no_outputs():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
     )
 
@@ -1552,6 +1655,7 @@ async def test_recover_job_complete_job_checksum_mismatch():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
     )
 
@@ -1847,6 +1951,7 @@ async def test_recover_job_force_all_complete():
                 htcondor_cpu_hours=_HTC_CPU_HOURS,
                 htcondor_max_memory=_HTC_MAX_MEM,
                 htcondor_runtime_seconds=_HTC_RUNTIME,
+                htcondor_stats_incomplete=False,
             ),
             update_time=advance_times[4],
         ),
@@ -2417,6 +2522,7 @@ async def test_error_unhealthy_subjobs_active_job_triggers_terminal_parent():
             htcondor_cpu_hours=_HTC_CPU_HOURS,
             htcondor_max_memory=_HTC_MAX_MEM,
             htcondor_runtime_seconds=_HTC_RUNTIME,
+            htcondor_stats_incomplete=False,
         ),
         last_update_time=_T,
     )

--- a/test/mongo_test.py
+++ b/test/mongo_test.py
@@ -418,6 +418,7 @@ async def test_update_job_htcondor_stats(mondb):
             htcondor_cpu_hours=1.5,
             htcondor_max_memory=536870912,
             htcondor_runtime_seconds=1800.0,
+            htcondor_stats_incomplete=False,
         ),
         dt, "tid1",
     )
@@ -427,6 +428,23 @@ async def test_update_job_htcondor_stats(mondb):
         cpu_hours=1.5,
         max_memory=536870912,
         runtime_seconds=1800.0,
+        stats_incomplete=False,
+    )
+
+    job2 = _BASEJOB.model_copy(deep=True)
+    job2.id = "bar"
+    job2.htcondor_details = models.HTCondorDetails(cluster_id=[99])
+    await mc.save_job(job2)
+
+    await mc.update_job_state(
+        "bar",
+        error("admin err 2", htcondor_stats_incomplete=True),
+        dt, "tid2",
+    )
+    got2 = await mc.get_job("bar", as_admin=True)
+    assert got2.htcondor_details == models.HTCondorDetails(
+        cluster_id=[99],
+        stats_incomplete=True,
     )
 
 
@@ -730,7 +748,8 @@ async def test_recover_job(mondb):
     job.cpu_factor = 0.8
     job.max_memory = 1024 * 1024 * 1024
     job.htcondor_details = models.HTCondorDetails(
-        cluster_id=[123], cpu_hours=3.0, max_memory=512 * 1024 * 1024, runtime_seconds=1800.0
+        cluster_id=[123], cpu_hours=3.0, max_memory=512 * 1024 * 1024, runtime_seconds=1800.0,
+        stats_incomplete=True,
     )
     dt1 = _SAFE_TIME + datetime.timedelta(minutes=1)
     dt2 = dt1 + datetime.timedelta(minutes=1)
@@ -783,6 +802,7 @@ async def test_recover_job(mondb):
     assert "cpu_hours" not in htc
     assert "max_memory" not in htc
     assert "runtime_seconds" not in htc
+    assert "stats_incomplete" not in htc
 
 
 async def test_recover_job_second_recovery(mondb):


### PR DESCRIPTION
If a job runs for a long period it's possible subjobs that completed early
may have their proc ClassAds missing from HTCondor. The job completion code
now takes this into account and checks the subjobs for the htcondor stats,
or marks the main job htcondor stats as impossible to calculate if the subjob htcondor stats were never added (if HTCondor or the server were down
long enough for the ClassAds to be removed before the subjob stats in Mongo
could be updated).