### PR TITLE
Refactor ComputeSite to support multiple NodeTypes

### DIFF
--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -4,9 +4,10 @@ Manages job state.
 
 import datetime
 import logging
+import math
 from pathlib import Path
 import uuid
-from typing import AsyncIterator
+from typing import AsyncIterator, Callable
 
 from cdmtaskservice import logfields
 from cdmtaskservice import models
@@ -55,10 +56,12 @@ class JobState:
         log_path: str,
         job_max_cpu_hours: float,
         test_mode: bool = False,
+        _timestamp_fn: Callable[[], datetime.datetime] = utcdatetime,
+        _uuid_fn: Callable[[], uuid.UUID] = uuid.uuid4,
     ):
         """
         Create the job state manager.
-        
+
         mongo - a MongoDB DAO.
         s3Client - an S3Client pointed at the S3 storage system to use.
         images - a handler for getting images.
@@ -92,6 +95,8 @@ class JobState:
         self._logpath = _require_string(log_path, "log_path")
         self._cpu_hrs = _check_num(job_max_cpu_hours, "job_max_cpu_hours")
         self._test_mode = test_mode
+        self._timestamp_fn = _timestamp_fn
+        self._uuid_fn = _uuid_fn
         
     async def submit(self, job_input: models.JobInput, user: CTSUser) -> str:
         """
@@ -109,24 +114,22 @@ class JobState:
         compute_time = job_input.get_total_compute_time_sec() / 3600
         if compute_time > self._cpu_hrs:
             raise IllegalParameterError(
-                f"Job compute time of {compute_time} CPU hours is greater than the limit of "
-                + f"{self._cpu_hrs}"
+                f"Job compute time of {math.ceil(compute_time * 1000) / 1000} CPU hours is "
+                + f"greater than the limit of {self._cpu_hrs}"
         )
         # Could parallelize these ops but probably not worth it
         image = await self._images.get_image(job_input.image)
         await self._check_refdata(job_input, image)
         await self._check_output_path(job_input)
         new_input, meta = await self._check_and_update_files(job_input)
-        job_id = str(uuid.uuid4())  # TODO TEST for testing we'll need to set up a mock for this
+        job_id = str(self._uuid_fn())
         if not self._test_mode:
             # check the flow is available before we make any changes
             flow = await self._flowman.get_flow(job_input.cluster)
             await flow.preflight(user, job_id, job_input)
         ji = job_input.model_copy(update={"input_files": new_input})
-        # TODO TEST will need a way to mock out timestamps
-        update_time = utcdatetime()
-        # TODO TEST will need to mock out uuid
-        trans_id = str(uuid.uuid4())
+        update_time = self._timestamp_fn()
+        trans_id = str(self._uuid_fn())
         job = models.AdminJobDetails(
             id=job_id,
             job_input=ji,
@@ -167,21 +170,21 @@ class JobState:
 
     def _check_site_limits(self, job_input: models.JobInput):
         site = sites.CLUSTER_TO_SITE[job_input.cluster]
-        if job_input.cpus > site.cpus_per_node:
-            raise IllegalParameterError(
-                f"The maximum number of CPUs for site {job_input.cluster.value} is "
-                f"{site.cpus_per_node} vs {job_input.cpus} submitted"
-            )
-        if (rt_max := job_input.runtime.total_seconds() / 60) > site.max_runtime_min:
-            raise IllegalParameterError(
-                f"The maximum runtime for site {job_input.cluster.value} is "
-                f"{site.max_runtime_min} minutes vs {rt_max} submitted"
-            )
-        if (gb := int(job_input.memory) / 1_000_000_000) > site.memory_per_node_gb:
-            raise IllegalParameterError(
-                f"The maximum memory for site {job_input.cluster.value} is "
-                f"{site.memory_per_node_gb}GB vs {gb}GB submitted"
-            )
+        cpus = job_input.cpus
+        rt_min = job_input.runtime.total_seconds() / 60
+        gb = int(job_input.memory) / 1_000_000_000
+        for nt in site.node_types:
+            if (
+                cpus <= nt.cpus_per_node
+                and rt_min <= nt.max_runtime_min
+                and gb <= nt.memory_per_node_gb
+            ):
+                return
+        raise IllegalParameterError(
+            f"No node type at site {job_input.cluster.value} can satisfy the requested resources "
+            f"(cpus={cpus}, mem={math.ceil(gb * 1000) / 1000}GB, ",
+            f"runtime={math.ceil(rt_min * 1000) / 1000}min)."
+        )
 
     async def _check_and_update_files(self, job_input: models.JobInput):
         paths = [

--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -182,7 +182,7 @@ class JobState:
                 return
         raise IllegalParameterError(
             f"No node type at site {job_input.cluster.value} can satisfy the requested resources "
-            f"(cpus={cpus}, mem={math.ceil(gb * 1000) / 1000}GB, ",
+            f"(cpus={cpus}, mem={math.ceil(gb * 1000) / 1000}GB, "
             f"runtime={math.ceil(rt_min * 1000) / 1000}min)."
         )
 

--- a/cdmtaskservice/sites.py
+++ b/cdmtaskservice/sites.py
@@ -38,16 +38,12 @@ class SubmittableCluster(str, Enum):
     KBASE = "kbase"
 
 
-class ComputeSite(BaseModel):
-    """ Represents a remote compute site. """
-    
-    cluster: Annotated[Cluster, Field(
-        examples=[Cluster.PERLMUTTER_JAWS.value],
-        description="The site identifier",
-    )]
+class NodeType(BaseModel):
+    """ Represents a class of nodes within a compute site. """
+
     nodes: Annotated[int | None, Field(
         examples=[3042],
-        description="The number of nodes at the site, or null if the node count is not static"
+        description="The number of nodes of this type, or null if the count is not static."
     )] = None
     cpus_per_node: Annotated[int, Field(
         examples=[256],
@@ -63,6 +59,22 @@ class ComputeSite(BaseModel):
         description="The maximum runtime of a job container in minutes."
     )]
     notes: Annotated[list[str], Field(
+        examples=[["These nodes have 4 A100 GPUs each."]],
+        description="Any notes about this node type."
+    )] = []
+
+
+class ComputeSite(BaseModel):
+    """ Represents a remote compute site. """
+
+    cluster: Annotated[Cluster, Field(
+        examples=[Cluster.PERLMUTTER_JAWS.value],
+        description="The site identifier",
+    )]
+    node_types: Annotated[list[NodeType], Field(
+        description="The node types available at this site."
+    )]
+    notes: Annotated[list[str], Field(
         examples=[["Queue times are typically shorter here."]],
         description="Any notes about the site."
     )] = []
@@ -71,10 +83,14 @@ class ComputeSite(BaseModel):
 # https://jaws-docs.jgi.doe.gov/en/latest/Resources/compute_resources.html
 PERLMUTTER_JAWS = ComputeSite(
     cluster=Cluster.PERLMUTTER_JAWS,
-    nodes=3072,
-    cpus_per_node=2 * 2 * 64, # 2 CPUs × 64 cores × 2 hyperthreads
-    memory_per_node_gb=492,  # in GB, not GiB, per the JAWS team
-    max_runtime_min=2 * 24 * 60 - 15,
+    node_types=[
+        NodeType(
+            nodes=3072,
+            cpus_per_node=2 * 2 * 64,  # 2 CPUs × 64 cores × 2 hyperthreads
+            memory_per_node_gb=492,  # in GB, not GiB, per the JAWS team
+            max_runtime_min=2 * 24 * 60 - 15,
+        ),
+    ],
     notes=[
         "The Perlmutter supercomputer at NERSC, serviced by the JAWS job running system.",
         "Queue times can be long - hours to days."
@@ -85,10 +101,14 @@ PERLMUTTER_JAWS = ComputeSite(
 # https://jaws-docs.jgi.doe.gov/en/latest/Resources/compute_resources.html
 LAWRENCIUM_JAWS = ComputeSite(
     cluster=Cluster.LAWRENCIUM_JAWS,
-    nodes=8,
-    cpus_per_node=32,
-    memory_per_node_gb=492,  # in GB, not GiB, per the JAWS team
-    max_runtime_min=3 * 24 * 60 - 15,
+    node_types=[
+        NodeType(
+            nodes=8,
+            cpus_per_node=32,
+            memory_per_node_gb=492,  # in GB, not GiB, per the JAWS team
+            max_runtime_min=3 * 24 * 60 - 15,
+        ),
+    ],
     notes=[
         "The Lawrencium cluster at LBNL, serviced by the JAWS job running system.",
         "Queue times are typically shorter here for smaller jobs."
@@ -98,11 +118,15 @@ LAWRENCIUM_JAWS = ComputeSite(
 
 KBASE = ComputeSite(
     cluster=Cluster.KBASE,
-    nodes=None,
-    cpus_per_node=84 * 2,
-    memory_per_node_gb=990,  # Leave 10GB for overhead
-    # Note 7 days is also hard coded in the condor client
-    max_runtime_min=(7 * 24 * 60) - 15, # Leave 15 slack for overhead
+    node_types=[
+        NodeType(
+            nodes=None,
+            cpus_per_node=84 * 2,
+            memory_per_node_gb=990,  # Leave 10GB for overhead
+            # 7 days; the condor client adds a 6-hour buffer
+            max_runtime_min=7 * 24 * 60,
+        ),
+    ],
     notes=[
         "The DOE Systems Biology Knowledge Base compute systems.",
         "The number of nodes may be adjusted up or down to support the needs of KBase "
@@ -132,15 +156,17 @@ True - managed by this service
 False - managed by an external service (e.g. JAWS)
 """
 
-MAX_CPUS = max([cl.cpus_per_node for cl in CLUSTER_TO_SITE.values()])
+MAX_CPUS = max([nt.cpus_per_node for s in CLUSTER_TO_SITE.values() for nt in s.node_types])
 """
 The maximum number of cpus that can be requested for a container across all clusters.
 """
 
 
-MAX_MEM_GB = max([cl.memory_per_node_gb for cl in CLUSTER_TO_SITE.values()])
+MAX_MEM_GB = max([nt.memory_per_node_gb for s in CLUSTER_TO_SITE.values() for nt in s.node_types])
 """ The maximum amount of memory that can be requested for a container across all clusters. """
 
 
-MAX_RUNTIME_MIN = max([cl.max_runtime_min for cl in CLUSTER_TO_SITE.values()])
+MAX_RUNTIME_MIN = max(
+    [nt.max_runtime_min for s in CLUSTER_TO_SITE.values() for nt in s.node_types]
+)
 """ The maximum runtime that can be requested for a container across all clusters. """

--- a/test/job_state_test.py
+++ b/test/job_state_test.py
@@ -1,5 +1,8 @@
+import datetime
 import pytest
-from unittest.mock import create_autospec, AsyncMock
+import uuid
+from dataclasses import dataclass
+from unittest.mock import ANY, create_autospec, AsyncMock
 
 from cdmtaskservice.coroutine_manager import CoroutineWrangler
 from cdmtaskservice.exceptions import IllegalParameterError
@@ -13,6 +16,7 @@ from cdmtaskservice.notifications.kafka_notifications import KafkaNotifier
 from cdmtaskservice.refdata import Refdata
 from cdmtaskservice.s3.client import S3Client, S3ObjectMeta
 from cdmtaskservice.s3.paths import S3Paths
+from cdmtaskservice.timestamp import utcdatetime
 from cdmtaskservice.user import CTSUser
 
 
@@ -20,7 +24,9 @@ from cdmtaskservice.user import CTSUser
 
 
 _USER = CTSUser(user="testuser")
-_JOB_ID = "test-job-id"
+_JOB_ID = "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+_TRANS_ID = "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+_T = utcdatetime()
 _LOG_PATH = "cts-logs/container_logs/test-job-id"
 _S3_STDOUT_PATH_0 = S3Paths([f"{_LOG_PATH}/container-0-stdout.txt"])
 _S3_STDERR_PATH_1 = S3Paths([f"{_LOG_PATH}/container-1-stderr.txt"])
@@ -37,190 +43,372 @@ def _make_job(cluster, num_containers=2, logpath: str | None = _LOG_PATH):
     )
 
 
-def _make_job_state():
+@dataclass
+class _JobStateMocks:
+    jobstate: JobState
+    mongo: MongoDAO
+    s3: S3Client
+    images: Images
+    kafka: KafkaNotifier
+
+
+def _make_job_state(
+    job_max_cpu_hours: float = 100,
+    test_mode: bool = False,
+) -> _JobStateMocks:
     mongo = create_autospec(MongoDAO, spec_set=True, instance=True)
     s3 = create_autospec(S3Client, spec_set=True, instance=True)
+    images = create_autospec(Images, spec_set=True, instance=True)
+    kafka = create_autospec(KafkaNotifier, spec_set=True, instance=True)
     jobstate = JobState(
         mongo=mongo,
         s3client=s3,
-        images=create_autospec(Images, spec_set=True, instance=True),
-        kafka=create_autospec(KafkaNotifier, spec_set=True, instance=True),
+        images=images,
+        kafka=kafka,
         refdata=create_autospec(Refdata, spec_set=True, instance=True),
         coro_manager=create_autospec(CoroutineWrangler, spec_set=True, instance=True),
         flow_manager=create_autospec(JobFlowManager, spec_set=True, instance=True),
         allowed_paths=[],
         log_path="cts-logs/",
-        job_max_cpu_hours=100,
+        job_max_cpu_hours=job_max_cpu_hours,
+        test_mode=test_mode,
+        _timestamp_fn=lambda: _T,
+        _uuid_fn=iter([uuid.UUID(_JOB_ID), uuid.UUID(_TRANS_ID)]).__next__,
     )
-    return jobstate, mongo, s3
+    return _JobStateMocks(jobstate=jobstate, mongo=mongo, s3=s3, images=images, kafka=kafka)
 
 
 async def test_stream_job_logs_no_logpath():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.KBASE, logpath=None)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.KBASE, logpath=None)
 
     with pytest.raises(NoJobLogsError, match=f"Job ID {_JOB_ID} has no logs available"):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
 
 
 async def test_stream_job_logs_container_num_too_large():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.KBASE, num_containers=2)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.KBASE, num_containers=2)
 
     with pytest.raises(IllegalParameterError, match="Container number must be < 2"):
-        await jobstate.stream_job_logs(_JOB_ID, 2, _USER)
+        await js.jobstate.stream_job_logs(_JOB_ID, 2, _USER)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
 
 
 async def test_stream_job_logs_kbase_container_succeeded():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
-    mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=0)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
+    js.mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=0)
 
     with pytest.raises(
         NoJobLogsError,
         match="logs are only uploaded for containers that exit with an error code"
     ):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
 
 
 async def test_stream_job_logs_kbase_container_exit_code_none():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
-    mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=None)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
+    js.mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=None)
 
     with pytest.raises(
         NoJobLogsError,
         match="logs are only uploaded for containers that exit with an error code"
     ):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
 
 
 async def test_stream_job_logs_kbase_container_errored():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
-    mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=1)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.KBASE)
+    js.mongo.get_subjob.return_value = models.SubJob.model_construct(sub_id=0, exit_code=1)
     sentinel = AsyncMock()
-    s3.stream_object.return_value = sentinel
+    js.s3.stream_object.return_value = sentinel
 
-    gen, filename = await jobstate.stream_job_logs(_JOB_ID, 0, _USER)
+    gen, filename = await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER)
 
     assert gen is sentinel
     assert filename == "container-0-stdout.txt"
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
-    s3.get_object_meta.assert_not_called()
-    s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=None)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_subjob.assert_called_once_with(_JOB_ID, 0)
+    js.s3.get_object_meta.assert_not_called()
+    js.s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=None)
 
 
 async def test_stream_job_logs_nersc_no_subjob_check():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
     sentinel = AsyncMock()
-    s3.stream_object.return_value = sentinel
+    js.s3.stream_object.return_value = sentinel
 
-    gen, filename = await jobstate.stream_job_logs(_JOB_ID, 0, _USER)
+    gen, filename = await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER)
 
     assert gen is sentinel
     assert filename == "container-0-stdout.txt"
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    mongo.get_subjob.assert_not_called()
-    s3.get_object_meta.assert_not_called()
-    s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=None)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_subjob.assert_not_called()
+    js.s3.get_object_meta.assert_not_called()
+    js.s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=None)
 
 
 async def test_stream_job_logs_stderr():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
     sentinel = AsyncMock()
-    s3.stream_object.return_value = sentinel
+    js.s3.stream_object.return_value = sentinel
 
-    gen, filename = await jobstate.stream_job_logs(_JOB_ID, 1, _USER, stderr=True)
+    gen, filename = await js.jobstate.stream_job_logs(_JOB_ID, 1, _USER, stderr=True)
 
     assert gen is sentinel
     assert filename == "container-1-stderr.txt"
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    s3.stream_object.assert_called_once_with(_S3_STDERR_PATH_1, seek=None, length=None)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.s3.stream_object.assert_called_once_with(_S3_STDERR_PATH_1, seek=None, length=None)
 
 
 async def test_stream_job_logs_seek_negative():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
 
     with pytest.raises(IllegalParameterError, match="Seek parameter must be >= 0"):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=-1)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=-1)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
 
 
 async def test_stream_job_logs_seek_zero_no_meta_call():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
-    s3.stream_object.return_value = AsyncMock()
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js.s3.stream_object.return_value = AsyncMock()
 
-    await jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=0)
+    await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=0)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    s3.get_object_meta.assert_not_called()
-    s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=0, length=None)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.s3.get_object_meta.assert_not_called()
+    js.s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=0, length=None)
 
 
 async def test_stream_job_logs_seek_at_eof():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
-    s3.get_object_meta.return_value = [S3ObjectMeta("path", "etag", 100)]
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js.s3.get_object_meta.return_value = [S3ObjectMeta("path", "etag", 100)]
 
     with pytest.raises(IllegalParameterError, match="Seek parameter 100 is >= file size 100"):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=100)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=100)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    s3.get_object_meta.assert_called_once_with(_S3_STDOUT_PATH_0)
-    s3.stream_object.assert_not_called()
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.s3.get_object_meta.assert_called_once_with(_S3_STDOUT_PATH_0)
+    js.s3.stream_object.assert_not_called()
 
 
 async def test_stream_job_logs_seek_valid():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
-    s3.get_object_meta.return_value = [S3ObjectMeta("path", "etag", 100)]
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js.s3.get_object_meta.return_value = [S3ObjectMeta("path", "etag", 100)]
     sentinel = AsyncMock()
-    s3.stream_object.return_value = sentinel
+    js.s3.stream_object.return_value = sentinel
 
-    gen, _ = await jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=50)
+    gen, _ = await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, seek=50)
 
     assert gen is sentinel
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    s3.get_object_meta.assert_called_once_with(_S3_STDOUT_PATH_0)
-    s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=50, length=None)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.s3.get_object_meta.assert_called_once_with(_S3_STDOUT_PATH_0)
+    js.s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=50, length=None)
 
 
 async def test_stream_job_logs_length_zero():
-    jobstate, mongo, _ = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
 
     with pytest.raises(IllegalParameterError, match="Length parameter must be >= 1"):
-        await jobstate.stream_job_logs(_JOB_ID, 0, _USER, length=0)
+        await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, length=0)
 
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
 
 
 async def test_stream_job_logs_length_valid():
-    jobstate, mongo, s3 = _make_job_state()
-    mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
+    js = _make_job_state()
+    js.mongo.get_job.return_value = _make_job(sites.Cluster.PERLMUTTER_JAWS)
     sentinel = AsyncMock()
-    s3.stream_object.return_value = sentinel
+    js.s3.stream_object.return_value = sentinel
 
-    gen, _ = await jobstate.stream_job_logs(_JOB_ID, 0, _USER, length=50)
+    gen, _ = await js.jobstate.stream_job_logs(_JOB_ID, 0, _USER, length=50)
 
     assert gen is sentinel
-    mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
-    s3.get_object_meta.assert_not_called()
-    s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=50)
+    js.mongo.get_job.assert_called_once_with(_JOB_ID, as_admin=False)
+    js.s3.get_object_meta.assert_not_called()
+    js.s3.stream_object.assert_called_once_with(_S3_STDOUT_PATH_0, seek=None, length=50)
+
+
+# KBASE node type limits for reference:
+#   cpus_per_node=168, memory_per_node_gb=990, max_runtime_min=10080
+_KBASE_MAX_CPUS = 84 * 2
+_KBASE_MAX_MEM_BYTES = 990 * 1_000_000_000
+_KBASE_MAX_RUNTIME_MIN = 7 * 24 * 60
+
+_INPUT_FILE = "mybucket/input/file.txt"
+_OUTPUT_DIR = "mybucket/output/"
+_CRC = "abc123=="
+_TEST_IMAGE = models.Image.model_construct(
+    registered_by="testuser",
+    registered_on=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+    name="ghcr.io/kbase/testimage",
+    digest="sha256:" + "a" * 64,
+    entrypoint=["run"],
+    tag="0.1.0",
+    refdata_id=None,
+    default_refdata_mount_point=None,
+    urls=None,
+    usage_notes=None,
+)
+_TEST_JOB_IMAGE = models.JobImage(
+    registered_by="testuser",
+    registered_on=datetime.datetime(2024, 1, 1, tzinfo=datetime.timezone.utc),
+    name="ghcr.io/kbase/testimage",
+    digest="sha256:" + "a" * 64,
+    entrypoint=["run"],
+    tag="0.1.0",
+    refdata_id=None,
+    default_refdata_mount_point=None,
+)
+
+
+def _make_job_input(
+    cluster=sites.Cluster.KBASE,
+    cpus=1,
+    memory_bytes=1_000_000_000,
+    runtime_sec=3600,
+    num_containers=1,
+    input_files=None,
+    output_dir=_OUTPUT_DIR,
+    image="ghcr.io/kbase/testimage:latest",
+):
+    return models.JobInput.model_construct(
+        cluster=cluster,
+        cpus=cpus,
+        memory=memory_bytes,
+        runtime=datetime.timedelta(seconds=runtime_sec),
+        num_containers=num_containers,
+        input_files=input_files or [_INPUT_FILE],
+        output_dir=output_dir,
+        image=image,
+        params=models.Parameters(),
+    )
+
+
+async def test_submit_null_job_input():
+    js = _make_job_state()
+
+    with pytest.raises(ValueError, match="job_input is required"):
+        await js.jobstate.submit(None, _USER)
+
+
+async def test_submit_null_user():
+    js = _make_job_state()
+
+    with pytest.raises(ValueError, match="user is required"):
+        await js.jobstate.submit(_make_job_input(), None)
+
+
+async def test_submit_compute_time_exceeds_limit():
+    # 1 cpu * 1 container * 360001 sec / 3600 sec/hr = 100.000... hrs > default limit of 100
+    js = _make_job_state(job_max_cpu_hours=100)
+    job_input = _make_job_input(cpus=1, runtime_sec=360001)
+
+    with pytest.raises(IllegalParameterError) as exc_info:
+        await js.jobstate.submit(job_input, _USER)
+    assert str(exc_info.value) == (
+        "Job compute time of 100.001 CPU hours is greater than the limit of 100"
+    )
+
+
+async def test_submit_cpus_exceed_site_limit():
+    js = _make_job_state()
+    job_input = _make_job_input(cpus=_KBASE_MAX_CPUS + 1)
+
+    with pytest.raises(IllegalParameterError) as exc_info:
+        await js.jobstate.submit(job_input, _USER)
+    assert str(exc_info.value) == (
+        "No node type at site kbase can satisfy the requested resources "
+        "(cpus=169, mem=1.0GB, runtime=60.0min)."
+    )
+
+
+async def test_submit_memory_exceeds_site_limit():
+    js = _make_job_state()
+    job_input = _make_job_input(memory_bytes=_KBASE_MAX_MEM_BYTES + 1)
+
+    with pytest.raises(IllegalParameterError) as exc_info:
+        await js.jobstate.submit(job_input, _USER)
+    assert str(exc_info.value) == (
+        "No node type at site kbase can satisfy the requested resources "
+        "(cpus=1, mem=990.001GB, runtime=60.0min)."
+    )
+
+
+async def test_submit_runtime_exceeds_site_limit():
+    js = _make_job_state()
+    job_input = _make_job_input(runtime_sec=(_KBASE_MAX_RUNTIME_MIN * 60) + 1)
+
+    with pytest.raises(IllegalParameterError) as exc_info:
+        await js.jobstate.submit(job_input, _USER)
+    assert str(exc_info.value) == (
+        "No node type at site kbase can satisfy the requested resources "
+        "(cpus=1, mem=1.0GB, runtime=10080.017min)."
+    )
+
+
+async def test_submit_kbase_at_site_limits():
+    # compute_time = 168 cpus * 1 container * (10080 min * 60 sec/min) / 3600 sec/hr = 28224 hrs
+    js = _make_job_state(job_max_cpu_hours=28225, test_mode=True)
+    job_input = _make_job_input(
+        cpus=_KBASE_MAX_CPUS,
+        memory_bytes=_KBASE_MAX_MEM_BYTES,
+        runtime_sec=_KBASE_MAX_RUNTIME_MIN * 60,
+    )
+    js.images.get_image.return_value = _TEST_IMAGE
+    js.s3.get_object_meta.return_value = [S3ObjectMeta(_INPUT_FILE, "etag", 1000, crc64nvme=_CRC)]
+
+    job_id = await js.jobstate.submit(job_input, _USER)
+
+    assert job_id == _JOB_ID
+    
+    js.images.get_image.assert_called_once_with(job_input.image)
+    js.s3.is_paths_writeable.assert_called_once_with(
+        S3Paths([_OUTPUT_DIR], no_index_in_errors=True)
+    )
+    expected_input_file = models.S3FileWithDataID.model_construct(
+        file=_INPUT_FILE, crc64nvme=_CRC, data_id=None
+    )
+    expected_ji = job_input.model_copy(update={"input_files": [expected_input_file]})
+    js.mongo.save_job.assert_called_once_with(
+        models.AdminJobDetails(
+            id=_JOB_ID,
+            job_input=expected_ji,
+            user="testuser",
+            image=_TEST_JOB_IMAGE,
+            input_file_count=1,
+            state=models.JobState.CREATED,
+            transition_times=[models.AdminJobStateTransition(
+                state=models.JobState.CREATED,
+                time=_T,
+                trans_id=_TRANS_ID,
+                notif_sent=False,
+            )]
+        )
+    )
+    js.kafka.update_job_state.assert_called_once_with(
+        _JOB_ID, models.JobState.CREATED, _T, _TRANS_ID, callback=ANY
+    )
+    await js.kafka.update_job_state.call_args.kwargs["callback"]
+    js.mongo.job_update_sent.assert_called_once_with(_JOB_ID, _TRANS_ID)
+    js.s3.get_object_meta.assert_called_once_with(S3Paths([_INPUT_FILE]))


### PR DESCRIPTION
ComputeSite now holds a list[NodeType] instead of flat resource fields, enabling multiple node classes (e.g. CPU + GPU) per site.