### PR TITLE
Add allowed_sites restriction to Docker images

### DIFF
--- a/cdmtaskservice/images.py
+++ b/cdmtaskservice/images.py
@@ -6,6 +6,7 @@ import re
 from typing import Awaitable, NamedTuple
 
 from cdmtaskservice import models
+from cdmtaskservice import sites
 from cdmtaskservice.arg_checkers import not_falsy as _not_falsy
 from cdmtaskservice.exceptions import IllegalParameterError
 from cdmtaskservice.image_remote_lookup import DockerImageInfo, parse_image_name
@@ -22,6 +23,7 @@ class _ImageFields(NamedTuple):
     usage_notes: str | None
     refdata_id: str | None
     default_refdata_mount_point: str | None
+    allowed_sites: set[sites.SubmittableCluster] | None
 
 
 class Images:
@@ -46,7 +48,8 @@ class Images:
         username: str,
         image_reg: models.ImageRegistration = None,
         refdata_id: str = None,
-        default_refdata_mount_point: str = None
+        default_refdata_mount_point: str = None,
+        allowed_sites: set[sites.SubmittableCluster] = None,
     ) -> models.Image:
         """
         Register an image to the service.
@@ -59,9 +62,13 @@ class Images:
         refdata_id - the ID of reference data to associate with the image.
         default_refdata_mount_point - the default mount point for refdata in an image container.
             Must be an absolute path with at least one path element.
+        allowed_sites - the compute sites at which the image is permitted to run. If not
+            provided, the image may run at any site.
         """
         image_reg = image_reg or models.ImageRegistration()
-        fields = await self._resolve_image_fields(image_reg, refdata_id, default_refdata_mount_point)
+        fields = await self._resolve_image_fields(
+            image_reg, refdata_id, default_refdata_mount_point, allowed_sites
+        )
         if fields.default_refdata_mount_point:
             if not fields.refdata_id:
                 raise IllegalParameterError(
@@ -89,6 +96,7 @@ class Images:
             default_refdata_mount_point=fields.default_refdata_mount_point,
             usage_notes=fields.usage_notes,
             urls=fields.urls,
+            allowed_sites=fields.allowed_sites,
         )
         await self._mongo.save_image(img)
         return img
@@ -98,6 +106,7 @@ class Images:
         image_reg: models.ImageRegistration,
         refdata_id: str,
         default_refdata_mount_point: str,
+        allowed_sites: set[sites.SubmittableCluster] | None,
     ) -> _ImageFields:
         """
         Resolve the final user-supplied field values for image registration from the two
@@ -116,11 +125,14 @@ class Images:
                 refdata_id = from_img.refdata_id
             if default_refdata_mount_point is None:
                 default_refdata_mount_point = from_img.default_refdata_mount_point
+            if allowed_sites is None and from_img.allowed_sites:
+                allowed_sites = set(from_img.allowed_sites)
         return _ImageFields(
             urls=urls,
             usage_notes=usage_notes,
             refdata_id=refdata_id or None,  # ensure not empty string, etc.
             default_refdata_mount_point=default_refdata_mount_point,
+            allowed_sites=allowed_sites,
         )
     
     async def get_image(self, imagename: str) -> models.Image:

--- a/cdmtaskservice/job_state.py
+++ b/cdmtaskservice/job_state.py
@@ -119,6 +119,7 @@ class JobState:
         )
         # Could parallelize these ops but probably not worth it
         image = await self._images.get_image(job_input.image)
+        self._check_image_site_compat(job_input, image)
         await self._check_refdata(job_input, image)
         await self._check_output_path(job_input)
         new_input, meta = await self._check_and_update_files(job_input)
@@ -192,6 +193,13 @@ class JobState:
             f"(cpus={cpus}, gpus={gpus}, mem={math.ceil(gb * 1000) / 1000}GB, "
             f"runtime={math.ceil(rt_min * 1000) / 1000}min)."
         )
+
+    def _check_image_site_compat(self, job_input: models.JobInput, image: models.Image):
+        if image.allowed_sites and job_input.cluster not in image.allowed_sites:
+            raise IllegalParameterError(
+                f"Image {image.name_with_digest} is not permitted to run at site "
+                + f"{job_input.cluster.value}"
+            )
 
     async def _check_and_update_files(self, job_input: models.JobInput):
         paths = [

--- a/cdmtaskservice/models.py
+++ b/cdmtaskservice/models.py
@@ -832,6 +832,20 @@ class Image(ImageUsage, JobImage):
     """
     Information about a docker image.
     """
+    allowed_sites: Annotated[list[sites.SubmittableCluster] | None, Field(
+        examples=[[sites.SubmittableCluster.KBASE.value]],
+        description="The compute sites at which this image is permitted to run. "
+            + "If not set, the image may run at any site. Duplicate sites are ignored."
+    )] = None
+
+    @field_validator("allowed_sites", mode="before")
+    @classmethod
+    def _check_allowed_sites(cls, v):
+        if v is None:
+            return None
+        if not v:
+            raise ValueError("allowed_sites cannot be an empty list")
+        return list(set(v))
 
 
 class JobState(str, Enum):

--- a/cdmtaskservice/routes.py
+++ b/cdmtaskservice/routes.py
@@ -32,7 +32,7 @@ from cdmtaskservice.callback_url_paths import (
     get_upload_complete_callback,
     get_error_log_upload_complete_callback,
 )
-from cdmtaskservice.exceptions import UnauthorizedError
+from cdmtaskservice.exceptions import IllegalParameterError, UnauthorizedError
 from cdmtaskservice.git_commit import GIT_COMMIT
 from cdmtaskservice.http_bearer import KBaseHTTPBearer
 from cdmtaskservice.jobflows.flowmanager import JobFlow
@@ -68,6 +68,19 @@ def _ensure_executor(user: CTSUser, err_msg: str):
 def _ensure_refdata_service(user: CTSUser, err_msg: str):
     if not user.is_refdata_service:
         raise UnauthorizedError(err_msg)
+
+
+def _parse_allowed_sites(allowed_sites: str | None) -> set[sites.SubmittableCluster] | None:
+    if not allowed_sites:
+        return None
+    parsed = set()
+    for s in allowed_sites.split(","):
+        s = s.strip()
+        try:
+            parsed.add(sites.SubmittableCluster(s))
+        except ValueError:
+            raise IllegalParameterError(f"Invalid site '{s}' in allowed_sites")
+    return parsed or None
 
 
 def _ensure_admin_or_executor(user: CTSUser, err_msg: str):
@@ -652,6 +665,13 @@ async def approve_image(
         min_length=1,
         max_length=1024,
     )] = None,
+    allowed_sites: Annotated[str, Query(
+        openapi_examples={"comma separated sites": {"value": "kbase,perlmutter-jaws"}},
+        description="A comma separated list of compute sites at which this image is permitted "
+            + "to run. If not provided, the image may run at any site.",
+        min_length=1,
+        max_length=1000,
+    )] = None,
     user: CTSUser=Depends(_AUTH)
 ) -> models.Image:
     _ensure_admin(user, "Only service administrators can approve images.")
@@ -661,7 +681,8 @@ async def approve_image(
         user.user,
         image_reg=image_reg,
         refdata_id=refdata_id,
-        default_refdata_mount_point=default_refdata_mount_point
+        default_refdata_mount_point=default_refdata_mount_point,
+        allowed_sites=_parse_allowed_sites(allowed_sites),
     )
 
 

--- a/test/job_state_test.py
+++ b/test/job_state_test.py
@@ -328,6 +328,29 @@ async def test_submit_null_user():
         await js.jobstate.submit(_make_job_input(), None)
 
 
+async def test_submit_image_allowed_at_site():
+    js = _make_job_state(test_mode=True)
+    job_input = _make_job_input(cluster=sites.Cluster.KBASE)
+    image = _TEST_IMAGE.model_copy(update={"allowed_sites": [sites.SubmittableCluster.KBASE]})
+
+    await _check_submit_succeeds(js, job_input, image=image)
+
+
+async def test_submit_image_not_allowed_at_site():
+    js = _make_job_state()
+    job_input = _make_job_input(cluster=sites.Cluster.KBASE)
+    js.images.get_image.return_value = _TEST_IMAGE.model_copy(
+        update={"allowed_sites": [sites.SubmittableCluster.PERLMUTTER_JAWS]}
+    )
+
+    with pytest.raises(IllegalParameterError) as exc_info:
+        await js.jobstate.submit(job_input, _USER)
+    assert str(exc_info.value) == (
+        "Image ghcr.io/kbase/testimage@sha256:" + "a" * 64
+        + " is not permitted to run at site kbase"
+    )
+
+
 async def test_submit_compute_time_exceeds_limit():
     # 1 cpu * 1 container * 360001 sec / 3600 sec/hr = 100.000... hrs > default limit of 100
     js = _make_job_state(job_max_cpu_hours=100)
@@ -391,8 +414,8 @@ async def test_submit_gpus_exceed_site_limit():
     )
 
 
-async def _check_submit_succeeds_at_site_limits(js, job_input):
-    js.images.get_image.return_value = _TEST_IMAGE
+async def _check_submit_succeeds(js, job_input, image=_TEST_IMAGE):
+    js.images.get_image.return_value = image
     js.s3.get_object_meta.return_value = [S3ObjectMeta(_INPUT_FILE, "etag", 1000, crc64nvme=_CRC)]
 
     job_id = await js.jobstate.submit(job_input, _USER)
@@ -441,7 +464,7 @@ async def test_submit_kbase_cpu_at_site_limits():
         runtime_sec=_KBASE_CPU_MAX_RUNTIME_MIN * 60,
     )
 
-    await _check_submit_succeeds_at_site_limits(js, job_input)
+    await _check_submit_succeeds(js, job_input)
 
 
 async def test_submit_kbase_gpu_at_site_limits():
@@ -454,4 +477,4 @@ async def test_submit_kbase_gpu_at_site_limits():
         runtime_sec=_KBASE_GPU_MAX_RUNTIME_MIN * 60,
     )
 
-    await _check_submit_succeeds_at_site_limits(js, job_input)
+    await _check_submit_succeeds(js, job_input)


### PR DESCRIPTION
Lets admins restrict an image to specific compute sites at registration time; job submission is rejected with IllegalParameterError if the target cluster isn't in the image's allowed_sites.